### PR TITLE
Credit where credit is due.

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,10 @@ It will feature precise steps on how to extend or inherit from interfaces descri
 Acknowledgements
 ----------------
 
+The following people have greatly contributed to this specification through extensive discussions on GitHub: <span id=gh-commenters>Anssi Kostiainen, Arthur Barstow, Boris Smus, Claes Nilsson, Dave Raggett, davidmarkclements, Domenic Denicola, fhirsch, Jafar Husain, Johannes Hund, Kris Kowal, Marcos Caceres, Mats Wichmann, Matthew Podwysocki, pablochacin, Remy Sharp, Rich Tibbett, Rijubrata Bhaumik, Sean T. McBeth, smaug----, and zenparsing</span>.
+
+We'd also like to thank <span id=gh-contributors>Anssi Kostiainen and Michael[tm] Smith</span> for their editorial input.
+
 </section>
 
 </body>


### PR DESCRIPTION
This is a stop gap solution until it gets automated by ReSpec (see https://github.com/w3c/respec/pull/447).