### PR TITLE
Use <dfn> tag for "read from the sensor"

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ interface SensorReading {
 
 ### <dfn>SensorReading.timestamp</dfn>
 
-Returns the time at which the data was <a>read from the sensor</a> in the number of milliseconds that passed since 00:00:00 UTC on 1 January 1970.
+Returns the time at which the data was <dfn>read from the sensor</dfn> in the number of milliseconds that passed since 00:00:00 UTC on 1 January 1970.
 
 ### <dfn>SensorReading.sensorIdentifier</dfn>
 


### PR DESCRIPTION
Respec complains about "<a>read from the sensor</a>", apparently because that phrase isn't defined via a <dfn> tag pair. This PR replaces the <a> tags with <dfn> tags. I think this is what you want but if not then just let me know and I'll delete this PR.