### PR TITLE
Large rewrite/refactoring of the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,6 +58,10 @@ urlPrefix: https://w3c.github.io/page-visibility; spec: PAGE-VISIBILITY
     text: steps to determine the visibility state; url: dfn-steps-to-determine-the-visibility-state
 </pre>
 
+<pre class=link-defaults>
+spec: webidl; type:dfn; text:attribute
+</pre>
+
 
 <h2 id="intro">Introduction</h2>
 
@@ -82,6 +86,10 @@ enable advanced use cases thanks to performant [=low-level=] APIs,
 and increase the pace at which new sensors can be exposed to the Web
 by simplifying the specification and implementation processes.
 
+Issue: This lacks an informative section with examples for developers.
+Should contain different use of the API,
+including using it in conjunction with `requestAnimationFrame`.
+
 
 <h2 id="scope">Scope</h2>
 
@@ -101,7 +109,7 @@ This should have little to no effects on implementations, however.
 
 This specification also does not currently expose a
 sensor discovery API.
-This is because the limited number of sensors currently available to User Agents
+This is because the limited number of sensors currently available to user agents
 does not warrant such an API.
 Using feature detection, such as described in [[#feature-detection]],
 is good enough for now.
@@ -113,6 +121,13 @@ and the current API has been designed with this in mind.
 
 <em>This section is non-normative</em>.
 
+Issue: This section is ill-named.
+It principally covers default sensors
+and explains the reasoning behind them.
+It should be renamed accordingly and moved,
+either to another section of the spec
+or to an external explainer document.
+
 The Generic Sensor API is designed to make the most common use cases straightforward
 while still enabling more complex use cases.
 
@@ -120,8 +135,8 @@ Most devices deployed today do not carry more than one
 [=sensor=] of each [=sensor type|sensor types=].
 This shouldn't come as a surprise since use cases for more than
 a [=sensor=] of a given [=sensor types|type=] are rare
-and generally limited to specific [=sensor types=] such as
-proximity sensors.
+and generally limited to specific [=sensor types=],
+such as proximity sensors.
 
 The API therefore makes it easy to interact with
 the device's default (and often unique) [=sensor=]
@@ -139,8 +154,8 @@ the default [=sensor=] is chosen.
     let sensor = new GeolocationSensor({ accuracy: "high" });
 
     sensor.onchange = function(event) {
-        var coords = [event.reading.latitude, event.reading.longitude];
-        updateMap(null, coords, event.reading.accuracy);
+        var coords = [sensor.latitude, sensor.longitude];
+        updateMap(null, coords, sensor.accuracy);
     };
 
     sensor.onerror = function(error) {
@@ -165,8 +180,8 @@ define ways to uniquely identify each one.
     For example checking the pressure of the left rear tire:
 
     <pre highlight="js">
-    let sensor = new DirectTirePressureSensor({ position: "rear", side: "left" });
-    sensor.onchange = event => console.log(event.reading.pressure);
+    var sensor = new DirectTirePressureSensor({ position: "rear", side: "left" });
+    sensor.onchange = _ => console.log(sensor.pressure);
     sensor.start();
     </pre>
 </div>
@@ -234,10 +249,10 @@ and defensive programming which includes:
 <div class="example">
     <pre highlight="js">
         try { // No need to feature detect thanks to try..catch block.
-            let sensor = new GeolocationSensor({});
+            var sensor = new GeolocationSensor();
             sensor.start();
             sensor.onerror = error => gracefullyDegrade(error);
-            sensor.onchange = event => updatePosition(event.reading.coords);
+            sensor.onchange = _ => updatePosition(sensor.latitude, sensor.longitude);
         } catch(error) {
             gracefullyDegrade(error);
         }
@@ -281,7 +296,7 @@ perform a privacy impact assessment of their application
 taking all aspects of their application into consideration.
 
 Ability to detect a full working set of sensors on a device can form an
-identifier and could be used to fingerprinting.
+identifier and could be used for fingerprinting.
 
 A combination of selected sensors can potentially be used to form an out of
 band communication channel between devices.
@@ -299,6 +314,8 @@ with contexts unfamiliar to the user.
 For example, a mobile device will only fire the event on
 the active tab, and not on the background tabs or within iframes.
 
+Note: [Feature Policy](https://docs.google.com/document/d/1k0Ua-ZWlM_PsFCFdLMa8kaVTo32PeNZ4G7FFHqpFx4E/edit)
+should allow securely lifting those restrictions once it matures.
 
 <h3 id="secure-context">Secure Context</h3>
 
@@ -324,6 +341,10 @@ through the Permissions API [[!PERMISSIONS]].
 A [=sensor=] measures different physical quantities
 and provide corresponding <dfn>raw sensor readings</dfn>
 which are a source of information about the user and their environment.
+
+Each [=raw sensor reading|reading=] is composed of the <dfn lt="reading value">values</dfn>
+of the different physical quantities measured by the [=sensor=]
+at time <var ignore>t<sub>n</sub></var>.
 
 Known, <em>predictable</em> discrepancies between [=raw sensor readings=]
 and the corresponding physical quantities being measured
@@ -418,9 +439,15 @@ or how the sensor is implemented ([=low-level=] sensors).
 
 <h3 id="concepts-reporting-modes">Reporting Modes</h3>
 
+Issue: **This feature is at risk.**
+It is not clear whether there is value
+in splitting up [=sensor types=] between
+those that fire events at regular intervals
+and those which don't.
+
 [=Sensors=] have different <dfn>reporting modes</dfn>.
 When [=sensor readings=] are reported at regular intervals,
-at an ajustable <dfn>frequency</dfn> measured in hertz (Hz),
+at an adjustable <dfn>frequency</dfn> measured in hertz (Hz),
 the [=reporting mode=] is said to be <dfn>periodic</dfn>.
 On [=sensor types=] with support for [=periodic|periodic reporting mode=],
 [=periodic|periodic reporting mode=] is triggered
@@ -455,56 +482,80 @@ perhaps because is is relying on [=smart sensors=] or a [=sensor hubs=],
 the [=reporting mode=] cannot be [=periodic=],
 as that would require data inference.
 
+Issue: This lacks a description of
+the different data acquisition modes,
+notably polling vs. on change,
+both at the platform and HW layer.
+
+Issue: It would be useful to describe
+the process of sensor polling and
+how increased sensor polling frequency decreases latency.
+
+Issue: A definition of sensor accuracy and
+how it affects threshold,
+and thus "on change" sensors would be useful.
+
 
 <h2 id="model">Model</h2>
 
+Issue: A diagram would really help here.
 
 <h3 id="model-sensor-type">Sensor Type</h3>
 
-A <dfn>sensor type</dfn> has one or many associated [=sensors=].
+A <dfn>sensor type</dfn> has an associated [=interface=]
+whose [=inherited interfaces=] contains {{Sensor}}.
 
-A [=sensor type=] has an associated <dfn export>Sensor subclass</dfn>.
-
-A [=sensor type=] has an associated <dfn export>SensorReading subclass</dfn>.
-Attributes of the [=SensorReading subclass=] subclass that
-hold [=sensor readings=] must be readonly.
-
-A [=sensor type=] may have a <dfn export>default sensor</dfn>.
-
-A [=sensor type=] has an associated set of <dfn export>supported reporting modes</dfn>,
-which cannot be empty and must be picked from the following:
-[=implementation specific=] and [=periodic=].
+A [=sensor type=] has one or many associated [=sensors=].
 
 If a [=sensor type=] has more than one [=sensor=],
 it must have a set of associated <dfn export>identifying parameters</dfn>
 to select the right [=sensor=] to associate to each new {{Sensor}} objects.
 
-A [=sensor type=] has an associated abstract operation to
-<dfn export lt="Construct SensorReading Object">construct a SensorReading object</dfn>
-which takes the [=sensor readings=] emitted by the [=sensor=] and
-returns an initialized {{SensorReading}} object
-which uses the [=sensor type=]'s associated [=SensorReading subclass=].
+A [=sensor type=] may have a <dfn export>default sensor</dfn>.
 
 
 <h3 id="model-sensor">Sensor</h3>
 
-A <dfn id=concept-sensor>sensor</dfn> has an associated set of <dfn>activated Sensor objects</dfn>. This set is initially empty.
+A <dfn id=concept-sensor>sensor</dfn> has an associated [=ordered set|set=]
+of <dfn>activated Sensor objects</dfn>.
+This set is initially [=set/is empty|empty=].
 
-A [=sensor=] has an associated <dfn>current reading</dfn>,
-which can initially be `null` or
-be set to a {{SensorReading}} object, that was cached in a user-agent-specific way.
+A [=sensor=] has an associated <dfn>latest reading</dfn> [=ordered map|map=]
+which holds the latest available [=sensor readings=].
+
+The [=latest reading=] [=ordered map|map=]
+contains an [=map/entry=]
+whose [=map/key=] is "timestamp" and
+whose [=map/value=] is a high resolution timestamp of the time
+at which the [=latest reading=] was obtained
+expressed in milliseconds that passed since the [=time origin=].
+[=latest reading=]["timestamp"] is initially set to `null`,
+unless the [=latest reading=] [=ordered map|map=] caches a previous [=sensor readings|reading=].
+
+The other [=map/entries=] of the [=latest reading=] [=ordered map|map=]
+hold the values of the different quantities measured by the [=sensor=].
+The [=map/keys=] of these [=map/entries=] must match
+the [=attribute=] names defined by
+the [=sensor type=]'s associated interface,
+so that the getter of the `foo` attribute
+can simply return [=latest reading=]["foo"].
+
+The [map/value] of all [=latest reading=] [=map/entries=]
+is initially set to `null`.
+<!-- ,
+unless the [=latest reading=] [=ordered map|map=]
+caches a previous [=sensor readings|reading=].
 
 Note: there are additional privacy concerns when using cached [=sensor readings|readings=]
 which predate either [=navigating=] to resources in the current [=origin=],
-or being granted permission to access the [=sensor=].
+or being granted permission to access the [=sensor=]. -->
 
-A [=sensor=] is said to <dfn lt="supports periodic reporting mode">support periodic reporting mode</dfn> if
-its associated [=sensor type=]'s [=supported reporting modes=]
-contains the [=periodic|periodic reporting mode=].
+A [=sensor=] <dfn>supports periodic reporting mode</dfn> if
+its associated [=sensor type=] does.
 
 A [=sensor=] has an associated <dfn>reporting flag</dfn> which is initially unset.
 
-A [=sensor=] has an associated <dfn>current reporting mode</dfn> which is initially `undefined`.
+A [=sensor=] has an associated <dfn>periodic reporting mode flag</dfn> which is initially unset.
 
 A [=sensor=] has an associated <dfn>current polling frequency</dfn> which is initially `null`.
 
@@ -518,11 +569,12 @@ returns a [=permission=] and, eventually, its [=associated PermissionDescriptor=
 
 
 <h3 id="the-sensor-interface">The Sensor Interface</h3>
+
 <pre class="idl">
 [SecureContext]
 interface Sensor : EventTarget {
   readonly attribute SensorState state;
-  readonly attribute SensorReading? reading;
+  readonly attribute DOMHighResTimeStamp timestamp;
   void start();
   void stop();
   attribute EventHandler onchange;
@@ -535,72 +587,122 @@ dictionary SensorOptions {
 };
 
 enum SensorState {
-  "idle",
+  "unconnected",
   "activating",
   "activated",
+  "idle",
   "errored"
 };
 </pre>
 
 A {{Sensor}} object has an associated [=sensor=].
 
-A {{Sensor}} object has an associated <dfn>state</dfn> which is one of
-<a enum-value>"idle"</a>,
-<a enum-value>"activating"</a>,
-<a enum-value>"activated"</a>, and
-<a enum-value>"errored"</a>.
-It is initially <a enum-value>"idle"</a>.
-
-A {{Sensor}} object has an associated <dfn>desired frequency</dfn>. It is initially `null`.
-
 Each {{Sensor}} object has a [=task source=]
 called a <dfn>sensor task source</dfn>, initially empty.
-A [=sensor task source=] can be enabled or disabled, and is initially enabled.
-When enabled, the [=event loop=] must use it as one of its [=task sources=].
-The [=task source=] for the [=tasks=] mentioned in this specification is the [=sensor task source=].
+A [=sensor task source=] can be enabled or disabled,
+and is initially enabled.
+When enabled,
+the [=event loop=] must use it as one of its [=task sources=].
+The [=task source=] for the [=tasks=] mentioned in this specification
+is the [=sensor task source=].
 
-When the [=visibility state=] of the [=Document=] in the [=top-level browsing context=] changes,
-let |current_visibility_state| be the result of running the [=steps to determine the visibility state=]
-of the [=Document=].
-If |current_visibility_state| is "visible", enable the sensor task source, otherwise, disable it.
+When the [=visibility state=] of the [=Document=] in
+the [=top-level browsing context=] changes,
+let |current_visibility_state| be the result of running
+the [=steps to determine the visibility state=] of the [=Document=].
+If |current_visibility_state| is "visible",
+enable the sensor task source,
+otherwise, disable it.
 
 Note: user agents are encouraged to stop sensor polling
 when [=sensor task sources=] are disabled in order
 to save battery.
 
+### Sensor internal slots ### {#sensor-internal-slots}
+
+Instances of {{Sensor}} are created
+with the internal slots described in the following table:
+
+<table id="sensor-slots" class="vert data">
+    <thead>
+        <tr><th>Internal Slot</th><th>Description (non-normative)</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><dfn export>\[[state]]</dfn></td>
+            <td>The current state of {{Sensor}} object which is one of
+                <a enum-value>"unconnected"</a>,
+                <a enum-value>"activating"</a>,
+                <a enum-value>"activated"</a>,
+                <a enum-value>"idle"</a>, and
+                <a enum-value>"errored"</a>.
+                It is initially <a enum-value>"unconnected"</a>.
+            </td>
+        </tr>
+        <tr>
+            <td><dfn>\[[desiredPollingFrequency]]</dfn></td>
+            <td>The requested polling frequency. It is initially unset.</td>
+        </tr>
+        <tr>
+            <td><dfn>\[[lastEventFiredAt]]</dfn></td>
+            <td>the high resolution timestamp of the latest [=sensor reading=]
+                that was sent to observers of the {{Sensor}} object,
+                expressed in milliseconds that passed since the [=time origin=].
+                It is initially `null`.
+            </td>
+        </tr>
+        <tr>
+            <td><dfn>\[[waitingForUpdate]]</dfn></td>
+            <td>A boolean which indicates wether the observers have been updated
+                or whether the object is waiting for a new reading to do so.
+                It is initially `true`.</td>
+        </tr>
+        <tr>
+            <td><dfn>\[[identifyingParameters]]</dfn></td>
+            <td>
+                A [=sensor type=]-epecific group of [=dictionary members=]
+                used to select the correct [=sensor=]
+                to associate to this {{Sensor}} object.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+
 ### Sensor.state ### {#sensor-state}
 
-The [=state=] attribute represents a {{Sensor}} object's [=state=].
+The getter of the {{Sensor/state!!attribute}} attribute returns <emu-val>this</emu-val>.\[[state]].
 
-### Sensor.reading ### {#sensor-reading}
+### Sensor.timestamp ### {#sensor-timestamp}
 
-When a {{Sensor}}'s [=state=] is <a enum-value>"activated"</a>,
-its {{Sensor/reading!!attribute}} attribute must always point to the [=current reading=]
-whatever the [=frequency=] so that
-the {{Sensor/reading!!attribute}} attribute of two instances of the same {{Sensor}} interface
-associated with the same [=sensor=]
-hold the same {{SensorReading}} during a single [=event loop=] turn.
+The getter of the {{Sensor/timestamp!!attribute}} attribute returns
+[=latest reading=]["timestamp"].
 
 ### Sensor.start() ### {#sensor-start}
 
 <div algorithm="to start a sensor">
 The {{Sensor/start()}} method must run these steps or their [=equivalent=]:
-
-    1.  If |sensor_instance|'s [=state=] is neither <a enum-value>"idle"</a> nor <a enum-value>"errored"</a>,
-        1.  throw an "{{InvalidStateError!!exception}}" exception and abort these steps.
-    1.  Set |sensor_instance|’s [=state=] to <a enum-value>"activating"</a>.
+    1.  Let |sensor_state| be the value of sensor_instance|.[=[[state]]=].
+    1.  If |sensor_state| is either <a enum-value>"activating"</a>
+        or <a enum-value>"activated"</a>,
+        1.  [=throw=] an "{{InvalidStateError!!exception}}" {{DOMException}}
+            and abort these steps.
+    1.  Set |sensor_instance|.[=[[state]]=] to <a enum-value>"activating"</a>.
     1.  Run these sub-steps [=in parallel=]:
-        1.  Let |permission_state| be the result of invoking the [=Request Sensor Access=] abstract operation,
+        1.  If |sensor_state| is <a enum-value>"unconnected"</a>, then:
+            1.  let |connected| be the result of invoking
+                the [=Connect to Sensor=] abstract operation.
+            1.  If |connected| is `false`, then abort these steps.
+        1.  Let |permission_state| be the result of invoking
+            the [=Request Sensor Access=] abstract operation,
             passing it |sensor_instance| as argument.
         1.  If |permission_state| is "granted",
-            1.  Invoke [=Register a Sensor=] passing it |sensor_instance| as argument.
-            1.  Abort these sub-steps.
-        1.  If |permission_state| is "denied",
-            1.  let |e| be the result of [=created|creating an exception=] named "{{NotAllowedError!!exception}}".
+            1.  Invoke [=Register a Sensor Object=] passing it |sensor_instance| as argument.
+        1.  Otherwise, if |permission_state| is "denied",
+            1.  let |e| be the result of [=created|creating=]
+                a "{{NotAllowedError!!exception}}" {{DOMException}}.
             1.  Invoke the [=Handle Errors=] abstract operation,
                 passing it |e| and |sensor_instance| as arguments.
-            1.  Abort these sub-steps.
-    1.  return `undefined`.
 </div>
 
 ### Sensor.stop() ### {#sensor-stop}
@@ -608,23 +710,26 @@ The {{Sensor/start()}} method must run these steps or their [=equivalent=]:
 <div algorithm="to stop a sensor">
 The {{Sensor/stop()}} method must run these steps or their [=equivalent=]:
 
-    1.  If |sensor_instance|'s [=state=] is either <a enum-value>"idle"</a> or <a enum-value>"errored"</a>, then
-        1.  throw an "{{InvalidStateError!!exception}}" exception and abort these steps.
-    1.  Set |sensor_instance|’s {{Sensor/reading!!attribute}} to `null`.
-    1.  Set |sensor_instance|’s [=state=] to <a enum-value>"idle"</a>.
+    1.  If |sensor_instance|.[=[[state]]=] is neither <a enum-value>"activating"</a>
+        nor <a enum-value>"activated"</a>, then
+        1.  [=throw=] an "{{InvalidStateError!!exception}}" {{DOMException}}
+            and abort these steps.
+    1.  Set |sensor_instance|.[=[[state]]=] to <a enum-value>"idle"</a>.
     1.  Run these sub-steps [=in parallel=]:
         1.  Invoke [=Unregister a Sensor=] passing it |sensor_instance| as argument.
-    1.  return `undefined`.
-
 </div>
 
 ### Sensor.onchange ### {#sensor-onchange}
 
 {{Sensor/onchange}} is an {{EventHandler}} which is called whenever a new [=sensor reading|reading=] is available.
 
+Issue: Should this be renamed `onreading`?
+Should we instead add an `ondata` {{EventHandler}} for continuous data
+and use `onchange` when the data changed?
+
 ### Sensor.onactivate ### {#sensor-onactivate}
 
-{{Sensor/onactivate}} is an {{EventHandler}} which is called when the [=state=] transitions from <a enum-value>"activating"</a> to <a enum-value>"activated"</a>.
+{{Sensor/onactivate}} is an {{EventHandler}} which is called when <emu-val>this</emu-val>.[=[[state]]=] transitions from <a enum-value>"activating"</a> to <a enum-value>"activated"</a>.
 
 ### Sensor.onerror ### {#sensor-onerror}
 
@@ -660,25 +765,6 @@ that must be supported as attributes by the objects implementing the [=Sensor=] 
 </table>
 
 
-<h3 id="the-sensor-reading-interface">The SensorReading Interface</h3>
-
-<pre class="idl">
-[SecureContext]
-interface SensorReading {
-  readonly attribute DOMHighResTimeStamp timeStamp;
-};
-</pre>
-
-A {{SensorReading}} represents the state of a [=sensor=] at a given point in time.
-
-### SensorReading.timeStamp ### {#sensor-reading-timestamp}
-
-Returns a high resolution timestamp of the time
-at which the [=sensor reading|reading=] was obtained from the [=sensor=]
-expressed in milliseconds that passed since the [=time origin=].
-
-
-
 <h3 id="the-sensor-error-event-interface">The SensorErrorEvent Interface</h3>
 
 <pre class="idl">
@@ -694,6 +780,7 @@ dictionary SensorErrorEventInit : EventInit {
 
 ### SensorErrorEvent.error ### {#sensor-error-event-error}
 
+Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 
 <h2 id="abstract-operations">Abstract Operations</h2>
 
@@ -707,35 +794,64 @@ dictionary SensorErrorEventInit : EventInit {
     :: |sensor_instance|, a {{Sensor}} object.
 
     1.  If the [=incumbent settings object=] is not a [=secure context=], then:
-        1.  [=throw=] a SecurityError.
+        1.  [=throw=] a {{SecurityError}}.
     1.  If the [=browsing context=] is not a [=top-level browsing context=], then:
-        1.  [=throw=] a SecurityError.
-    1.  Otherwise, if [=identifying parameters=] in |options| are set, then:
-        1.  If these [=identifying parameters=] allow a unique [=sensor=] to be identified, then:
-            1.  let |sensor| be that [=sensor=],
-            1.  let |sensor_instance| be a new {{Sensor}} object,
-            1.  associate |sensor_instance| with |sensor|.
-        1. Otherwise, [=throw=] a TypeError.
-    1.  Otherwise, if a [=default sensor=] exists for this [=sensor type=]:
-        1.  let |sensor| be that [=sensor=],
-        1.  let |sensor_instance| be a new {{Sensor}} object,
-        1.  associate |sensor_instance| with |sensor|.
-    1.  Otherwise, [=throw=] a TypeError.
-    1.  Let |frequency| be the value of the {{frequency!!dict-member}} member of |options|.
-    1.  If |frequency| is [=present=],
-        1.  If |sensor| [=supports periodic reporting mode=],
-            1.  Set |sensor_instance|'s [=desired frequency=] to |frequency|.
-        1.  Otherwise,
-            1.  [=throw=] a TypeError.
-    1.  Set |sensor_instance|'s {{Sensor/reading!!attribute}} attribute to `null`.
-    1.  Set |sensor_instance|'s [=state=] to <a enum-value>"idle"</a>.
-    1.  return |sensor_instance|.
+        1.  [=throw=] a {{SecurityError}}.
+    1.  Let |sensor_instance| be a new {{Sensor}} object,
+    1.  If [=sensor=] [=supports periodic reporting mode=] and
+        |options|.{{frequency!!dict-member}} is [=present=], then
+        1.  Set |sensor_instance|.[=[[desiredPollingFrequency]]=] to |options|.{{frequency!!dict-member}}.
+
+        Note: there is not guarantee that the requested |options|.{{frequency!!dict-member}}
+        can be respected. The actual [=frequency=] can be calculated using
+        {{Sensor}} {{Sensor/timestamp!!attribute}} attributes.
+    1.  If [=identifying parameters=] in |options| are set, then:
+        1.  Set |sensor_instance|.[=[[identifyingParameters]]=] to [=identifying parameters=].
+    1.  Set |sensor_instance|.[=[[state]]=] to <a enum-value>"unconnected"</a>.
+    1.  Return |sensor_instance|.
 </div>
 
 
-<h3 dfn>Register a Sensor</h3>
+<h3 dfn export>Connect to Sensor</h3>
 
-<div algorithm="register a sensor">
+<div algorithm="connect to sensor">
+
+    : input
+    :: |sensor_instance|, a {{Sensor} object.
+    : output
+    :: a boolean.
+
+    1.  If |sensor_instance|.[=[[identifyingParameters]]=] is set and
+        |sensor_instance|.[=[[identifyingParameters]]=] allows
+        a unique [=sensor=] to be identified, then:
+        1.  let |sensor| be that [=sensor=],
+        1.  associate |sensor_instance| with |sensor|.
+        1.  Return `true`.
+    1.  If the [=sensor type=] of |sensor_instance| has an associated [=default sensor=]
+        and there is a corresponding [=sensor=] on the device, then
+        1.  associate |sensor_instance| with [=default sensor=].
+        1.  Return `true`.
+    1.  let |e| be the result of [=created|creating=] a
+        "{{NotReadableError!!exception}}" {{DOMException}}.
+        <!-- Note: user agents may decide to use a
+        "{{NotAllowedError!!exception}}" {{DOMException}},
+        here instead, possibly after a random but bounded delay,
+        to simulate the user denying the permission request,
+        rather than giving away physical characteristics of the device
+        which might be used for fingerprinting or profiling.
+        This would of course prevent the developer from
+        correctly diagnosing the reason for the rejection
+        and might lead to confusing instructions to the user,
+        but it is a tradeoff some User Agent might choose to make. -->
+    1.  Invoke the [=Handle Errors=] abstract operation,
+        passing it |e| and |sensor_instance| as arguments.
+    1.  Return `false`.
+</div>
+
+
+<h3 dfn>Register a Sensor Object</h3>
+
+<div algorithm="register a sensor object">
 
     : input
     :: |sensor_instance|, a {{Sensor}} object.
@@ -746,10 +862,10 @@ dictionary SensorErrorEventInit : EventInit {
     1.  Add |sensor_instance| to |sensor|'s set of [=activated Sensor objects=].
     1.  Invoke the [=Set Sensor Settings=] abstract operation,
         passing it |sensor| as argument.
-    1.  Let |current_reading| be |sensor|'s associated [=current reading=].
-    1.  If |current_reading| is not `null` and |sensor_instance|'s state is still <a enum-value>"activating"</a>, then
-        1.  invoke the [=Update Reading=] operation, passing it
-            |sensor_instance| and |current_reading| as arguments.
+    <!-- 1.  Let |latest_reading| be |sensor|'s associated [=latest reading=] [ordered map|map].
+    1.  If |current_reading|["timestamp"] is not `null` and |sensor_instance|'s state is still <a enum-value>"activating"</a>, then
+        1.  invoke the [=Update Observers=] operation, passing it
+            |sensor_instance| and |current_reading| as arguments. -->
 </div>
 
 
@@ -765,7 +881,7 @@ dictionary SensorErrorEventInit : EventInit {
     1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
     1.  Remove |sensor_instance| from |sensor|'s set of [=activated Sensor objects=].
     1.  If |sensor|'s set of [=activated Sensor objects=] is empty,
-        1.  Set [=current reporting mode=] to `undefined`.
+        1.  Unset the [=periodic reporting mode flag=].
         1.  Set [=current polling frequency=] to `null`.
         1.  Update the user-agent-specific way in which [=sensor readings=] are obtained from |sensor|
             to no longer provide [=sensor readings|readings=].
@@ -785,18 +901,27 @@ dictionary SensorErrorEventInit : EventInit {
     :: None
 
     1.  Let |settings_changed| be `false`.
-    1.  Let |mode| be the result of invoking the [=find current reporting mode of a sensor=] abstract operation,
+    1.  Let |is_periodic| be the result of invoking
+        the [=Is Current Reporting Mode Periodic=] abstract operation,
         with |sensor| as argument.
-    1.  If |mode| is different from |sensor|'s [=current reporting mode=],
+    1.  If |is_periodic| is `false` and the [=periodic reporting mode flag=] is set, then
         1.  set |settings_changed| to `true`.
-        1.  Set [=current reporting mode=] to |mode|.
-    1.  Let |frequency| be the result of invoking the [=Find the polling frequency of a Sensor=] abstract operation,
+        1.  Unset the [=periodic reporting mode flag=].
+    1.  Otherwise if |is_periodic| is `true` and the [=periodic reporting mode flag=] is unset, then
+        1.  set |settings_changed| to `true`.
+        1.  Set the [=periodic reporting mode flag=].
+    1.  Let |frequency| be the result of invoking
+        the [=Find the polling frequency of a Sensor=] abstract operation,
         with |sensor| as argument.
     1.  If |frequency| is different from |sensor|'s [=current polling frequency=],
         1.  set |settings_changed| to `true`.
         1.  Set [=current polling frequency=] to |frequency|.
     1.  If |settings_changed| is `true`
-        1.  Invoke the [=Observe a Sensor=] abstract operation, passing it |sensor| as argument.
+        1.  Invoke the [=Observe a Sensor=] abstract operation,
+            passing it |sensor| as argument.
+    
+    Issue: This abstract operation needs to return |settings_changed|
+    instead of the [=Observe a Sensor=] abstract operation itself.
 </div>
 
 
@@ -804,44 +929,71 @@ dictionary SensorErrorEventInit : EventInit {
 
 <div algorithm="observe a sensor">
 
+    Issue: This needs to be refactored in an abstract operation
+    that has access to the {{Sensor}} instance |sensor_instance|
+    that just got started.
+
     : input
     :: |sensor|, a [=sensor=].
     : output
     :: None
 
-    1.  If |sensor|'s [=current reporting mode=] is [=periodic=],
+    <!-- 1.  Immediately invoke the [=Update latest reading=] abstract operation
+        to report fresh [=sensor readings|readings=],
+        passing it |sensor| and [=latest reading=]["timestamp"] as arguments. -->
+    1.  If |sensor|'s |latest reading|["timestamp"] is not `null`,
+        invoke the [=update observers=] abstract operation passing it |sensor_instance|
+        and |latest reading|["timestamp"] as arguments.
+    1.  Otherwise, poll |sensor| immediately.
+
+        Issue: How do we handle this for [=sensors=] that
+        do not provide values immediately?
+        Fire a dedicated event to signal brokenness?
+
+    1.  If |sensor|'s [=periodic reporting mode flag=] is set,
         1.  let |frequency| be the [=current polling frequency=],
             capped by the upper and lower bounds of the underlying hardware.
-        1.  Invoke the [=Update Current Reading=] abstract operation
-            at a [=frequency=] of |frequency| passing it |sensor| and
-            the latest [=sensor reading=] as arguments.
 
-            Note: there is not guarantee that the [=current polling frequency=]
-            can be respected. The actual [=frequency=] can be calculated using
-            {{SensorReading}} {{SensorReading/timeStamp!!attribute}} attributes.
-    1.  If the [=current reporting mode=] is set to [=implementation specific=],
-        1.  Immediately invoke the [=Update Current Reading=] abstract operation
-            to report fresh [=sensor readings|readings=],
-            passing it |sensor| and the latest [=sensor reading=] as arguments.
+            Issue: Should this max polling frequency be reflected in the {{Sensor}} interface?
+            E.g. Through a dedicated attribute?
+
+            Issue: Does the max polling frequency affect the reporting frequency?
+            If so, should we advise the developer of this issue?
+            E.g. via a dedicated event?
+        1.  Poll |sensor| at |frequency|.
+        1.  Issue: Hook into the `requestAnimationFrame` framework [[HTML]]
+            to invoke the [=update latest reading=] abstract operation
+            with every new frame passing it |sensor| and
+            the latest [=sensor reading=] as arguments.
+            
+            Issue: Relying on `requestAnimationFrame` gives us a perfect point
+            to buffer readings > 60Hz and to pass them to together with every new frame.
+            That's a level 2 feature.
+            
+            Issue: Figure out how to handle sensors/platforms that push the data
+            rather than wait for it to be polled.
+    1.  If the [=periodic reporting mode flag=] is unset,
         1.  the user-agent can decide on the best reporting strategy
             for this particular |sensor| and [=sensor type=].
+
+            Issue: This needs to be defined better.
 </div>
 
 
-<h3 dfn>Find Current Reporting Mode of a Sensor</h3>
+<h3 dfn>Is Current Reporting Mode Periodic</h3>
 
-<div algorithm="find current reporting mode of a sensor">
+<div algorithm="is current reporting mode periodic">
 
     : input
     :: |sensor|, a [=sensor=].
     : output
-    :: |mode|, a [=reporting mode=].
+    :: |result|, a boolean.
 
-    1. let |mode| be [=implementation specific=].
-    1.  For each |sensor_instance| in |sensor|'s set of [=activated Sensor objects=]:
-        1. if |sensor_instance|'s [=frequency=] is not `null`,
-            1. set |mode| to [=periodic=]
-    1. return |mode|.
+    1.  Let |result| be `false`.
+    1.  [=list/For each=] |sensor_instance| in |sensor|'s set of [=activated Sensor objects=]:
+        1. if |sensor_instance|.[=[[desiredPollingFrequency]]=] is set,
+            1. set |result| to `true`, then [=break=].
+    1. return |result|.
 </div>
 
 
@@ -854,55 +1006,69 @@ dictionary SensorErrorEventInit : EventInit {
     : output
     :: |frequency|, a [=frequency=].
 
-    1. let |frequency| be `null`.
-    1.  For each |sensor_instance| in |sensor|'s set of [=activated Sensor objects=]:
-        1. let |f| be |sensor_instance|'s [=desired frequency=].
-        1. if |f| is not `null` and |f| is greater than |frequency|,
+    1.  Let |frequency| be `null`.
+    1.  [=set/For each=] |sensor_instance| in |sensor|'s set of [=activated Sensor objects=]:
+        1. let |f| be |sensor_instance|.[=[[desiredPollingFrequency]]=].
+        1. if |f| is set and |f| is greater than |frequency|,
             1. set |frequency| to |f|.
     1. return |frequency|.
 </div>
 
 
-<h3 dfn>Update Current Reading</h3>
+<h3 dfn>Update latest reading</h3>
 
-<div algorithm="update current reading">
+<div algorithm="update latest reading">
 
     : input
     :: |sensor|, a [=sensor=].
     :: |reading|, a [=sensor reading=].
+    :: |reading_timestamp|, the timestamp at which [=sensor=] was polled.
+
+    Issue: The timestamp needs to be specified more precisely,
+    see [issue #155](https://github.com/w3c/sensors/issues/155).
     : output
     :: None
 
     1.  If |sensor|’s [=reporting flag=] is set,
         1. abort these steps.
+    1.  If |reading_timestamp| is equal [=latest reading=]["timestamp"],
+        1. abort these steps.
     1.  Set |sensor|’s [=reporting flag=].
-    1.  Let |reading_instance| be the result of invoking the
-        [=Construct SensorReading Object=] operation
-        associated with |sensor|'s [=sensor type|type=],
-        passing it |reading| as argument.
-    1.  Set |sensor|’s [=current reading=] to |reading_instance|.
-    1.  For each |sensor_instance| in |sensor|'s set of [=activated Sensor objects=]:
-        1.  Invoke the [=update reading=] algorithm passing |sensor_instance|
-            and |reading_instance| as arguments.
+    1.  [=map/Set=] [=latest reading=]["timestamp"] to |reading_timestamp|.
+    1.  [=map/For each=] |key| → |value| of [=latest reading=].
+        1.  If |key| is "timestamp", [=continue=].
+        1.  [=map/Set=] [=latest reading=][|key|] to the corresponding
+            value of |reading|.
+
+        Issue: Maybe compare |value| with corresponding
+        value of |reading| to see if there's a change
+        that needs to be propagated.
     1.  Unset |sensor|’s [=reporting flag=].
 </div>
 
 
-<h3 dfn>Update Reading</h3>
+<h3 dfn>Update Observers</h3>
 
-<div algorithm="update reading">
+<div algorithm="update observers">
 
     : input
     :: |sensor_instance|, a {{Sensor}} object.
-    :: |reading|, a {{SensorReading}} object.
+    :: |timestamp|, a high resolution timestamp.
     : output
     :: None
 
-    1.  Set |sensor_instance|’s {{Sensor/reading!!attribute}} to |reading|.
-    1.  If |sensor_instance|'s [=state=] is <a enum-value>"activating"</a>:
-        1.  Set |sensor_instance|’s [=state=] <a enum-value>"activated"</a>.
+    1.  If |sensor_instance|.[=[[state]]=] is <a enum-value>"activating"</a>:
+        1.  Set |sensor_instance|.[=[[state]]=] <a enum-value>"activated"</a>.
         1.  [=Fire an event=] named "activate" at |sensor_instance|.
-    1.  [=Fire an event=] named "reading" at |sensor_instance|.
+    1.  If |sensor_instance|.[=[[waitingForUpdate]]=] is true, then
+
+        Issue: Should we fire delayed readings? Or should we just drop readings instead?
+
+        1.  Set |sensor_instance|.[=[[waitingForUpdate]]=] to `false`.
+        1.  [=Fire an event=] named "reading" at |sensor_instance|.
+        1.  Set |sensor_instance|.[=[[lastEventFiredAt]]=] to |timestamp|.
+
+        Issue: Should these last steps be done from within a new task?
 </div>
 
 
@@ -916,8 +1082,7 @@ dictionary SensorErrorEventInit : EventInit {
     : output
     :: None
 
-    1.  Set |sensor_instance|’s {{Sensor/reading!!attribute}} to `null`.
-    1.  Set |sensor_instance|’s [=state=] to <a enum-value>"errored"</a>.
+    1.  Set |sensor_instance|.[=[[state]]=] to <a enum-value>"errored"</a>.
     1.  [=Fire an event=] named "error" at |sensor_instance| using {{SensorErrorEvent}}
         with its {{SensorErrorEvent/error!!attribute}} attribute initialized to |error|.
 </div>
@@ -942,7 +1107,7 @@ dictionary SensorErrorEventInit : EventInit {
             1. set |state| to "granted",
         1.  else,
             1. set |state| to "denied".
-    1.  return |state|.
+    1.  Return |state|.
 </div>
 
 
@@ -957,6 +1122,8 @@ different [=sensor types=].
 Extension specifications are encouraged to focus on a single [=sensor type=],
 exposing both [=high-level|high=] and [=low-level|low=] level
 as appropriate.
+
+
 
 
 <h3 id="security">Security</h3>
@@ -978,10 +1145,10 @@ For example, a [=sensor=] measuring
 the distance at which an object is from it
 may see its associated interface called `ProximitySensor`.
 
-Attributes of the {{SensorReading}} subclass that
+Attributes of the {{Sensor}} subclass that
 hold [=sensor readings=] values
 should be named after the full name of these values.
-For example, the `TemperatureSensorReading` interface should hold
+For example, the `Thermometer` interface should hold
 the [=sensor reading=]'s value in
 a `temperature` attribute (and not a `value` or `temp` attribute).
 A good starting point for naming are the
@@ -992,7 +1159,7 @@ Quantities, Units, Dimensions and Data Types Ontologies [[QUDT]].
 
 Extension specification must specify the unit of [=sensor readings=].
 
-As per the Technical Architecure Group's (TAG) API Design Principles [[API-DESIGN-PRINCIPLES]],
+As per the Technical Architecture Group's (TAG) API Design Principles [[API-DESIGN-PRINCIPLES]],
 all time measurement should be in milliseconds.
 All other units should be specified using,
 in order of preference,
@@ -1045,25 +1212,24 @@ TODO: provide guidance on when to:
 
 <h3 id="definition-reqs">Definition Requirements</h3>
 
-At least the following definitions must be specified in each extension specification:
+The following definitions must be specified for
+each [=sensor type=] in extension specifications:
 
--   A [=Sensor subclass=] which is constructible and takes
-    an optional {{SensorOptions}} dictionary as argument.
--   A [=SensorReading subclass=] which is constructible and
-    whose attributes which hold [=sensor readings=] are readonly.
--   A abstract operation to
-    [=Construct SensorReading Object|construct a SensorReading object=]
-    which takes the [=sensor readings=] emitted by the [=sensor=] and
-    returns an initialized [=SensorReading subclass=] object.
--   The [=sensor type=]'s [=supported reporting modes=].
+-   An [=interface=] whose [=inherited interfaces=] contains {{Sensor}}.
+    This interface must be constructible.
+    Its [{{Constructor!!extended-attribute}}] must take, as argument,
+    an optional [=dictionary=] whose [=inherited dictionaries=] contains {{SensorOptions}}.
+    Its attributes which expose [=sensor readings=] are readonly and
+    have getters must return the  if disturbed, and `null` otherwise.
 -   A abstract operation to
     [=retrieve the sensor permission|retrieve sensor permission=] which
-    takes a [=Sensor subclass=] object as input and
+    takes an object implementing the [=sensor type=]'s associated interface as input and
     returns a [=permission=] and, eventually, its [=associated PermissionDescriptor=].
 
-An extension specification may specify the following defintions:
+An extension specification may specify the following definitions
+for each [=sensor types=]:
 
--   A {{SensorOptions}} subclass.
+-   A [=dictionary=] whose [=inherited dictionaries=] contains {{SensorOptions}}.
 -   A [=default sensor=]. Generally, devices are equipped with a single [=sensor=]
     of each [=sensor types|type=],
     so defining a [=default sensor=] should be straightforward.
@@ -1087,10 +1253,6 @@ for proximity [=sensors=].
 <pre class=example>
     [SecureContext, Constructor(optional ProximitySensorOptions proximitySensorOptions)]
     interface ProximitySensor : Sensor {
-    };
-
-    [SecureContext]
-    interface ProximitySensorReading : SensorReading {
         readonly attribute unrestricted double distance;
     };
 
@@ -1127,7 +1289,7 @@ for proximity [=sensors=].
 <h2 id="acknowledgements">Acknowledgements</h2>
 
 First and foremost, I would like to thank Anssi Kostiainen
-for his continuous and dedicates support and input throughout
+for his continuous and dedicated support and input throughout
 the development of this specification.
 
 Special thanks to Rick Waldron for
@@ -1137,7 +1299,7 @@ providing implementation feedback from his work on Johnny-Five,
 and continuous input during the development of this specification.
 
 Special thanks to Boris Smus, Tim Volodine, and Rich Tibbett
-for their initial work on exposing sensors to the Web with consistency.
+for their initial work on exposing sensors to the web with consistency.
 
 Thanks to Anne van Kesteren
 for his tireless help both in person and through IRC.
@@ -1147,7 +1309,7 @@ Thanks to Domenic Denicola and Jake Archibald for their help.
 Thanks also to Frederick Hirsch and Dominique Hazaël-Massieux (via the HTML5Apps project)
 for both their administrative help and technical input.
 
-Thanks to Tab Atkins for making Bikeshed and taking the time to explain its subtelties.
+Thanks to Tab Atkins for making Bikeshed and taking the time to explain its subtleties.
 
 The following people have greatly contributed to this specification through extensive discussions on GitHub:
 Anssi Kostiainen,

--- a/index.html
+++ b/index.html
@@ -969,6 +969,8 @@ Possible extra rowspan handling
 		/* Reverse color scheme */
 		color: black;
 		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
 	}
 	.toc a:visited {
 		border-color: #054572;
@@ -1181,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed 1.0.0" name="generator">
+  <meta content="Bikeshed version 237216488a585c6f0fbfeb6dc67a26c10fd1d88d" name="generator">
 <style>
     #toc .current,
     #toc .current-parent {
@@ -1441,7 +1443,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-01">1 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-26">26 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1462,7 +1464,7 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -1529,40 +1531,37 @@ that can be extended to accommodate different sensor types.</p>
       <li>
        <a href="#the-sensor-interface"><span class="secno">8.1</span> <span class="content">The Sensor Interface</span></a>
        <ol class="toc">
-        <li><a href="#sensor-state"><span class="secno">8.1.1</span> <span class="content">Sensor.state</span></a>
-        <li><a href="#sensor-reading"><span class="secno">8.1.2</span> <span class="content">Sensor.reading</span></a>
-        <li><a href="#sensor-start"><span class="secno">8.1.3</span> <span class="content">Sensor.start()</span></a>
-        <li><a href="#sensor-stop"><span class="secno">8.1.4</span> <span class="content">Sensor.stop()</span></a>
-        <li><a href="#sensor-onchange"><span class="secno">8.1.5</span> <span class="content">Sensor.onchange</span></a>
-        <li><a href="#sensor-onactivate"><span class="secno">8.1.6</span> <span class="content">Sensor.onactivate</span></a>
-        <li><a href="#sensor-onerror"><span class="secno">8.1.7</span> <span class="content">Sensor.onerror</span></a>
-        <li><a href="#event-handlers"><span class="secno">8.1.8</span> <span class="content">Event handlers</span></a>
+        <li><a href="#sensor-internal-slots"><span class="secno">8.1.1</span> <span class="content">Sensor internal slots</span></a>
+        <li><a href="#sensor-state"><span class="secno">8.1.2</span> <span class="content">Sensor.state</span></a>
+        <li><a href="#sensor-timestamp"><span class="secno">8.1.3</span> <span class="content">Sensor.timestamp</span></a>
+        <li><a href="#sensor-start"><span class="secno">8.1.4</span> <span class="content">Sensor.start()</span></a>
+        <li><a href="#sensor-stop"><span class="secno">8.1.5</span> <span class="content">Sensor.stop()</span></a>
+        <li><a href="#sensor-onchange"><span class="secno">8.1.6</span> <span class="content">Sensor.onchange</span></a>
+        <li><a href="#sensor-onactivate"><span class="secno">8.1.7</span> <span class="content">Sensor.onactivate</span></a>
+        <li><a href="#sensor-onerror"><span class="secno">8.1.8</span> <span class="content">Sensor.onerror</span></a>
+        <li><a href="#event-handlers"><span class="secno">8.1.9</span> <span class="content">Event handlers</span></a>
        </ol>
       <li>
-       <a href="#the-sensor-reading-interface"><span class="secno">8.2</span> <span class="content">The SensorReading Interface</span></a>
+       <a href="#the-sensor-error-event-interface"><span class="secno">8.2</span> <span class="content">The SensorErrorEvent Interface</span></a>
        <ol class="toc">
-        <li><a href="#sensor-reading-timestamp"><span class="secno">8.2.1</span> <span class="content">SensorReading.timeStamp</span></a>
-       </ol>
-      <li>
-       <a href="#the-sensor-error-event-interface"><span class="secno">8.3</span> <span class="content">The SensorErrorEvent Interface</span></a>
-       <ol class="toc">
-        <li><a href="#sensor-error-event-error"><span class="secno">8.3.1</span> <span class="content">SensorErrorEvent.error</span></a>
+        <li><a href="#sensor-error-event-error"><span class="secno">8.2.1</span> <span class="content">SensorErrorEvent.error</span></a>
        </ol>
      </ol>
     <li>
      <a href="#abstract-operations"><span class="secno">9</span> <span class="content">Abstract Operations</span></a>
      <ol class="toc">
       <li><a href="#construct-sensor-object"><span class="secno">9.1</span> <span class="content">Construct Sensor Object</span></a>
-      <li><a href="#register-a-sensor"><span class="secno">9.2</span> <span class="content">Register a Sensor</span></a>
-      <li><a href="#unregister-a-sensor"><span class="secno">9.3</span> <span class="content">Unregister a Sensor</span></a>
-      <li><a href="#set-sensor-settings"><span class="secno">9.4</span> <span class="content">Set Sensor Settings</span></a>
-      <li><a href="#observe-a-sensor"><span class="secno">9.5</span> <span class="content">Observe a Sensor</span></a>
-      <li><a href="#find-current-reporting-mode-of-a-sensor"><span class="secno">9.6</span> <span class="content">Find Current Reporting Mode of a Sensor</span></a>
-      <li><a href="#find-the-polling-frequency-of-a-sensor"><span class="secno">9.7</span> <span class="content">Find the polling frequency of a Sensor</span></a>
-      <li><a href="#update-current-reading"><span class="secno">9.8</span> <span class="content">Update Current Reading</span></a>
-      <li><a href="#update-reading"><span class="secno">9.9</span> <span class="content">Update Reading</span></a>
-      <li><a href="#handle-errors"><span class="secno">9.10</span> <span class="content">Handle Errors</span></a>
-      <li><a href="#request-sensor-access"><span class="secno">9.11</span> <span class="content">Request Sensor Access</span></a>
+      <li><a href="#connect-to-sensor"><span class="secno">9.2</span> <span class="content">Connect to Sensor</span></a>
+      <li><a href="#register-a-sensor-object"><span class="secno">9.3</span> <span class="content">Register a Sensor Object</span></a>
+      <li><a href="#unregister-a-sensor"><span class="secno">9.4</span> <span class="content">Unregister a Sensor</span></a>
+      <li><a href="#set-sensor-settings"><span class="secno">9.5</span> <span class="content">Set Sensor Settings</span></a>
+      <li><a href="#observe-a-sensor"><span class="secno">9.6</span> <span class="content">Observe a Sensor</span></a>
+      <li><a href="#is-current-reporting-mode-periodic"><span class="secno">9.7</span> <span class="content">Is Current Reporting Mode Periodic</span></a>
+      <li><a href="#find-the-polling-frequency-of-a-sensor"><span class="secno">9.8</span> <span class="content">Find the polling frequency of a Sensor</span></a>
+      <li><a href="#update-latest-reading"><span class="secno">9.9</span> <span class="content">Update latest reading</span></a>
+      <li><a href="#update-observers"><span class="secno">9.10</span> <span class="content">Update Observers</span></a>
+      <li><a href="#handle-errors"><span class="secno">9.11</span> <span class="content">Handle Errors</span></a>
+      <li><a href="#request-sensor-access"><span class="secno">9.12</span> <span class="content">Request Sensor Access</span></a>
      </ol>
     <li>
      <a href="#extensibility"><span class="secno">10</span> <span class="content">Extensibility</span></a>
@@ -1618,6 +1617,9 @@ promote consistency across sensor APIs,
 enable advanced use cases thanks to performant <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-1">low-level</a> APIs,
 and increase the pace at which new sensors can be exposed to the Web
 by simplifying the specification and implementation processes.</p>
+   <p class="issue" id="issue-77d9d95c"><a class="self-link" href="#issue-77d9d95c"></a> This lacks an informative section with examples for developers.
+Should contain different use of the API,
+including using it in conjunction with <code>requestAnimationFrame</code>.</p>
    <h2 class="heading settled" data-level="2" id="scope"><span class="secno">2. </span><span class="content">Scope</span><a class="self-link" href="#scope"></a></h2>
    <p><em>This section is non-normative</em>.</p>
    <p>The scope of this specification is currently limited
@@ -1632,7 +1634,7 @@ in which case this specification will be updated accordingly.
 This should have little to no effects on implementations, however.</p>
    <p>This specification also does not currently expose a
 sensor discovery API.
-This is because the limited number of sensors currently available to User Agents
+This is because the limited number of sensors currently available to user agents
 does not warrant such an API.
 Using feature detection, such as described in <a href="#feature-detection">§4 A note on Feature Detection of Hardware Features</a>,
 is good enough for now.
@@ -1640,24 +1642,30 @@ A subsequent version of this specification might specify such an API,
 and the current API has been designed with this in mind.</p>
    <h2 class="heading settled" data-level="3" id="background"><span class="secno">3. </span><span class="content">Background</span><a class="self-link" href="#background"></a></h2>
    <p><em>This section is non-normative</em>.</p>
+   <p class="issue" id="issue-6a3e5f8d"><a class="self-link" href="#issue-6a3e5f8d"></a> This section is ill-named.
+It principally covers default sensors
+and explains the reasoning behind them.
+It should be renamed accordingly and moved,
+either to another section of the spec
+or to an external explainer document.</p>
    <p>The Generic Sensor API is designed to make the most common use cases straightforward
 while still enabling more complex use cases.</p>
    <p>Most devices deployed today do not carry more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-1">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-1">sensor types</a>.
 This shouldn’t come as a surprise since use cases for more than
 a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-2">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-2">type</a> are rare
-and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-3">sensor types</a> such as
-proximity sensors.</p>
+and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-3">sensor types</a>,
+such as proximity sensors.</p>
    <p>The API therefore makes it easy to interact with
 the device’s default (and often unique) <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-3">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-4">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-1">Sensor</a></code> subclass.</p>
    <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-4">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-5">type</a>,
 the default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-5">sensor</a> is chosen.</p>
-   <div class="example" id="example-c35950d7">
-    <a class="self-link" href="#example-c35950d7"></a> Listening to geolocation changes: 
+   <div class="example" id="example-663bd772">
+    <a class="self-link" href="#example-663bd772"></a> Listening to geolocation changes: 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">(</span><span class="p">{</span> accuracy<span class="o">:</span> <span class="s2">"high"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 
 sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="kd">function</span><span class="p">(</span>event<span class="p">)</span> <span class="p">{</span>
-    <span class="kd">var</span> coords <span class="o">=</span> <span class="p">[</span>event<span class="p">.</span>reading<span class="p">.</span>latitude<span class="p">,</span> event<span class="p">.</span>reading<span class="p">.</span>longitude<span class="p">]</span><span class="p">;</span>
-    updateMap<span class="p">(</span><span class="kc">null</span><span class="p">,</span> coords<span class="p">,</span> event<span class="p">.</span>reading<span class="p">.</span>accuracy<span class="p">)</span><span class="p">;</span>
+    <span class="kd">var</span> coords <span class="o">=</span> <span class="p">[</span>sensor<span class="p">.</span>latitude<span class="p">,</span> sensor<span class="p">.</span>longitude<span class="p">]</span><span class="p">;</span>
+    updateMap<span class="p">(</span><span class="kc">null</span><span class="p">,</span> coords<span class="p">,</span> sensor<span class="p">.</span>accuracy<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span><span class="p">;</span>
 
 sensor<span class="p">.</span>onerror <span class="o">=</span> <span class="kd">function</span><span class="p">(</span>error<span class="p">)</span> <span class="p">{</span>
@@ -1674,10 +1682,10 @@ proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sen
 multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-8">sensors</a> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-6">type</a> may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.</p>
-   <div class="example" id="example-1e642d41">
-    <a class="self-link" href="#example-1e642d41"></a> For example checking the pressure of the left rear tire: 
-<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> DirectTirePressureSensor<span class="p">(</span><span class="p">{</span> position<span class="o">:</span> <span class="s2">"rear"</span><span class="p">,</span> side<span class="o">:</span> <span class="s2">"left"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
-sensor<span class="p">.</span>onchange <span class="o">=</span> event <span class="o">=</span><span class="o">></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>reading<span class="p">.</span>pressure<span class="p">)</span><span class="p">;</span>
+   <div class="example" id="example-7c72945b">
+    <a class="self-link" href="#example-7c72945b"></a> For example checking the pressure of the left rear tire: 
+<pre class="highlight"><span class="kd">var</span> sensor <span class="o">=</span> <span class="k">new</span> DirectTirePressureSensor<span class="p">(</span><span class="p">{</span> position<span class="o">:</span> <span class="s2">"rear"</span><span class="p">,</span> side<span class="o">:</span> <span class="s2">"left"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+sensor<span class="p">.</span>onchange <span class="o">=</span> _ <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>pressure<span class="p">)</span><span class="p">;</span>
 sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 </pre>
    </div>
@@ -1736,13 +1744,13 @@ and defensive programming which includes:</p>
   enhanced by the possible usage of a sensor, not degraded by its
   absence.</p>
    </ol>
-   <div class="example" id="example-a18661d1">
-    <a class="self-link" href="#example-a18661d1"></a> 
+   <div class="example" id="example-051703e2">
+    <a class="self-link" href="#example-051703e2"></a> 
 <pre class="highlight"><span class="k">try</span> <span class="p">{</span> <span class="c1">// No need to feature detect thanks to try..catch block.
-</span>    <span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">(</span><span class="p">{</span><span class="p">}</span><span class="p">)</span><span class="p">;</span>
+</span>    <span class="kd">var</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">(</span><span class="p">)</span><span class="p">;</span>
     sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
-    sensor<span class="p">.</span>onerror <span class="o">=</span> error <span class="o">=</span><span class="o">></span> gracefullyDegrade<span class="p">(</span>error<span class="p">)</span><span class="p">;</span>
-    sensor<span class="p">.</span>onchange <span class="o">=</span> event <span class="o">=</span><span class="o">></span> updatePosition<span class="p">(</span>event<span class="p">.</span>reading<span class="p">.</span>coords<span class="p">)</span><span class="p">;</span>
+    sensor<span class="p">.</span>onerror <span class="o">=</span> error <span class="o">=></span> gracefullyDegrade<span class="p">(</span>error<span class="p">)</span><span class="p">;</span>
+    sensor<span class="p">.</span>onchange <span class="o">=</span> _ <span class="o">=></span> updatePosition<span class="p">(</span>sensor<span class="p">.</span>latitude<span class="p">,</span> sensor<span class="p">.</span>longitude<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span> <span class="k">catch</span><span class="p">(</span>error<span class="p">)</span> <span class="p">{</span>
     gracefullyDegrade<span class="p">(</span>error<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
@@ -1776,7 +1784,7 @@ and allowing the user to disable it.</p>
 perform a privacy impact assessment of their application
 taking all aspects of their application into consideration.</p>
    <p>Ability to detect a full working set of sensors on a device can form an
-identifier and could be used to fingerprinting.</p>
+identifier and could be used for fingerprinting.</p>
    <p>A combination of selected sensors can potentially be used to form an out of
 band communication channel between devices.</p>
    <p>Sensors can potentially be used in cross-device linking and tracking of a user.</p>
@@ -1787,6 +1795,7 @@ sharing the information defined in this specification
 with contexts unfamiliar to the user.
 For example, a mobile device will only fire the event on
 the active tab, and not on the background tabs or within iframes.</p>
+   <p class="note" role="note">Note: <a href="https://docs.google.com/document/d/1k0Ua-ZWlM_PsFCFdLMa8kaVTo32PeNZ4G7FFHqpFx4E/edit">Feature Policy</a> should allow securely lifting those restrictions once it matures.</p>
    <h3 class="heading settled" data-level="5.2" id="secure-context"><span class="secno">5.2. </span><span class="content">Secure Context</span><a class="self-link" href="#secure-context"></a></h3>
    <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-3">Sensor readings</a> are explicitly flagged by the
 Secure Contexts specification <a data-link-type="biblio" href="#biblio-powerful-features">[POWERFUL-FEATURES]</a> as a high-value target for network attackers.
@@ -1800,11 +1809,12 @@ through the Permissions API <a data-link-type="biblio" href="#biblio-permissions
    <h3 class="heading settled" data-level="6.1" id="concepts-sensors"><span class="secno">6.1. </span><span class="content">Sensors</span><a class="self-link" href="#concepts-sensors"></a></h3>
    <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-12">sensor</a> measures different physical quantities
 and provide corresponding <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="raw-sensor-readings">raw sensor readings</dfn> which are a source of information about the user and their environment.</p>
-   <p>Known, <em>predictable</em> discrepancies between <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-1">raw sensor readings</a> and the corresponding physical quantities being measured
+   <p>Each <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-1">reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the different physical quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-13">sensor</a> at time <var>t<sub>n</sub></var>.</p>
+   <p>Known, <em>predictable</em> discrepancies between <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-2">raw sensor readings</a> and the corresponding physical quantities being measured
 are corrected through <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="calibration">calibration</dfn>.</p>
    <p>Known but <em>unpredictable</em> discrepancies need to be addressed dynamically
 through a process called <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-1">sensor fusion</a>.</p>
-   <p><a data-link-type="dfn" href="#calibration" id="ref-for-calibration-1">Calibrated</a> <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-2">raw sensor readings</a> are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-readings">sensor readings</dfn>,
+   <p><a data-link-type="dfn" href="#calibration" id="ref-for-calibration-1">Calibrated</a> <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-3">raw sensor readings</a> are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-readings">sensor readings</dfn>,
 whether or not they have undergone <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-2">sensor fusion</a>.</p>
    <h3 class="heading settled" data-level="6.2" id="concepts-sensor-types"><span class="secno">6.2. </span><span class="content">Sensor Types</span><a class="self-link" href="#concepts-sensor-types"></a></h3>
    <p>Different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-7">sensor types</a> measure different physical quantities
@@ -1813,7 +1823,7 @@ such as temperature, air pressure, heart-rate, or luminosity.</p>
    <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-9">Sensor types</a> which are characterized by their implementation
 are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="low-level">low-level</dfn> sensors.
 For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-3">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-10">sensor type</a>.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-13">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-5">readings</a>,
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-14">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-5">readings</a>,
 regardless of the implementation,
 are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-level">high-level</dfn> sensors.
 For instance, geolocation sensors provide information about the user’s location,
@@ -1858,19 +1868,23 @@ That low-latency is best provided
 by using the raw output of a gyroscope
 and waiting for quick rotational movements of the head
 to compensate for drift.</p>
-   <p class="note" role="note">Note: <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-14">sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-7">sensor fusion</a> are sometimes
+   <p class="note" role="note">Note: <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-15">sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-7">sensor fusion</a> are sometimes
 called virtual or synthetic sensors.
 However, the specification doesn’t make any practical differences between them,
-preferring instead to differentiate <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-15">sensors</a> as to whether they describe
+preferring instead to differentiate <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-16">sensors</a> as to whether they describe
 the kind of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-9">readings</a> produced--these are <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-8">high-level</a> sensors—<wbr>or how the sensor is implemented (<a data-link-type="dfn" href="#low-level" id="ref-for-low-level-8">low-level</a> sensors).</p>
    <h3 class="heading settled" data-level="6.3" id="concepts-reporting-modes"><span class="secno">6.3. </span><span class="content">Reporting Modes</span><a class="self-link" href="#concepts-reporting-modes"></a></h3>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-16">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
+   <p class="issue" id="issue-f240c7ff"><a class="self-link" href="#issue-f240c7ff"></a> <strong>This feature is at risk.</strong> It is not clear whether there is value
+in splitting up <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-15">sensor types</a> between
+those that fire events at regular intervals
+and those which don’t.</p>
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-17">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
 When <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-10">sensor readings</a> are reported at regular intervals,
-at an ajustable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frequency">frequency</dfn> measured in hertz (Hz),
+at an adjustable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frequency">frequency</dfn> measured in hertz (Hz),
 the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-1">reporting mode</a> is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic">periodic</dfn>.
-On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-15">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-1">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-2">periodic reporting mode</a> is triggered
+On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-16">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-1">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-2">periodic reporting mode</a> is triggered
 by requesting a specific <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-1">frequency</a>.</p>
-   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-16">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-3">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
+   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-17">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-3">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
 When the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-2">reporting mode</a> is <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-1">implementation specific</a>, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-11">sensor readings</a> may be provided at regular intervals, irregularly,
 or only when a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-12">reading</a> change is observed.
 This allows user agents more latitude to
@@ -1879,51 +1893,63 @@ and support multiple hardware configurations. <a data-link-type="dfn" href="#per
 allows a much more fine-grained approach
 and is essential for use cases with, for example,
 low latency requirements.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-17">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-5">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-2">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-2">frequency</a> they should operate at.</p>
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-18">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-5">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-2">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-2">frequency</a> they should operate at.</p>
    <p class="note" role="note">Note: <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-3">reporting mode</a> is distinct from,
 but related to, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-13">sensor readings</a> acquisition.
-If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-18">sensors</a> are polled at regular interval,
+If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-19">sensors</a> are polled at regular interval,
 as is generally the case, <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-4">reporting mode</a> can be either <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-6">periodic</a> or <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-3">implementation specific</a>.
 However, when the underlying implementation itself only provides <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-14">sensor readings</a> when it measures change,
 perhaps because is is relying on <a data-link-type="dfn" href="#smart-sensors" id="ref-for-smart-sensors-1">smart sensors</a> or a <a data-link-type="dfn" href="#sensor-hubs" id="ref-for-sensor-hubs-1">sensor hubs</a>,
 the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-5">reporting mode</a> cannot be <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-7">periodic</a>,
 as that would require data inference.</p>
+   <p class="issue" id="issue-ac15beaf"><a class="self-link" href="#issue-ac15beaf"></a> This lacks a description of
+the different data acquisition modes,
+notably polling vs. on change,
+both at the platform and HW layer.</p>
+   <p class="issue" id="issue-ee9f08bc"><a class="self-link" href="#issue-ee9f08bc"></a> It would be useful to describe
+the process of sensor polling and
+how increased sensor polling frequency decreases latency.</p>
+   <p class="issue" id="issue-38946dd2"><a class="self-link" href="#issue-38946dd2"></a> A definition of sensor accuracy and
+how it affects threshold,
+and thus "on change" sensors would be useful.</p>
    <h2 class="heading settled" data-level="7" id="model"><span class="secno">7. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
+   <p class="issue" id="issue-d36d1a2e"><a class="self-link" href="#issue-d36d1a2e"></a> A diagram would really help here.</p>
    <h3 class="heading settled" data-level="7.1" id="model-sensor-type"><span class="secno">7.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has one or many associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-19">sensors</a>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-17">sensor type</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-subclass">Sensor subclass</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-18">sensor type</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensorreading-subclass">SensorReading subclass</dfn>.
-Attributes of the <a data-link-type="dfn" href="#sensorreading-subclass" id="ref-for-sensorreading-subclass-1">SensorReading subclass</a> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-15">sensor readings</a> must be readonly.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-19">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-20">sensor type</a> has an associated set of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="supported-reporting-modes">supported reporting modes</dfn>,
-which cannot be empty and must be picked from the following: <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-4">implementation specific</a> and <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-8">periodic</a>.</p>
-   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-21">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-20">sensor</a>,
-it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-3">Sensor</a></code> objects.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> has an associated abstract operation to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="Construct SensorReading Object" id="construct-sensorreading-object">construct a SensorReading object</dfn> which takes the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-16">sensor readings</a> emitted by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a> and
-returns an initialized <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-1">SensorReading</a></code> object
-which uses the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-23">sensor type</a>'s associated <a data-link-type="dfn" href="#sensorreading-subclass" id="ref-for-sensorreading-subclass-2">SensorReading subclass</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-3">Sensor</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-18">sensor type</a> has one or many associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-20">sensors</a>.</p>
+   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-19">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a>,
+it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> objects.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-20">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
    <h3 class="heading settled" data-level="7.2" id="model-sensor"><span class="secno">7.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated set of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated Sensor objects</dfn>. This set is initially empty.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-reading">current reading</dfn>,
-which can initially be <code>null</code> or
-be set to a <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-2">SensorReading</a></code> object, that was cached in a user-agent-specific way.</p>
-   <p class="note" role="note">Note: there are additional privacy concerns when using cached <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-17">readings</a> which predate either <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigating</a> to resources in the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>,
-or being granted permission to access the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a>.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a> is said to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="supports periodic reporting mode" data-noexport="" id="supports-periodic-reporting-mode">support periodic reporting mode</dfn> if
-its associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-24">sensor type</a>'s <a data-link-type="dfn" href="#supported-reporting-modes" id="ref-for-supported-reporting-modes-1">supported reporting modes</a> contains the <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-9">periodic reporting mode</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated Sensor objects</dfn>.
+This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a>.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-15">sensor readings</a>.</p>
+   <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-1">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "timestamp" and
+whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> is a high resolution timestamp of the time
+at which the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-2">latest reading</a> was obtained
+expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>. <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-3">latest reading</a>["timestamp"] is initially set to <code>null</code>,
+unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-4">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-16">reading</a>.</p>
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-5">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a>.
+The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> must match
+the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> names defined by
+the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-21">sensor type</a>'s associated interface,
+so that the getter of the <code>foo</code> attribute
+can simply return <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-6">latest reading</a>["foo"].</p>
+   <p>The [map/value] of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-7">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> is initially set to <code>null</code>.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="supports-periodic-reporting-mode">supports periodic reporting mode</dfn> if
+its associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> does.</p>
    <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-26">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-flag">reporting flag</dfn> which is initially unset.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-reporting-mode">current reporting mode</dfn> which is initially <code>undefined</code>.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic-reporting-mode-flag">periodic reporting mode flag</dfn> which is initially unset.</p>
    <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-28">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-polling-frequency">current polling frequency</dfn> which is initially <code>null</code>.</p>
    <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-29">sensor</a> has an associated abstract operation to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="retrieve the sensor permission" id="retrieve-the-sensor-permission">retrieve its permission</dfn> which
-takes a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> object as input and
+takes a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensor</a></code> object as input and
 returns a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#idl-def-Permission">permission</a> and, eventually, its <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-associated-permissiondescriptor">associated PermissionDescriptor</a>.</p>
    <h2 class="heading settled" data-level="8" id="api"><span class="secno">8. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="8.1" id="the-sensor-interface"><span class="secno">8.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensor">Sensor</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-sensorstate" id="ref-for-enumdef-sensorstate-1">SensorState</a> <dfn class="nv idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SensorState" id="dom-sensor-state">state<a class="self-link" href="#dom-sensor-state"></a></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#sensorreading" id="ref-for-sensorreading-3">SensorReading</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SensorReading?" id="dom-sensor-reading">reading</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-sensorstate" id="ref-for-enumdef-sensorstate-1">SensorState</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SensorState" id="dom-sensor-state">state</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMHighResTimeStamp" id="dom-sensor-timestamp">timestamp</dfn>;
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="start()" id="dom-sensor-start">start</dfn>();
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="stop()" id="dom-sensor-stop">stop</dfn>();
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onchange">onchange</dfn>;
@@ -1936,106 +1962,143 @@ returns a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#idl-d
 };
 
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-sensorstate">SensorState</dfn> {
-  <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;idle&quot;|idle" id="dom-sensorstate-idle">"idle"</dfn>,
+  <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;unconnected&quot;|unconnected" id="dom-sensorstate-unconnected">"unconnected"</dfn>,
   <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;activating&quot;|activating" id="dom-sensorstate-activating">"activating"</dfn>,
   <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;activated&quot;|activated" id="dom-sensorstate-activated">"activated"</dfn>,
+  <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;idle&quot;|idle" id="dom-sensorstate-idle">"idle"</dfn>,
   <dfn class="s dfn-paneled idl-code" data-dfn-for="SensorState" data-dfn-type="enum-value" data-export="" data-lt="&quot;errored&quot;|errored" id="dom-sensorstate-errored">"errored"</dfn>
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a>.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="state">state</dfn> which is one of <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-1">"idle"</a>, <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-1">"activating"</a>, <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-1">"activated"</a>, and <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-1">"errored"</a>.
-It is initially <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-2">"idle"</a>.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="desired-frequency">desired frequency</dfn>. It is initially <code>null</code>.</p>
-   <p>Each <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> object has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>, initially empty.
-A <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-1">sensor task source</a> can be enabled or disabled, and is initially enabled.
-When enabled, the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> must use it as one of its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.
-The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> mentioned in this specification is the <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-2">sensor task source</a>.</p>
-   <p>When the <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-visibility-states">visibility state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> changes,
-let <var>current_visibility_state</var> be the result of running the <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-steps-to-determine-the-visibility-state">steps to determine the visibility state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a>.
-If <var>current_visibility_state</var> is "visible", enable the sensor task source, otherwise, disable it.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a>.</p>
+   <p>Each <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> object has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>, initially empty.
+A <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-1">sensor task source</a> can be enabled or disabled,
+and is initially enabled.
+When enabled,
+the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> must use it as one of its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.
+The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> mentioned in this specification
+is the <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-2">sensor task source</a>.</p>
+   <p>When the <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-visibility-states">visibility state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a> in
+the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> changes,
+let <var>current_visibility_state</var> be the result of running
+the <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-steps-to-determine-the-visibility-state">steps to determine the visibility state</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a>.
+If <var>current_visibility_state</var> is "visible",
+enable the sensor task source,
+otherwise, disable it.</p>
    <p class="note" role="note">Note: user agents are encouraged to stop sensor polling
 when <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-3">sensor task sources</a> are disabled in order
 to save battery.</p>
-   <h4 class="heading settled" data-level="8.1.1" id="sensor-state"><span class="secno">8.1.1. </span><span class="content">Sensor.state</span><a class="self-link" href="#sensor-state"></a></h4>
-   <p>The <a data-link-type="dfn" href="#state" id="ref-for-state-1">state</a> attribute represents a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object’s <a data-link-type="dfn" href="#state" id="ref-for-state-2">state</a>.</p>
-   <h4 class="heading settled" data-level="8.1.2" id="sensor-reading"><span class="secno">8.1.2. </span><span class="content">Sensor.reading</span><a class="self-link" href="#sensor-reading"></a></h4>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code>'s <a data-link-type="dfn" href="#state" id="ref-for-state-3">state</a> is <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-2">"activated"</a>,
-its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-1">reading</a></code> attribute must always point to the <a data-link-type="dfn" href="#current-reading" id="ref-for-current-reading-1">current reading</a> whatever the <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-3">frequency</a> so that
-the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-2">reading</a></code> attribute of two instances of the same <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> interface
-associated with the same <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a> hold the same <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-4">SensorReading</a></code> during a single <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> turn.</p>
-   <h4 class="heading settled" data-level="8.1.3" id="sensor-start"><span class="secno">8.1.3. </span><span class="content">Sensor.start()</span><a class="self-link" href="#sensor-start"></a></h4>
+   <h4 class="heading settled" data-level="8.1.1" id="sensor-internal-slots"><span class="secno">8.1.1. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> are created
+with the internal slots described in the following table:</p>
+   <table class="vert data" id="sensor-slots">
+    <thead>
+     <tr>
+      <th>Internal Slot
+      <th>Description (non-normative)
+    <tbody>
+     <tr>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="state">[[state]]</dfn>
+      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object which is one of <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-unconnected" id="ref-for-dom-sensorstate-unconnected-1">"unconnected"</a>, <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-1">"activating"</a>, <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-1">"activated"</a>, <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-1">"idle"</a>, and <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-1">"errored"</a>.
+                It is initially <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-unconnected" id="ref-for-dom-sensorstate-unconnected-2">"unconnected"</a>. 
+     <tr>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="desiredpollingfrequency">[[desiredPollingFrequency]]</dfn>
+      <td>The requested polling frequency. It is initially unset.
+     <tr>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="lasteventfiredat">[[lastEventFiredAt]]</dfn>
+      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-17">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code> object,
+                expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>.
+                It is initially <code>null</code>. 
+     <tr>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="waitingforupdate">[[waitingForUpdate]]</dfn>
+      <td>A boolean which indicates wether the observers have been updated
+                or whether the object is waiting for a new reading to do so.
+                It is initially <code>true</code>.
+     <tr>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="identifyingparameters">[[identifyingParameters]]</dfn>
+      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-23">sensor type</a>-epecific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> object. 
+   </table>
+   <h4 class="heading settled" data-level="8.1.2" id="sensor-state"><span class="secno">8.1.2. </span><span class="content">Sensor.state</span><a class="self-link" href="#sensor-state"></a></h4>
+   <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-state" id="ref-for-dom-sensor-state-1">state</a></code> attribute returns <emu-val>this</emu-val>.[[state]].</p>
+   <h4 class="heading settled" data-level="8.1.3" id="sensor-timestamp"><span class="secno">8.1.3. </span><span class="content">Sensor.timestamp</span><a class="self-link" href="#sensor-timestamp"></a></h4>
+   <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-1">timestamp</a></code> attribute returns <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-8">latest reading</a>["timestamp"].</p>
+   <h4 class="heading settled" data-level="8.1.4" id="sensor-start"><span class="secno">8.1.4. </span><span class="content">Sensor.start()</span><a class="self-link" href="#sensor-start"></a></h4>
    <div class="algorithm" data-algorithm="to start a sensor">
      The <code class="idl"><a data-link-type="idl" href="#dom-sensor-start" id="ref-for-dom-sensor-start-1">start()</a></code> method must run these steps or their <a data-link-type="dfn" href="#equivalent" id="ref-for-equivalent-1">equivalent</a>: 
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-4">state</a> is neither <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-3">"idle"</a> nor <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-2">"errored"</a>,</p>
+      <p>Let <var>sensor_state</var> be the value of sensor_instance|.<a data-link-type="dfn" href="#state" id="ref-for-state-1">[[state]]</a>.</p>
+     <li data-md="">
+      <p>If <var>sensor_state</var> is either <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-2">"activating"</a> or <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-2">"activated"</a>,</p>
       <ol>
        <li data-md="">
-        <p>throw an "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception and abort these steps.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
       </ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-5">state</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-2">"activating"</a>.</p>
+      <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-2">[[state]]</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-3">"activating"</a>.</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>permission_state</var> be the result of invoking the <a data-link-type="dfn" href="#request-sensor-access" id="ref-for-request-sensor-access-1">Request Sensor Access</a> abstract operation,
+        <p>If <var>sensor_state</var> is <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-unconnected" id="ref-for-dom-sensorstate-unconnected-3">"unconnected"</a>, then:</p>
+        <ol>
+         <li data-md="">
+          <p>let <var>connected</var> be the result of invoking
+  the <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor-1">Connect to Sensor</a> abstract operation.</p>
+         <li data-md="">
+          <p>If <var>connected</var> is <code>false</code>, then abort these steps.</p>
+        </ol>
+       <li data-md="">
+        <p>Let <var>permission_state</var> be the result of invoking
+  the <a data-link-type="dfn" href="#request-sensor-access" id="ref-for-request-sensor-access-1">Request Sensor Access</a> abstract operation,
   passing it <var>sensor_instance</var> as argument.</p>
        <li data-md="">
         <p>If <var>permission_state</var> is "granted",</p>
         <ol>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#register-a-sensor" id="ref-for-register-a-sensor-1">Register a Sensor</a> passing it <var>sensor_instance</var> as argument.</p>
-         <li data-md="">
-          <p>Abort these sub-steps.</p>
+          <p>Invoke <a data-link-type="dfn" href="#register-a-sensor-object" id="ref-for-register-a-sensor-object-1">Register a Sensor Object</a> passing it <var>sensor_instance</var> as argument.</p>
         </ol>
        <li data-md="">
-        <p>If <var>permission_state</var> is "denied",</p>
+        <p>Otherwise, if <var>permission_state</var> is "denied",</p>
         <ol>
          <li data-md="">
-          <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating an exception</a> named "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a></code>".</p>
+          <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
          <li data-md="">
           <p>Invoke the <a data-link-type="dfn" href="#handle-errors" id="ref-for-handle-errors-1">Handle Errors</a> abstract operation,
   passing it <var>e</var> and <var>sensor_instance</var> as arguments.</p>
-         <li data-md="">
-          <p>Abort these sub-steps.</p>
         </ol>
       </ol>
-     <li data-md="">
-      <p>return <code>undefined</code>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="8.1.4" id="sensor-stop"><span class="secno">8.1.4. </span><span class="content">Sensor.stop()</span><a class="self-link" href="#sensor-stop"></a></h4>
+   <h4 class="heading settled" data-level="8.1.5" id="sensor-stop"><span class="secno">8.1.5. </span><span class="content">Sensor.stop()</span><a class="self-link" href="#sensor-stop"></a></h4>
    <div class="algorithm" data-algorithm="to stop a sensor">
      The <code class="idl"><a data-link-type="idl" href="#dom-sensor-stop" id="ref-for-dom-sensor-stop-1">stop()</a></code> method must run these steps or their <a data-link-type="dfn" href="#equivalent" id="ref-for-equivalent-2">equivalent</a>: 
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-6">state</a> is either <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-4">"idle"</a> or <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-3">"errored"</a>, then</p>
+      <p>If <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-3">[[state]]</a> is neither <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-4">"activating"</a> nor <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-3">"activated"</a>, then</p>
       <ol>
        <li data-md="">
-        <p>throw an "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception and abort these steps.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
       </ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-3">reading</a></code> to <code>null</code>.</p>
-     <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-7">state</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-5">"idle"</a>.</p>
+      <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-4">[[state]]</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-2">"idle"</a>.</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#unregister-a-sensor" id="ref-for-unregister-a-sensor-1">Unregister a Sensor</a> passing it <var>sensor_instance</var> as argument.</p>
       </ol>
-     <li data-md="">
-      <p>return <code>undefined</code>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="8.1.5" id="sensor-onchange"><span class="secno">8.1.5. </span><span class="content">Sensor.onchange</span><a class="self-link" href="#sensor-onchange"></a></h4>
+   <h4 class="heading settled" data-level="8.1.6" id="sensor-onchange"><span class="secno">8.1.6. </span><span class="content">Sensor.onchange</span><a class="self-link" href="#sensor-onchange"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onchange" id="ref-for-dom-sensor-onchange-1">onchange</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called whenever a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-18">reading</a> is available.</p>
-   <h4 class="heading settled" data-level="8.1.6" id="sensor-onactivate"><span class="secno">8.1.6. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate-1">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called when the <a data-link-type="dfn" href="#state" id="ref-for-state-8">state</a> transitions from <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-3">"activating"</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-3">"activated"</a>.</p>
-   <h4 class="heading settled" data-level="8.1.7" id="sensor-onerror"><span class="secno">8.1.7. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
+   <p class="issue" id="issue-482bcf28"><a class="self-link" href="#issue-482bcf28"></a> Should this be renamed <code>onreading</code>?
+Should we instead add an <code>ondata</code> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> for continuous data
+and use <code>onchange</code> when the data changed?</p>
+   <h4 class="heading settled" data-level="8.1.7" id="sensor-onactivate"><span class="secno">8.1.7. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
+   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate-1">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called when <emu-val>this</emu-val>.<a data-link-type="dfn" href="#state" id="ref-for-state-5">[[state]]</a> transitions from <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-5">"activating"</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-4">"activated"</a>.</p>
+   <h4 class="heading settled" data-level="8.1.8" id="sensor-onerror"><span class="secno">8.1.8. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onerror" id="ref-for-dom-sensor-onerror-1">onerror</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called whenever an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type">exception</a> cannot be handled synchronously.</p>
-   <h4 class="heading settled" data-level="8.1.8" id="event-handlers"><span class="secno">8.1.8. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
+   <h4 class="heading settled" data-level="8.1.9" id="event-handlers"><span class="secno">8.1.9. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>)
 that must be supported as attributes by the objects implementing the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-32">Sensor</a> interface:</p>
    <table class="simple">
@@ -2054,17 +2117,7 @@ that must be supported as attributes by the objects implementing the <a data-lin
       <td><strong><code>onerror</code></strong>
       <td><code>error</code>
    </table>
-   <h3 class="heading settled" data-level="8.2" id="the-sensor-reading-interface"><span class="secno">8.2. </span><span class="content">The SensorReading Interface</span><a class="self-link" href="#the-sensor-reading-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensorreading">SensorReading</dfn> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorReading" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMHighResTimeStamp" id="dom-sensorreading-timestamp">timeStamp</dfn>;
-};
-</pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-5">SensorReading</a></code> represents the state of a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a> at a given point in time.</p>
-   <h4 class="heading settled" data-level="8.2.1" id="sensor-reading-timestamp"><span class="secno">8.2.1. </span><span class="content">SensorReading.timeStamp</span><a class="self-link" href="#sensor-reading-timestamp"></a></h4>
-   <p>Returns a high resolution timestamp of the time
-at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-19">reading</a> was obtained from the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a> expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>.</p>
-   <h3 class="heading settled" data-level="8.3" id="the-sensor-error-event-interface"><span class="secno">8.3. </span><span class="content">The SensorErrorEvent Interface</span><a class="self-link" href="#the-sensor-error-event-interface"></a></h3>
+   <h3 class="heading settled" data-level="8.2" id="the-sensor-error-event-interface"><span class="secno">8.2. </span><span class="content">The SensorErrorEvent Interface</span><a class="self-link" href="#the-sensor-error-event-interface"></a></h3>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="constructor" data-export="" data-lt="SensorErrorEvent(type, errorEventInitDict)" id="dom-sensorerrorevent-sensorerrorevent">Constructor<a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type">type<a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-1">SensorErrorEventInit</a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict">errorEventInitDict<a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"></a></dfn>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensorerrorevent">SensorErrorEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Error</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Error" id="dom-sensorerrorevent-error">error</dfn>;
@@ -2074,7 +2127,8 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
   <span class="kt">required</span> <span class="kt">Error</span> <dfn class="nv idl-code" data-dfn-for="SensorErrorEventInit" data-dfn-type="dict-member" data-export="" data-type="Error " id="dom-sensorerroreventinit-error">error<a class="self-link" href="#dom-sensorerroreventinit-error"></a></dfn>;
 };
 </pre>
-   <h4 class="heading settled" data-level="8.3.1" id="sensor-error-event-error"><span class="secno">8.3.1. </span><span class="content">SensorErrorEvent.error</span><a class="self-link" href="#sensor-error-event-error"></a></h4>
+   <h4 class="heading settled" data-level="8.2.1" id="sensor-error-event-error"><span class="secno">8.2.1. </span><span class="content">SensorErrorEvent.error</span><a class="self-link" href="#sensor-error-event-error"></a></h4>
+   <p>Gets the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Error">Error</a></code> object passed to <code class="idl"><a data-link-type="idl" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-2">SensorErrorEventInit</a></code>.</p>
    <h2 class="heading settled" data-level="9" id="abstract-operations"><span class="secno">9. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="9.1" data-lt="Construct Sensor Object" id="construct-sensor-object"><span class="secno">9.1. </span><span class="content">Construct Sensor Object</span><a class="self-link" href="#construct-sensor-object"></a></h3>
    <div class="algorithm" data-algorithm="construct sensor object">
@@ -2093,70 +2147,79 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, then:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a SecurityError.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>, then:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a SecurityError.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, if <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-1">identifying parameters</a> in <var>options</var> are set, then:</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> object,</p>
+     <li data-md="">
+      <p>If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a> <a data-link-type="dfn" href="#supports-periodic-reporting-mode" id="ref-for-supports-periodic-reporting-mode-1">supports periodic reporting mode</a> and <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
-        <p>If these <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-2">identifying parameters</a> allow a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a> to be identified, then:</p>
-        <ol>
-         <li data-md="">
-          <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a>,</p>
-         <li data-md="">
-          <p>let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> object,</p>
-         <li data-md="">
-          <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
-        </ol>
-       <li data-md="">
-        <p>Otherwise, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a TypeError.</p>
+        <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#desiredpollingfrequency" id="ref-for-desiredpollingfrequency-1">[[desiredPollingFrequency]]</a> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-2">frequency</a></code>.</p>
       </ol>
+      <p class="note" role="note">Note: there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-3">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-3">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-2">timestamp</a></code> attributes.</p>
      <li data-md="">
-      <p>Otherwise, if a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a> exists for this <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-25">sensor type</a>:</p>
+      <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-1">identifying parameters</a> in <var>options</var> are set, then:</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a>,</p>
-       <li data-md="">
-        <p>let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> object,</p>
-       <li data-md="">
-        <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
+        <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#identifyingparameters" id="ref-for-identifyingparameters-1">[[identifyingParameters]]</a> to <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-2">identifying parameters</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a TypeError.</p>
+      <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-6">[[state]]</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-unconnected" id="ref-for-dom-sensorstate-unconnected-4">"unconnected"</a>.</p>
      <li data-md="">
-      <p>Let <var>frequency</var> be the value of the <code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> member of <var>options</var>.</p>
-     <li data-md="">
-      <p>If <var>frequency</var> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>,</p>
-      <ol>
-       <li data-md="">
-        <p>If <var>sensor</var> <a data-link-type="dfn" href="#supports-periodic-reporting-mode" id="ref-for-supports-periodic-reporting-mode-1">supports periodic reporting mode</a>,</p>
-        <ol>
-         <li data-md="">
-          <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#desired-frequency" id="ref-for-desired-frequency-1">desired frequency</a> to <var>frequency</var>.</p>
-        </ol>
-       <li data-md="">
-        <p>Otherwise,</p>
-        <ol>
-         <li data-md="">
-          <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a TypeError.</p>
-        </ol>
-      </ol>
-     <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-4">reading</a></code> attribute to <code>null</code>.</p>
-     <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-9">state</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-idle" id="ref-for-dom-sensorstate-idle-6">"idle"</a>.</p>
-     <li data-md="">
-      <p>return <var>sensor_instance</var>.</p>
+      <p>Return <var>sensor_instance</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.2" data-lt="Register a Sensor" data-noexport="" id="register-a-sensor"><span class="secno">9.2. </span><span class="content">Register a Sensor</span></h3>
-   <div class="algorithm" data-algorithm="register a sensor">
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="9.2" data-lt="Connect to Sensor" id="connect-to-sensor"><span class="secno">9.2. </span><span class="content">Connect to Sensor</span></h3>
+   <div class="algorithm" data-algorithm="connect to sensor">
+    <dl>
+     <dt data-md="">
+      <p>input</p>
+     <dd data-md="">
+      <p><var>sensor_instance</var>, a {{Sensor} object.</p>
+     <dt data-md="">
+      <p>output</p>
+     <dd data-md="">
+      <p>a boolean.</p>
+    </dl>
+    <ol>
+     <li data-md="">
+      <p>If <var>sensor_instance</var>.<a data-link-type="dfn" href="#identifyingparameters" id="ref-for-identifyingparameters-2">[[identifyingParameters]]</a> is set and <var>sensor_instance</var>.<a data-link-type="dfn" href="#identifyingparameters" id="ref-for-identifyingparameters-3">[[identifyingParameters]]</a> allows
+  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a> to be identified, then:</p>
+      <ol>
+       <li data-md="">
+        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a>,</p>
+       <li data-md="">
+        <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
+       <li data-md="">
+        <p>Return <code>true</code>.</p>
+      </ol>
+     <li data-md="">
+      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-24">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a> on the device, then</p>
+      <ol>
+       <li data-md="">
+        <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-2">default sensor</a>.</p>
+       <li data-md="">
+        <p>Return <code>true</code>.</p>
+      </ol>
+     <li data-md="">
+      <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating</a> a
+  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+     <li data-md="">
+      <p>Invoke the <a data-link-type="dfn" href="#handle-errors" id="ref-for-handle-errors-2">Handle Errors</a> abstract operation,
+  passing it <var>e</var> and <var>sensor_instance</var> as arguments.</p>
+     <li data-md="">
+      <p>Return <code>false</code>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.3" data-lt="Register a Sensor Object" data-noexport="" id="register-a-sensor-object"><span class="secno">9.3. </span><span class="content">Register a Sensor Object</span></h3>
+   <div class="algorithm" data-algorithm="register a sensor object">
     <dl>
      <dt data-md="">
       <p>input</p>
@@ -2169,23 +2232,15 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>Add <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-1">activated Sensor objects</a>.</p>
      <li data-md="">
       <p>Invoke the <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings-1">Set Sensor Settings</a> abstract operation,
   passing it <var>sensor</var> as argument.</p>
-     <li data-md="">
-      <p>Let <var>current_reading</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="#current-reading" id="ref-for-current-reading-2">current reading</a>.</p>
-     <li data-md="">
-      <p>If <var>current_reading</var> is not <code>null</code> and <var>sensor_instance</var>’s state is still <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-4">"activating"</a>, then</p>
-      <ol>
-       <li data-md="">
-        <p>invoke the <a data-link-type="dfn" href="#update-reading" id="ref-for-update-reading-1">Update Reading</a> operation, passing it <var>sensor_instance</var> and <var>current_reading</var> as arguments.</p>
-      </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.3" data-lt="Unregister a Sensor" data-noexport="" id="unregister-a-sensor"><span class="secno">9.3. </span><span class="content">Unregister a Sensor</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.4" data-lt="Unregister a Sensor" data-noexport="" id="unregister-a-sensor"><span class="secno">9.4. </span><span class="content">Unregister a Sensor</span></h3>
    <div class="algorithm" data-algorithm="unregister a sensor">
     <dl>
      <dt data-md="">
@@ -2199,18 +2254,18 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>Remove <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-2">activated Sensor objects</a>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-3">activated Sensor objects</a> is empty,</p>
       <ol>
        <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#current-reporting-mode" id="ref-for-current-reporting-mode-1">current reporting mode</a> to <code>undefined</code>.</p>
+        <p>Unset the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-1">periodic reporting mode flag</a>.</p>
        <li data-md="">
         <p>Set <a data-link-type="dfn" href="#current-polling-frequency" id="ref-for-current-polling-frequency-1">current polling frequency</a> to <code>null</code>.</p>
        <li data-md="">
-        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-20">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-21">readings</a>.</p>
+        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-19">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-20">readings</a>.</p>
        <li data-md="">
         <p>Abort these steps.</p>
       </ol>
@@ -2219,13 +2274,13 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
   passing it <var>sensor</var> as argument.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.4" data-lt="Set Sensor Settings" data-noexport="" id="set-sensor-settings"><span class="secno">9.4. </span><span class="content">Set Sensor Settings</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.5" data-lt="Set Sensor Settings" data-noexport="" id="set-sensor-settings"><span class="secno">9.5. </span><span class="content">Set Sensor Settings</span></h3>
    <div class="algorithm" data-algorithm="set sensor settings">
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a>.</p>
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
@@ -2235,18 +2290,28 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
      <li data-md="">
       <p>Let <var>settings_changed</var> be <code>false</code>.</p>
      <li data-md="">
-      <p>Let <var>mode</var> be the result of invoking the <a data-link-type="dfn" href="#find-current-reporting-mode-of-a-sensor" id="ref-for-find-current-reporting-mode-of-a-sensor-1">find current reporting mode of a sensor</a> abstract operation,
+      <p>Let <var>is_periodic</var> be the result of invoking
+  the <a data-link-type="dfn" href="#is-current-reporting-mode-periodic" id="ref-for-is-current-reporting-mode-periodic-1">Is Current Reporting Mode Periodic</a> abstract operation,
   with <var>sensor</var> as argument.</p>
      <li data-md="">
-      <p>If <var>mode</var> is different from <var>sensor</var>’s <a data-link-type="dfn" href="#current-reporting-mode" id="ref-for-current-reporting-mode-2">current reporting mode</a>,</p>
+      <p>If <var>is_periodic</var> is <code>false</code> and the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-2">periodic reporting mode flag</a> is set, then</p>
       <ol>
        <li data-md="">
         <p>set <var>settings_changed</var> to <code>true</code>.</p>
        <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#current-reporting-mode" id="ref-for-current-reporting-mode-3">current reporting mode</a> to <var>mode</var>.</p>
+        <p>Unset the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-3">periodic reporting mode flag</a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>frequency</var> be the result of invoking the <a data-link-type="dfn" href="#find-the-polling-frequency-of-a-sensor" id="ref-for-find-the-polling-frequency-of-a-sensor-1">Find the polling frequency of a Sensor</a> abstract operation,
+      <p>Otherwise if <var>is_periodic</var> is <code>true</code> and the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-4">periodic reporting mode flag</a> is unset, then</p>
+      <ol>
+       <li data-md="">
+        <p>set <var>settings_changed</var> to <code>true</code>.</p>
+       <li data-md="">
+        <p>Set the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-5">periodic reporting mode flag</a>.</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>frequency</var> be the result of invoking
+  the <a data-link-type="dfn" href="#find-the-polling-frequency-of-a-sensor" id="ref-for-find-the-polling-frequency-of-a-sensor-1">Find the polling frequency of a Sensor</a> abstract operation,
   with <var>sensor</var> as argument.</p>
      <li data-md="">
       <p>If <var>frequency</var> is different from <var>sensor</var>’s <a data-link-type="dfn" href="#current-polling-frequency" id="ref-for-current-polling-frequency-2">current polling frequency</a>,</p>
@@ -2260,17 +2325,21 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
       <p>If <var>settings_changed</var> is <code>true</code></p>
       <ol>
        <li data-md="">
-        <p>Invoke the <a data-link-type="dfn" href="#observe-a-sensor" id="ref-for-observe-a-sensor-1">Observe a Sensor</a> abstract operation, passing it <var>sensor</var> as argument.</p>
+        <p>Invoke the <a data-link-type="dfn" href="#observe-a-sensor" id="ref-for-observe-a-sensor-1">Observe a Sensor</a> abstract operation,
+  passing it <var>sensor</var> as argument.</p>
       </ol>
     </ol>
+    <p class="issue" id="issue-9a4dcce1"><a class="self-link" href="#issue-9a4dcce1"></a> This abstract operation needs to return <var>settings_changed</var> instead of the <a data-link-type="dfn" href="#observe-a-sensor" id="ref-for-observe-a-sensor-2">Observe a Sensor</a> abstract operation itself.</p>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.5" data-lt="Observe a Sensor" data-noexport="" id="observe-a-sensor"><span class="secno">9.5. </span><span class="content">Observe a Sensor</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.6" data-lt="Observe a Sensor" data-noexport="" id="observe-a-sensor"><span class="secno">9.6. </span><span class="content">Observe a Sensor</span></h3>
    <div class="algorithm" data-algorithm="observe a sensor">
+    <p class="issue" id="issue-43b6e658"><a class="self-link" href="#issue-43b6e658"></a> This needs to be refactored in an abstract operation
+    that has access to the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> instance <var>sensor_instance</var> that just got started.</p>
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a>.</p>
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
@@ -2278,32 +2347,48 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#current-reporting-mode" id="ref-for-current-reporting-mode-4">current reporting mode</a> is <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-10">periodic</a>,</p>
+      <p>If <var>sensor</var>’s <var>latest reading</var>["timestamp"] is not <code>null</code>,
+  invoke the <a data-link-type="dfn" href="#update-observers" id="ref-for-update-observers-1">update observers</a> abstract operation passing it <var>sensor_instance</var> and <var>latest reading</var>["timestamp"] as arguments.</p>
+     <li data-md="">
+      <p>Otherwise, poll <var>sensor</var> immediately.</p>
+      <p class="issue" id="issue-ad0f065d"><a class="self-link" href="#issue-ad0f065d"></a> How do we handle this for <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensors</a> that
+  do not provide values immediately?
+  Fire a dedicated event to signal brokenness?</p>
+     <li data-md="">
+      <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-6">periodic reporting mode flag</a> is set,</p>
       <ol>
        <li data-md="">
         <p>let <var>frequency</var> be the <a data-link-type="dfn" href="#current-polling-frequency" id="ref-for-current-polling-frequency-4">current polling frequency</a>,
   capped by the upper and lower bounds of the underlying hardware.</p>
+        <p class="issue" id="issue-045f373a"><a class="self-link" href="#issue-045f373a"></a> Should this max polling frequency be reflected in the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> interface?
+  E.g. Through a dedicated attribute?</p>
+        <p class="issue" id="issue-b28ffcf7"><a class="self-link" href="#issue-b28ffcf7"></a> Does the max polling frequency affect the reporting frequency?
+  If so, should we advise the developer of this issue?
+  E.g. via a dedicated event?</p>
        <li data-md="">
-        <p>Invoke the <a data-link-type="dfn" href="#update-current-reading" id="ref-for-update-current-reading-1">Update Current Reading</a> abstract operation
-  at a <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-4">frequency</a> of <var>frequency</var> passing it <var>sensor</var> and
-  the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-22">sensor reading</a> as arguments.</p>
-        <p class="note" role="note">Note: there is not guarantee that the <a data-link-type="dfn" href="#current-polling-frequency" id="ref-for-current-polling-frequency-5">current polling frequency</a> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-5">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-6">SensorReading</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorreading-timestamp" id="ref-for-dom-sensorreading-timestamp-1">timeStamp</a></code> attributes.</p>
+        <p>Poll <var>sensor</var> at <var>frequency</var>.</p>
+       <li data-md="">
+        <p class="issue" id="issue-63b367e3"><a class="self-link" href="#issue-63b367e3"></a> Hook into the <code>requestAnimationFrame</code> framework <a data-link-type="biblio" href="#biblio-html">[HTML]</a> to invoke the <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading-1">update latest reading</a> abstract operation
+  with every new frame passing it <var>sensor</var> and
+  the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-21">sensor reading</a> as arguments.</p>
+        <p class="issue" id="issue-c1d5eff3"><a class="self-link" href="#issue-c1d5eff3"></a> Relying on <code>requestAnimationFrame</code> gives us a perfect point
+  to buffer readings > 60Hz and to pass them to together with every new frame.
+  That’s a level 2 feature.</p>
+        <p class="issue" id="issue-2366cb7f"><a class="self-link" href="#issue-2366cb7f"></a> Figure out how to handle sensors/platforms that push the data
+  rather than wait for it to be polled.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#current-reporting-mode" id="ref-for-current-reporting-mode-5">current reporting mode</a> is set to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-5">implementation specific</a>,</p>
+      <p>If the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-7">periodic reporting mode flag</a> is unset,</p>
       <ol>
        <li data-md="">
-        <p>Immediately invoke the <a data-link-type="dfn" href="#update-current-reading" id="ref-for-update-current-reading-2">Update Current Reading</a> abstract operation
-  to report fresh <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-23">readings</a>,
-  passing it <var>sensor</var> and the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-24">sensor reading</a> as arguments.</p>
-       <li data-md="">
         <p>the user-agent can decide on the best reporting strategy
-  for this particular <var>sensor</var> and <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-26">sensor type</a>.</p>
+  for this particular <var>sensor</var> and <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-25">sensor type</a>.</p>
+        <p class="issue" id="issue-9c23a829"><a class="self-link" href="#issue-9c23a829"></a> This needs to be defined better.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.6" data-lt="Find Current Reporting Mode of a Sensor" data-noexport="" id="find-current-reporting-mode-of-a-sensor"><span class="secno">9.6. </span><span class="content">Find Current Reporting Mode of a Sensor</span></h3>
-   <div class="algorithm" data-algorithm="find current reporting mode of a sensor">
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.7" data-lt="Is Current Reporting Mode Periodic" data-noexport="" id="is-current-reporting-mode-periodic"><span class="secno">9.7. </span><span class="content">Is Current Reporting Mode Periodic</span></h3>
+   <div class="algorithm" data-algorithm="is current reporting mode periodic">
     <dl>
      <dt data-md="">
       <p>input</p>
@@ -2312,26 +2397,26 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
-      <p><var>mode</var>, a <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-6">reporting mode</a>.</p>
+      <p><var>result</var>, a boolean.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>let <var>mode</var> be <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-6">implementation specific</a>.</p>
+      <p>Let <var>result</var> be <code>false</code>.</p>
      <li data-md="">
-      <p>For each <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated Sensor objects</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated Sensor objects</a>:</p>
       <ol>
        <li data-md="">
-        <p>if <var>sensor_instance</var>’s <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-6">frequency</a> is not <code>null</code>,</p>
+        <p>if <var>sensor_instance</var>.<a data-link-type="dfn" href="#desiredpollingfrequency" id="ref-for-desiredpollingfrequency-2">[[desiredPollingFrequency]]</a> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>mode</var> to <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-11">periodic</a></p>
+          <p>set <var>result</var> to <code>true</code>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break">break</a>.</p>
         </ol>
       </ol>
      <li data-md="">
-      <p>return <var>mode</var>.</p>
+      <p>return <var>result</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.7" data-lt="Find the polling frequency of a Sensor" data-noexport="" id="find-the-polling-frequency-of-a-sensor"><span class="secno">9.7. </span><span class="content">Find the polling frequency of a Sensor</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.8" data-lt="Find the polling frequency of a Sensor" data-noexport="" id="find-the-polling-frequency-of-a-sensor"><span class="secno">9.8. </span><span class="content">Find the polling frequency of a Sensor</span></h3>
    <div class="algorithm" data-algorithm="find the polling frequency of a sensor">
     <dl>
      <dt data-md="">
@@ -2341,18 +2426,18 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
-      <p><var>frequency</var>, a <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-7">frequency</a>.</p>
+      <p><var>frequency</var>, a <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-4">frequency</a>.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>let <var>frequency</var> be <code>null</code>.</p>
+      <p>Let <var>frequency</var> be <code>null</code>.</p>
      <li data-md="">
-      <p>For each <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated Sensor objects</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated Sensor objects</a>:</p>
       <ol>
        <li data-md="">
-        <p>let <var>f</var> be <var>sensor_instance</var>’s <a data-link-type="dfn" href="#desired-frequency" id="ref-for-desired-frequency-2">desired frequency</a>.</p>
+        <p>let <var>f</var> be <var>sensor_instance</var>.<a data-link-type="dfn" href="#desiredpollingfrequency" id="ref-for-desiredpollingfrequency-3">[[desiredPollingFrequency]]</a>.</p>
        <li data-md="">
-        <p>if <var>f</var> is not <code>null</code> and <var>f</var> is greater than <var>frequency</var>,</p>
+        <p>if <var>f</var> is set and <var>f</var> is greater than <var>frequency</var>,</p>
         <ol>
          <li data-md="">
           <p>set <var>frequency</var> to <var>f</var>.</p>
@@ -2362,15 +2447,21 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
       <p>return <var>frequency</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.8" data-lt="Update Current Reading" data-noexport="" id="update-current-reading"><span class="secno">9.8. </span><span class="content">Update Current Reading</span></h3>
-   <div class="algorithm" data-algorithm="update current reading">
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.9" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">9.9. </span><span class="content">Update latest reading</span></h3>
+   <div class="algorithm" data-algorithm="update latest reading">
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
       <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-44">sensor</a>.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor reading</a>.</p>
+      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-22">sensor reading</a>.</p>
+     <dd data-md="">
+      <p><var>reading_timestamp</var>, the timestamp at which <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-45">sensor</a> was polled.</p>
+    </dl>
+    <p class="issue" id="issue-d62b5d37"><a class="self-link" href="#issue-d62b5d37"></a> The timestamp needs to be specified more precisely,
+    see <a href="https://github.com/w3c/sensors/issues/155">issue #155</a>.</p>
+    <dl>
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
@@ -2384,32 +2475,40 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
         <p>abort these steps.</p>
       </ol>
      <li data-md="">
-      <p>Set <var>sensor</var>’s <a data-link-type="dfn" href="#reporting-flag" id="ref-for-reporting-flag-2">reporting flag</a>.</p>
-     <li data-md="">
-      <p>Let <var>reading_instance</var> be the result of invoking the <a data-link-type="dfn" href="#construct-sensorreading-object" id="ref-for-construct-sensorreading-object-1">Construct SensorReading Object</a> operation
-  associated with <var>sensor</var>’s <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-27">type</a>,
-  passing it <var>reading</var> as argument.</p>
-     <li data-md="">
-      <p>Set <var>sensor</var>’s <a data-link-type="dfn" href="#current-reading" id="ref-for-current-reading-3">current reading</a> to <var>reading_instance</var>.</p>
-     <li data-md="">
-      <p>For each <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-6">activated Sensor objects</a>:</p>
+      <p>If <var>reading_timestamp</var> is equal <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-9">latest reading</a>["timestamp"],</p>
       <ol>
        <li data-md="">
-        <p>Invoke the <a data-link-type="dfn" href="#update-reading" id="ref-for-update-reading-2">update reading</a> algorithm passing <var>sensor_instance</var> and <var>reading_instance</var> as arguments.</p>
+        <p>abort these steps.</p>
       </ol>
+     <li data-md="">
+      <p>Set <var>sensor</var>’s <a data-link-type="dfn" href="#reporting-flag" id="ref-for-reporting-flag-2">reporting flag</a>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-10">latest reading</a>["timestamp"] to <var>reading_timestamp</var>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-11">latest reading</a>.</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>key</var> is "timestamp", <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-12">latest reading</a>[<var>key</var>] to the corresponding
+  value of <var>reading</var>.</p>
+      </ol>
+      <p class="issue" id="issue-0a097748"><a class="self-link" href="#issue-0a097748"></a> Maybe compare <var>value</var> with corresponding
+  value of <var>reading</var> to see if there’s a change
+  that needs to be propagated.</p>
      <li data-md="">
       <p>Unset <var>sensor</var>’s <a data-link-type="dfn" href="#reporting-flag" id="ref-for-reporting-flag-3">reporting flag</a>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.9" data-lt="Update Reading" data-noexport="" id="update-reading"><span class="secno">9.9. </span><span class="content">Update Reading</span></h3>
-   <div class="algorithm" data-algorithm="update reading">
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.10" data-lt="Update Observers" data-noexport="" id="update-observers"><span class="secno">9.10. </span><span class="content">Update Observers</span></h3>
+   <div class="algorithm" data-algorithm="update observers">
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> object.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-7">SensorReading</a></code> object.</p>
+      <p><var>timestamp</var>, a high resolution timestamp.</p>
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
@@ -2417,26 +2516,34 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-5">reading</a></code> to <var>reading</var>.</p>
-     <li data-md="">
-      <p>If <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-10">state</a> is <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-5">"activating"</a>:</p>
+      <p>If <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-7">[[state]]</a> is <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activating" id="ref-for-dom-sensorstate-activating-6">"activating"</a>:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-11">state</a> <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-4">"activated"</a>.</p>
+        <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-8">[[state]]</a> <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-activated" id="ref-for-dom-sensorstate-activated-5">"activated"</a>.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
+      <p>If <var>sensor_instance</var>.<a data-link-type="dfn" href="#waitingforupdate" id="ref-for-waitingforupdate-1">[[waitingForUpdate]]</a> is true, then</p>
+      <p class="issue" id="issue-c26873bf"><a class="self-link" href="#issue-c26873bf"></a> Should we fire delayed readings? Or should we just drop readings instead?</p>
+      <ol>
+       <li data-md="">
+        <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#waitingforupdate" id="ref-for-waitingforupdate-2">[[waitingForUpdate]]</a> to <code>false</code>.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
+       <li data-md="">
+        <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#lasteventfiredat" id="ref-for-lasteventfiredat-1">[[lastEventFiredAt]]</a> to <var>timestamp</var>.</p>
+      </ol>
+      <p class="issue" id="issue-3c3e5a61"><a class="self-link" href="#issue-3c3e5a61"></a> Should these last steps be done from within a new task?</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.10" data-lt="Handle Errors" data-noexport="" id="handle-errors"><span class="secno">9.10. </span><span class="content">Handle Errors</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.11" data-lt="Handle Errors" data-noexport="" id="handle-errors"><span class="secno">9.11. </span><span class="content">Handle Errors</span></h3>
    <div class="algorithm" data-algorithm="handle errors">
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>.</p>
      <dt data-md="">
@@ -2446,20 +2553,18 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-reading" id="ref-for-dom-sensor-reading-6">reading</a></code> to <code>null</code>.</p>
-     <li data-md="">
-      <p>Set <var>sensor_instance</var>’s <a data-link-type="dfn" href="#state" id="ref-for-state-12">state</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-4">"errored"</a>.</p>
+      <p>Set <var>sensor_instance</var>.<a data-link-type="dfn" href="#state" id="ref-for-state-9">[[state]]</a> to <a class="idl-code" data-link-type="enum-value" href="#dom-sensorstate-errored" id="ref-for-dom-sensorstate-errored-2">"errored"</a>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent-1">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error-1">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.11" data-lt="Request Sensor Access" data-noexport="" id="request-sensor-access"><span class="secno">9.11. </span><span class="content">Request Sensor Access</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.12" data-lt="Request Sensor Access" data-noexport="" id="request-sensor-access"><span class="secno">9.12. </span><span class="content">Request Sensor Access</span></h3>
    <div class="algorithm" data-algorithm="request sensor access">
     <dl>
      <dt data-md="">
       <p>input</p>
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> object.</p>
      <dt data-md="">
       <p>output</p>
      <dd data-md="">
@@ -2467,7 +2572,7 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-45">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-46">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>let <var>permission</var> be the result of invoking the abstract operation <a data-link-type="dfn" href="#retrieve-the-sensor-permission" id="ref-for-retrieve-the-sensor-permission-1">retrieve the sensor permission</a> associated with <var>sensor</var>,
   passing it <var>sensor_instance</var> as argument.</p>
@@ -2492,41 +2597,41 @@ at which the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-
         </ol>
       </ol>
      <li data-md="">
-      <p>return <var>state</var>.</p>
+      <p>Return <var>state</var>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="10" id="extensibility"><span class="secno">10. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><em>This section is non-normative.</em></p>
    <p>Its purpose is to describe
 how this specification can be extended to specify APIs for
-different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-28">sensor types</a>.</p>
-   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-29">sensor type</a>,
+different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-26">sensor types</a>.</p>
+   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-27">sensor type</a>,
 exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-9">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-9">low</a> level
 as appropriate.</p>
    <h3 class="heading settled" data-level="10.1" id="security"><span class="secno">10.1. </span><span class="content">Security</span><a class="self-link" href="#security"></a></h3>
    <p>All interfaces defined by extension specifications
 should only be available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <h3 class="heading settled" data-level="10.2" id="naming"><span class="secno">10.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-46">sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-47">sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-47">sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-23">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-48">sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-48">sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-49">sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensorreading" id="ref-for-sensorreading-8">SensorReading</a></code> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">sensor readings</a> values
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-24">Sensor</a></code> subclass that
+hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-23">sensor readings</a> values
 should be named after the full name of these values.
-For example, the <code>TemperatureSensorReading</code> interface should hold
-the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-27">sensor reading</a>'s value in
+For example, the <code>Thermometer</code> interface should hold
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-24">sensor reading</a>'s value in
 a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp</code> attribute).
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="10.3" id="unit"><span class="secno">10.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-28">sensor readings</a>.</p>
-   <p>As per the Technical Architecure Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
+   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor readings</a>.</p>
+   <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
 in order of preference,
@@ -2570,38 +2675,36 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-13">low
     <li data-md="">
      <p>allow multiple sensors of the same type to be instantiated,</p>
     <li data-md="">
-     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code>,</p>
+     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-25">Sensor</a></code>,</p>
     <li data-md="">
      <p>add constructor parameters to tweak sensors settings (e.g. setting required accuracy).</p>
    </ul>
    <h3 class="heading settled" data-level="10.6" id="definition-reqs"><span class="secno">10.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
-   <p>At least the following definitions must be specified in each extension specification:</p>
+   <p>The following definitions must be specified for
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-28">sensor type</a> in extension specifications:</p>
    <ul>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#sensor-subclass" id="ref-for-sensor-subclass-1">Sensor subclass</a> which is constructible and takes
-  an optional <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-2">SensorOptions</a></code> dictionary as argument.</p>
-    <li data-md="">
-     <p>A <a data-link-type="dfn" href="#sensorreading-subclass" id="ref-for-sensorreading-subclass-3">SensorReading subclass</a> which is constructible and
-  whose attributes which hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-29">sensor readings</a> are readonly.</p>
-    <li data-md="">
-     <p>A abstract operation to <a data-link-type="dfn" href="#construct-sensorreading-object" id="ref-for-construct-sensorreading-object-2">construct a SensorReading object</a> which takes the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-30">sensor readings</a> emitted by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-49">sensor</a> and
-  returns an initialized <a data-link-type="dfn" href="#sensorreading-subclass" id="ref-for-sensorreading-subclass-4">SensorReading subclass</a> object.</p>
-    <li data-md="">
-     <p>The <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor type</a>'s <a data-link-type="dfn" href="#supported-reporting-modes" id="ref-for-supported-reporting-modes-2">supported reporting modes</a>.</p>
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-26">Sensor</a></code>.
+  This interface must be constructible.
+  Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor">Constructor</a></code>] must take, as argument,
+  an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-2">SensorOptions</a></code>.
+  Its attributes which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">sensor readings</a> are readonly and
+  have getters must return the  if disturbed, and <code>null</code> otherwise.</p>
     <li data-md="">
      <p>A abstract operation to <a data-link-type="dfn" href="#retrieve-the-sensor-permission" id="ref-for-retrieve-the-sensor-permission-2">retrieve sensor permission</a> which
-  takes a <a data-link-type="dfn" href="#sensor-subclass" id="ref-for-sensor-subclass-2">Sensor subclass</a> object as input and
+  takes an object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-29">sensor type</a>'s associated interface as input and
   returns a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#idl-def-Permission">permission</a> and, eventually, its <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-associated-permissiondescriptor">associated PermissionDescriptor</a>.</p>
    </ul>
-   <p>An extension specification may specify the following defintions:</p>
+   <p>An extension specification may specify the following definitions
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor types</a>:</p>
    <ul>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-3">SensorOptions</a></code> subclass.</p>
+     <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-3">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-2">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-50">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">type</a>,
-  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-3">default sensor</a> should be straightforward.
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-3">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-50">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">type</a>,
+  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-4">default sensor</a> should be straightforward.
   For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-32">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-51">sensors</a> are common,
-  extension specifications may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-4">default sensor</a>,
+  extension specifications may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-5">default sensor</a>,
   especially when doing so would not make sense.</p>
     <li data-md="">
      <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-3">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
@@ -2611,13 +2714,8 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-13">low
    <h3 class="heading settled" data-level="10.8" id="example-webidl"><span class="secno">10.8. </span><span class="content">Example WebIDL</span><a class="self-link" href="#example-webidl"></a></h3>
    <p>Here’s example WebIDL for a possible extension of this specification
 for proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-52">sensors</a>.</p>
-<pre class="example" id="example-86e9d7b6"><a class="self-link" href="#example-86e9d7b6"></a>[SecureContext, Constructor(optional ProximitySensorOptions proximitySensorOptions)]
+<pre class="example" id="example-899e9b74"><a class="self-link" href="#example-899e9b74"></a>[SecureContext, Constructor(optional ProximitySensorOptions proximitySensorOptions)]
 interface ProximitySensor : Sensor {
-  readonly attribute ProximitySensorReading? reading;
-};
-
-[SecureContext]
-interface ProximitySensorReading : SensorReading {
     readonly attribute unrestricted double distance;
 };
 
@@ -2651,7 +2749,7 @@ enum ProximitySensorDirection {
 </pre>
    <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>First and foremost, I would like to thank Anssi Kostiainen
-for his continuous and dedicates support and input throughout
+for his continuous and dedicated support and input throughout
 the development of this specification.</p>
    <p>Special thanks to Rick Waldron for
 driving the discussion around a generic sensor API design for the Web,
@@ -2659,13 +2757,13 @@ sketching the original API on which this is based,
 providing implementation feedback from his work on Johnny-Five,
 and continuous input during the development of this specification.</p>
    <p>Special thanks to Boris Smus, Tim Volodine, and Rich Tibbett
-for their initial work on exposing sensors to the Web with consistency.</p>
+for their initial work on exposing sensors to the web with consistency.</p>
    <p>Thanks to Anne van Kesteren
 for his tireless help both in person and through IRC.</p>
    <p>Thanks to Domenic Denicola and Jake Archibald for their help.</p>
    <p>Thanks also to Frederick Hirsch and Dominique Hazaël-Massieux (via the HTML5Apps project)
 for both their administrative help and technical input.</p>
-   <p>Thanks to Tab Atkins for making Bikeshed and taking the time to explain its subtelties.</p>
+   <p>Thanks to Tab Atkins for making Bikeshed and taking the time to explain its subtleties.</p>
    <p>The following people have greatly contributed to this specification through extensive discussions on GitHub:
 Anssi Kostiainen,
 Boris Smus,
@@ -2878,81 +2976,78 @@ for their editorial input.</p>
    <li><a href="#dom-sensorstate-activating">activating</a><span>, in §8.1</span>
    <li><a href="#calibration">calibration</a><span>, in §6.1</span>
    <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §Unnumbered section</span>
+   <li><a href="#connect-to-sensor">Connect to Sensor</a><span>, in §9.1</span>
    <li><a href="#construct-sensor-object">Construct Sensor Object</a><span>, in §9</span>
-   <li><a href="#construct-sensorreading-object">Construct SensorReading Object</a><span>, in §7.1</span>
    <li><a href="#current-polling-frequency">current polling frequency</a><span>, in §7.2</span>
-   <li><a href="#current-reading">current reading</a><span>, in §7.2</span>
-   <li><a href="#current-reporting-mode">current reporting mode</a><span>, in §7.2</span>
    <li><a href="#default-sensor">default sensor</a><span>, in §7.1</span>
-   <li><a href="#desired-frequency">desired frequency</a><span>, in §8.1</span>
+   <li><a href="#desiredpollingfrequency">[[desiredPollingFrequency]]</a><span>, in §8.1.1</span>
    <li><a href="#equivalent">equivalent</a><span>, in §Unnumbered section</span>
    <li>
     error
     <ul>
-     <li><a href="#dom-sensorerrorevent-error">attribute for SensorErrorEvent</a><span>, in §8.3</span>
-     <li><a href="#dom-sensorerroreventinit-error">dict-member for SensorErrorEventInit</a><span>, in §8.3</span>
+     <li><a href="#dom-sensorerrorevent-error">attribute for SensorErrorEvent</a><span>, in §8.2</span>
+     <li><a href="#dom-sensorerroreventinit-error">dict-member for SensorErrorEventInit</a><span>, in §8.2</span>
     </ul>
-   <li><a href="#dom-sensorstate-errored">"errored"</a><span>, in §8.1</span>
    <li><a href="#dom-sensorstate-errored">errored</a><span>, in §8.1</span>
+   <li><a href="#dom-sensorstate-errored">"errored"</a><span>, in §8.1</span>
    <li><a href="#fallback">fallback</a><span>, in §6.3</span>
-   <li><a href="#find-current-reporting-mode-of-a-sensor">Find Current Reporting Mode of a Sensor</a><span>, in §9.5</span>
-   <li><a href="#find-the-polling-frequency-of-a-sensor">Find the polling frequency of a Sensor</a><span>, in §9.6</span>
+   <li><a href="#find-the-polling-frequency-of-a-sensor">Find the polling frequency of a Sensor</a><span>, in §9.7</span>
    <li>
     frequency
     <ul>
      <li><a href="#frequency">definition of</a><span>, in §6.3</span>
      <li><a href="#dom-sensoroptions-frequency">dict-member for SensorOptions</a><span>, in §8.1</span>
     </ul>
-   <li><a href="#handle-errors">Handle Errors</a><span>, in §9.9</span>
+   <li><a href="#handle-errors">Handle Errors</a><span>, in §9.10</span>
    <li><a href="#high-level">high-level</a><span>, in §6.2</span>
    <li><a href="#identifying-parameters">identifying parameters</a><span>, in §7.1</span>
+   <li><a href="#identifyingparameters">[[identifyingParameters]]</a><span>, in §8.1.1</span>
    <li><a href="#dom-sensorstate-idle">"idle"</a><span>, in §8.1</span>
    <li><a href="#dom-sensorstate-idle">idle</a><span>, in §8.1</span>
    <li><a href="#implementation-specific">implementation specific</a><span>, in §6.3</span>
+   <li><a href="#is-current-reporting-mode-periodic">Is Current Reporting Mode Periodic</a><span>, in §9.6</span>
+   <li><a href="#lasteventfiredat">[[lastEventFiredAt]]</a><span>, in §8.1.1</span>
+   <li><a href="#latest-reading">latest reading</a><span>, in §7.2</span>
    <li><a href="#low-level">low-level</a><span>, in §6.2</span>
-   <li><a href="#observe-a-sensor">Observe a Sensor</a><span>, in §9.4</span>
+   <li><a href="#observe-a-sensor">Observe a Sensor</a><span>, in §9.5</span>
    <li><a href="#dom-sensor-onactivate">onactivate</a><span>, in §8.1</span>
    <li><a href="#dom-sensor-onchange">onchange</a><span>, in §8.1</span>
    <li><a href="#dom-sensor-onerror">onerror</a><span>, in §8.1</span>
    <li><a href="#periodic">periodic</a><span>, in §6.3</span>
+   <li><a href="#periodic-reporting-mode-flag">periodic reporting mode flag</a><span>, in §7.2</span>
    <li><a href="#raw-sensor-readings">raw sensor readings</a><span>, in §6.1</span>
-   <li><a href="#dom-sensor-reading">reading</a><span>, in §8.1</span>
-   <li><a href="#register-a-sensor">Register a Sensor</a><span>, in §9.1</span>
+   <li><a href="#reading-value">reading value</a><span>, in §6.1</span>
+   <li><a href="#register-a-sensor-object">Register a Sensor Object</a><span>, in §9.2</span>
    <li><a href="#reporting-flag">reporting flag</a><span>, in §7.2</span>
    <li><a href="#reporting-modes">reporting modes</a><span>, in §6.3</span>
-   <li><a href="#request-sensor-access">Request Sensor Access</a><span>, in §9.10</span>
+   <li><a href="#request-sensor-access">Request Sensor Access</a><span>, in §9.11</span>
    <li><a href="#retrieve-the-sensor-permission">retrieve the sensor permission</a><span>, in §7.2</span>
    <li><a href="#sensor">Sensor</a><span>, in §8.1</span>
    <li><a href="#concept-sensor">sensor</a><span>, in §7.2</span>
-   <li><a href="#sensorerrorevent">SensorErrorEvent</a><span>, in §8.3</span>
-   <li><a href="#dictdef-sensorerroreventinit">SensorErrorEventInit</a><span>, in §8.3</span>
-   <li><a href="#dom-sensorerrorevent-sensorerrorevent">SensorErrorEvent(type, errorEventInitDict)</a><span>, in §8.3</span>
+   <li><a href="#sensorerrorevent">SensorErrorEvent</a><span>, in §8.2</span>
+   <li><a href="#dictdef-sensorerroreventinit">SensorErrorEventInit</a><span>, in §8.2</span>
+   <li><a href="#dom-sensorerrorevent-sensorerrorevent">SensorErrorEvent(type, errorEventInitDict)</a><span>, in §8.2</span>
    <li><a href="#sensor-fusion">sensor fusion</a><span>, in §6.2</span>
    <li><a href="#sensor-hubs">sensor hubs</a><span>, in §6.2</span>
    <li><a href="#dictdef-sensoroptions">SensorOptions</a><span>, in §8.1</span>
-   <li><a href="#sensorreading">SensorReading</a><span>, in §8.2</span>
    <li><a href="#sensor-readings">sensor readings</a><span>, in §6.1</span>
-   <li><a href="#sensorreading-subclass">SensorReading subclass</a><span>, in §7.1</span>
    <li><a href="#enumdef-sensorstate">SensorState</a><span>, in §8.1</span>
-   <li><a href="#sensor-subclass">Sensor subclass</a><span>, in §7.1</span>
    <li><a href="#sensor-task-source">sensor task source</a><span>, in §8.1</span>
    <li><a href="#sensor-type">sensor type</a><span>, in §7.1</span>
-   <li><a href="#set-sensor-settings">Set Sensor Settings</a><span>, in §9.3</span>
+   <li><a href="#set-sensor-settings">Set Sensor Settings</a><span>, in §9.4</span>
    <li><a href="#smart-sensors">Smart sensors</a><span>, in §6.2</span>
    <li><a href="#dom-sensor-start">start()</a><span>, in §8.1</span>
-   <li>
-    state
-    <ul>
-     <li><a href="#dom-sensor-state">attribute for Sensor</a><span>, in §8.1</span>
-     <li><a href="#state">definition of</a><span>, in §8.1</span>
-    </ul>
+   <li><a href="#dom-sensor-state">state</a><span>, in §8.1</span>
+   <li><a href="#state">[[state]]</a><span>, in §8.1.1</span>
    <li><a href="#dom-sensor-stop">stop()</a><span>, in §8.1</span>
-   <li><a href="#supported-reporting-modes">supported reporting modes</a><span>, in §7.1</span>
    <li><a href="#supports-periodic-reporting-mode">supports periodic reporting mode</a><span>, in §7.2</span>
-   <li><a href="#dom-sensorreading-timestamp">timeStamp</a><span>, in §8.2</span>
-   <li><a href="#unregister-a-sensor">Unregister a Sensor</a><span>, in §9.2</span>
-   <li><a href="#update-current-reading">Update Current Reading</a><span>, in §9.7</span>
-   <li><a href="#update-reading">Update Reading</a><span>, in §9.8</span>
+   <li><a href="#dom-sensor-timestamp">timestamp</a><span>, in §8.1</span>
+   <li><a href="#dom-sensorstate-unconnected">unconnected</a><span>, in §8.1</span>
+   <li><a href="#dom-sensorstate-unconnected">"unconnected"</a><span>, in §8.1</span>
+   <li><a href="#unregister-a-sensor">Unregister a Sensor</a><span>, in §9.3</span>
+   <li><a href="#update-latest-reading">Update latest reading</a><span>, in §9.8</span>
+   <li><a href="#update-observers">Update Observers</a><span>, in §9.9</span>
+   <li><a href="#waitingforupdate">[[waitingForUpdate]]</a><span>, in §8.1.1</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -2981,11 +3076,24 @@ for their editorial input.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigating</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#iteration-break">break</a>
+     <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-entry">entry</a>
+     <li><a href="https://infra.spec.whatwg.org/#list-iterate">for each <small>(for list)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#map-iterate">for each <small>(for map)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-set">set</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
    <li>
     <a data-link-type="biblio">[page-visibility]</a> defines the following terms:
@@ -3009,12 +3117,23 @@ for their editorial input.</p>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#Constructor">Constructor</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-Error">Error</a>
      <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
      <li><a href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a>
+     <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
      <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
+     <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception">exception</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception-type">exception types</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-interface">interface</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
     </ul>
@@ -3025,7 +3144,9 @@ for their editorial input.</p>
    <dt id="biblio-hr-time-2">[HR-TIME-2]
    <dd>Ilya Grigorik; James Simonsen; Jatinder Mann. <a href="https://w3c.github.io/hr-time/">High Resolution Time Level 2</a>. URL: <a href="https://w3c.github.io/hr-time/">https://w3c.github.io/hr-time/</a>
    <dt id="biblio-html">[HTML]
-   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-page-visibility">[PAGE-VISIBILITY]
    <dd>Jatinder Mann; Arvind Jain. <a href="https://www.w3.org/TR/page-visibility/">Page Visibility (Second Edition)</a>. 29 October 2013. REC. URL: <a href="https://www.w3.org/TR/page-visibility/">https://www.w3.org/TR/page-visibility/</a>
    <dt id="biblio-permissions">[PERMISSIONS]
@@ -3046,7 +3167,7 @@ for their editorial input.</p>
    <dt id="biblio-extennnnsible">[EXTENNNNSIBLE]
    <dd><a href="https://extensiblewebmanifesto.org/">The Extensible Web Manifesto</a>. 10 June 2013. URL: <a href="https://extensiblewebmanifesto.org/">https://extensiblewebmanifesto.org/</a>
    <dt id="biblio-geolocation-api">[GEOLOCATION-API]
-   <dd>Andrei Popescu. <a href="http://dev.w3.org/geo/api/spec-source.html">Geolocation API Specification</a>. URL: <a href="http://dev.w3.org/geo/api/spec-source.html">http://dev.w3.org/geo/api/spec-source.html</a>
+   <dd>Andrei Popescu. <a href="http://dev.w3.org/geo/api/spec-source.html">Geolocation API Specification 2nd Edition</a>. URL: <a href="http://dev.w3.org/geo/api/spec-source.html">http://dev.w3.org/geo/api/spec-source.html</a>
    <dt id="biblio-orientation-event">[ORIENTATION-EVENT]
    <dd>Rich Tibbett; et al. <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">DeviceOrientation Event Specification</a>. URL: <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">https://w3c.github.io/deviceorientation/spec-source-orientation.html</a>
    <dt id="biblio-qudt">[QUDT]
@@ -3058,7 +3179,7 @@ for their editorial input.</p>
 <pre class="idl def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#sensor">Sensor</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-sensorstate">SensorState</a> <a class="nv" data-readonly="" data-type="SensorState" href="#dom-sensor-state">state</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#sensorreading">SensorReading</a>? <a class="nv" data-readonly="" data-type="SensorReading?" href="#dom-sensor-reading">reading</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> <a class="nv" data-readonly="" data-type="DOMHighResTimeStamp" href="#dom-sensor-timestamp">timestamp</a>;
   <span class="kt">void</span> <a class="nv" href="#dom-sensor-start">start</a>();
   <span class="kt">void</span> <a class="nv" href="#dom-sensor-stop">stop</a>();
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onchange">onchange</a>;
@@ -3071,15 +3192,11 @@ for their editorial input.</p>
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-sensorstate">SensorState</a> {
-  <a class="s" href="#dom-sensorstate-idle">"idle"</a>,
+  <a class="s" href="#dom-sensorstate-unconnected">"unconnected"</a>,
   <a class="s" href="#dom-sensorstate-activating">"activating"</a>,
   <a class="s" href="#dom-sensorstate-activated">"activated"</a>,
+  <a class="s" href="#dom-sensorstate-idle">"idle"</a>,
   <a class="s" href="#dom-sensorstate-errored">"errored"</a>
-};
-
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <a class="nv" href="#sensorreading">SensorReading</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> <a class="nv" data-readonly="" data-type="DOMHighResTimeStamp" href="#dom-sensorreading-timestamp">timeStamp</a>;
 };
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type">type</a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit">SensorErrorEventInit</a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict">errorEventInitDict</a>)]
@@ -3095,7 +3212,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="raw-sensor-readings">
    <b><a href="#raw-sensor-readings">#raw-sensor-readings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-raw-sensor-readings-1">6.1. Sensors</a> <a href="#ref-for-raw-sensor-readings-2">(2)</a>
+    <li><a href="#ref-for-raw-sensor-readings-1">6.1. Sensors</a> <a href="#ref-for-raw-sensor-readings-2">(2)</a> <a href="#ref-for-raw-sensor-readings-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="calibration">
@@ -3114,16 +3231,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings-4">5.3. Obtaining Explicit User Permission</a>
     <li><a href="#ref-for-sensor-readings-5">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings-6">(2)</a> <a href="#ref-for-sensor-readings-7">(3)</a> <a href="#ref-for-sensor-readings-8">(4)</a> <a href="#ref-for-sensor-readings-9">(5)</a>
     <li><a href="#ref-for-sensor-readings-10">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings-11">(2)</a> <a href="#ref-for-sensor-readings-12">(3)</a> <a href="#ref-for-sensor-readings-13">(4)</a> <a href="#ref-for-sensor-readings-14">(5)</a>
-    <li><a href="#ref-for-sensor-readings-15">7.1. Sensor Type</a> <a href="#ref-for-sensor-readings-16">(2)</a>
-    <li><a href="#ref-for-sensor-readings-17">7.2. Sensor</a>
-    <li><a href="#ref-for-sensor-readings-18">8.1.5. Sensor.onchange</a>
-    <li><a href="#ref-for-sensor-readings-19">8.2.1. SensorReading.timeStamp</a>
-    <li><a href="#ref-for-sensor-readings-20">9.3. Unregister a Sensor</a> <a href="#ref-for-sensor-readings-21">(2)</a>
-    <li><a href="#ref-for-sensor-readings-22">9.5. Observe a Sensor</a> <a href="#ref-for-sensor-readings-23">(2)</a> <a href="#ref-for-sensor-readings-24">(3)</a>
-    <li><a href="#ref-for-sensor-readings-25">9.8. Update Current Reading</a>
-    <li><a href="#ref-for-sensor-readings-26">10.2. Naming</a> <a href="#ref-for-sensor-readings-27">(2)</a>
-    <li><a href="#ref-for-sensor-readings-28">10.3. Unit</a>
-    <li><a href="#ref-for-sensor-readings-29">10.6. Definition Requirements</a> <a href="#ref-for-sensor-readings-30">(2)</a>
+    <li><a href="#ref-for-sensor-readings-15">7.2. Sensor</a> <a href="#ref-for-sensor-readings-16">(2)</a>
+    <li><a href="#ref-for-sensor-readings-17">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-sensor-readings-18">8.1.6. Sensor.onchange</a>
+    <li><a href="#ref-for-sensor-readings-19">9.4. Unregister a Sensor</a> <a href="#ref-for-sensor-readings-20">(2)</a>
+    <li><a href="#ref-for-sensor-readings-21">9.6. Observe a Sensor</a>
+    <li><a href="#ref-for-sensor-readings-22">9.9. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings-23">10.2. Naming</a> <a href="#ref-for-sensor-readings-24">(2)</a>
+    <li><a href="#ref-for-sensor-readings-25">10.3. Unit</a>
+    <li><a href="#ref-for-sensor-readings-26">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
@@ -3169,36 +3285,26 @@ for their editorial input.</p>
    <b><a href="#reporting-modes">#reporting-modes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reporting-modes-1">6.3. Reporting Modes</a> <a href="#ref-for-reporting-modes-2">(2)</a> <a href="#ref-for-reporting-modes-3">(3)</a> <a href="#ref-for-reporting-modes-4">(4)</a> <a href="#ref-for-reporting-modes-5">(5)</a>
-    <li><a href="#ref-for-reporting-modes-6">9.6. Find Current Reporting Mode of a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="frequency">
    <b><a href="#frequency">#frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-1">6.3. Reporting Modes</a> <a href="#ref-for-frequency-2">(2)</a>
-    <li><a href="#ref-for-frequency-3">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-frequency-4">9.5. Observe a Sensor</a> <a href="#ref-for-frequency-5">(2)</a>
-    <li><a href="#ref-for-frequency-6">9.6. Find Current Reporting Mode of a Sensor</a>
-    <li><a href="#ref-for-frequency-7">9.7. Find the polling frequency of a Sensor</a>
+    <li><a href="#ref-for-frequency-3">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-frequency-4">9.8. Find the polling frequency of a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic">
    <b><a href="#periodic">#periodic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-1">6.3. Reporting Modes</a> <a href="#ref-for-periodic-2">(2)</a> <a href="#ref-for-periodic-3">(3)</a> <a href="#ref-for-periodic-4">(4)</a> <a href="#ref-for-periodic-5">(5)</a> <a href="#ref-for-periodic-6">(6)</a> <a href="#ref-for-periodic-7">(7)</a>
-    <li><a href="#ref-for-periodic-8">7.1. Sensor Type</a>
-    <li><a href="#ref-for-periodic-9">7.2. Sensor</a>
-    <li><a href="#ref-for-periodic-10">9.5. Observe a Sensor</a>
-    <li><a href="#ref-for-periodic-11">9.6. Find Current Reporting Mode of a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="implementation-specific">
    <b><a href="#implementation-specific">#implementation-specific</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-specific-1">6.3. Reporting Modes</a> <a href="#ref-for-implementation-specific-2">(2)</a> <a href="#ref-for-implementation-specific-3">(3)</a>
-    <li><a href="#ref-for-implementation-specific-4">7.1. Sensor Type</a>
-    <li><a href="#ref-for-implementation-specific-5">9.5. Observe a Sensor</a>
-    <li><a href="#ref-for-implementation-specific-6">9.6. Find Current Reporting Mode of a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-type">
@@ -3206,42 +3312,15 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-sensor-type-1">3. Background</a> <a href="#ref-for-sensor-type-2">(2)</a> <a href="#ref-for-sensor-type-3">(3)</a> <a href="#ref-for-sensor-type-4">(4)</a> <a href="#ref-for-sensor-type-5">(5)</a> <a href="#ref-for-sensor-type-6">(6)</a>
     <li><a href="#ref-for-sensor-type-7">6.2. Sensor Types</a> <a href="#ref-for-sensor-type-8">(2)</a> <a href="#ref-for-sensor-type-9">(3)</a> <a href="#ref-for-sensor-type-10">(4)</a> <a href="#ref-for-sensor-type-11">(5)</a> <a href="#ref-for-sensor-type-12">(6)</a> <a href="#ref-for-sensor-type-13">(7)</a> <a href="#ref-for-sensor-type-14">(8)</a>
-    <li><a href="#ref-for-sensor-type-15">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type-16">(2)</a>
-    <li><a href="#ref-for-sensor-type-17">7.1. Sensor Type</a> <a href="#ref-for-sensor-type-18">(2)</a> <a href="#ref-for-sensor-type-19">(3)</a> <a href="#ref-for-sensor-type-20">(4)</a> <a href="#ref-for-sensor-type-21">(5)</a> <a href="#ref-for-sensor-type-22">(6)</a> <a href="#ref-for-sensor-type-23">(7)</a>
-    <li><a href="#ref-for-sensor-type-24">7.2. Sensor</a>
-    <li><a href="#ref-for-sensor-type-25">9.1. Construct Sensor Object</a>
-    <li><a href="#ref-for-sensor-type-26">9.5. Observe a Sensor</a>
-    <li><a href="#ref-for-sensor-type-27">9.8. Update Current Reading</a>
-    <li><a href="#ref-for-sensor-type-28">10. Extensibility</a> <a href="#ref-for-sensor-type-29">(2)</a>
-    <li><a href="#ref-for-sensor-type-30">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type-31">(2)</a> <a href="#ref-for-sensor-type-32">(3)</a>
+    <li><a href="#ref-for-sensor-type-15">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type-16">(2)</a> <a href="#ref-for-sensor-type-17">(3)</a>
+    <li><a href="#ref-for-sensor-type-18">7.1. Sensor Type</a> <a href="#ref-for-sensor-type-19">(2)</a> <a href="#ref-for-sensor-type-20">(3)</a>
+    <li><a href="#ref-for-sensor-type-21">7.2. Sensor</a> <a href="#ref-for-sensor-type-22">(2)</a>
+    <li><a href="#ref-for-sensor-type-23">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-sensor-type-24">9.2. Connect to Sensor</a>
+    <li><a href="#ref-for-sensor-type-25">9.6. Observe a Sensor</a>
+    <li><a href="#ref-for-sensor-type-26">10. Extensibility</a> <a href="#ref-for-sensor-type-27">(2)</a>
+    <li><a href="#ref-for-sensor-type-28">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type-29">(2)</a> <a href="#ref-for-sensor-type-30">(3)</a> <a href="#ref-for-sensor-type-31">(4)</a> <a href="#ref-for-sensor-type-32">(5)</a>
     <li><a href="#ref-for-sensor-type-33">10.7. Extending the Permission API</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="sensor-subclass">
-   <b><a href="#sensor-subclass">#sensor-subclass</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sensor-subclass-1">10.6. Definition Requirements</a> <a href="#ref-for-sensor-subclass-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="sensorreading-subclass">
-   <b><a href="#sensorreading-subclass">#sensorreading-subclass</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sensorreading-subclass-1">7.1. Sensor Type</a> <a href="#ref-for-sensorreading-subclass-2">(2)</a>
-    <li><a href="#ref-for-sensorreading-subclass-3">10.6. Definition Requirements</a> <a href="#ref-for-sensorreading-subclass-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="default-sensor">
-   <b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-default-sensor-1">9.1. Construct Sensor Object</a>
-    <li><a href="#ref-for-default-sensor-2">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor-3">(2)</a> <a href="#ref-for-default-sensor-4">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="supported-reporting-modes">
-   <b><a href="#supported-reporting-modes">#supported-reporting-modes</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-supported-reporting-modes-1">7.2. Sensor</a>
-    <li><a href="#ref-for-supported-reporting-modes-2">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="identifying-parameters">
@@ -3251,11 +3330,11 @@ for their editorial input.</p>
     <li><a href="#ref-for-identifying-parameters-3">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-sensorreading-object">
-   <b><a href="#construct-sensorreading-object">#construct-sensorreading-object</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="default-sensor">
+   <b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-construct-sensorreading-object-1">9.8. Update Current Reading</a>
-    <li><a href="#ref-for-construct-sensorreading-object-2">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-default-sensor-1">9.2. Connect to Sensor</a> <a href="#ref-for-default-sensor-2">(2)</a>
+    <li><a href="#ref-for-default-sensor-3">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor-4">(2)</a> <a href="#ref-for-default-sensor-5">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="concept-sensor">
@@ -3263,46 +3342,44 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-concept-sensor-1">3. Background</a> <a href="#ref-for-concept-sensor-2">(2)</a> <a href="#ref-for-concept-sensor-3">(3)</a> <a href="#ref-for-concept-sensor-4">(4)</a> <a href="#ref-for-concept-sensor-5">(5)</a> <a href="#ref-for-concept-sensor-6">(6)</a> <a href="#ref-for-concept-sensor-7">(7)</a> <a href="#ref-for-concept-sensor-8">(8)</a>
     <li><a href="#ref-for-concept-sensor-9">5. Security and privacy considerations</a> <a href="#ref-for-concept-sensor-10">(2)</a> <a href="#ref-for-concept-sensor-11">(3)</a>
-    <li><a href="#ref-for-concept-sensor-12">6.1. Sensors</a>
-    <li><a href="#ref-for-concept-sensor-13">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor-14">(2)</a> <a href="#ref-for-concept-sensor-15">(3)</a>
-    <li><a href="#ref-for-concept-sensor-16">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor-17">(2)</a> <a href="#ref-for-concept-sensor-18">(3)</a>
-    <li><a href="#ref-for-concept-sensor-19">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-20">(2)</a> <a href="#ref-for-concept-sensor-21">(3)</a> <a href="#ref-for-concept-sensor-22">(4)</a>
+    <li><a href="#ref-for-concept-sensor-12">6.1. Sensors</a> <a href="#ref-for-concept-sensor-13">(2)</a>
+    <li><a href="#ref-for-concept-sensor-14">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor-15">(2)</a> <a href="#ref-for-concept-sensor-16">(3)</a>
+    <li><a href="#ref-for-concept-sensor-17">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor-18">(2)</a> <a href="#ref-for-concept-sensor-19">(3)</a>
+    <li><a href="#ref-for-concept-sensor-20">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-21">(2)</a> <a href="#ref-for-concept-sensor-22">(3)</a>
     <li><a href="#ref-for-concept-sensor-23">7.2. Sensor</a> <a href="#ref-for-concept-sensor-24">(2)</a> <a href="#ref-for-concept-sensor-25">(3)</a> <a href="#ref-for-concept-sensor-26">(4)</a> <a href="#ref-for-concept-sensor-27">(5)</a> <a href="#ref-for-concept-sensor-28">(6)</a> <a href="#ref-for-concept-sensor-29">(7)</a>
     <li><a href="#ref-for-concept-sensor-30">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-concept-sensor-31">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-concept-sensor-32">8.1.8. Event handlers</a>
-    <li><a href="#ref-for-concept-sensor-33">8.2. The SensorReading Interface</a>
-    <li><a href="#ref-for-concept-sensor-34">8.2.1. SensorReading.timeStamp</a>
-    <li><a href="#ref-for-concept-sensor-35">9.1. Construct Sensor Object</a> <a href="#ref-for-concept-sensor-36">(2)</a> <a href="#ref-for-concept-sensor-37">(3)</a>
-    <li><a href="#ref-for-concept-sensor-38">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-concept-sensor-39">9.3. Unregister a Sensor</a>
-    <li><a href="#ref-for-concept-sensor-40">9.4. Set Sensor Settings</a>
-    <li><a href="#ref-for-concept-sensor-41">9.5. Observe a Sensor</a>
-    <li><a href="#ref-for-concept-sensor-42">9.6. Find Current Reporting Mode of a Sensor</a>
-    <li><a href="#ref-for-concept-sensor-43">9.7. Find the polling frequency of a Sensor</a>
-    <li><a href="#ref-for-concept-sensor-44">9.8. Update Current Reading</a>
-    <li><a href="#ref-for-concept-sensor-45">9.11. Request Sensor Access</a>
-    <li><a href="#ref-for-concept-sensor-46">10.2. Naming</a> <a href="#ref-for-concept-sensor-47">(2)</a> <a href="#ref-for-concept-sensor-48">(3)</a>
-    <li><a href="#ref-for-concept-sensor-49">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor-50">(2)</a> <a href="#ref-for-concept-sensor-51">(3)</a>
+    <li><a href="#ref-for-concept-sensor-31">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-sensor-32">8.1.9. Event handlers</a>
+    <li><a href="#ref-for-concept-sensor-33">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-concept-sensor-34">9.2. Connect to Sensor</a> <a href="#ref-for-concept-sensor-35">(2)</a> <a href="#ref-for-concept-sensor-36">(3)</a>
+    <li><a href="#ref-for-concept-sensor-37">9.3. Register a Sensor Object</a>
+    <li><a href="#ref-for-concept-sensor-38">9.4. Unregister a Sensor</a>
+    <li><a href="#ref-for-concept-sensor-39">9.5. Set Sensor Settings</a>
+    <li><a href="#ref-for-concept-sensor-40">9.6. Observe a Sensor</a> <a href="#ref-for-concept-sensor-41">(2)</a>
+    <li><a href="#ref-for-concept-sensor-42">9.7. Is Current Reporting Mode Periodic</a>
+    <li><a href="#ref-for-concept-sensor-43">9.8. Find the polling frequency of a Sensor</a>
+    <li><a href="#ref-for-concept-sensor-44">9.9. Update latest reading</a> <a href="#ref-for-concept-sensor-45">(2)</a>
+    <li><a href="#ref-for-concept-sensor-46">9.12. Request Sensor Access</a>
+    <li><a href="#ref-for-concept-sensor-47">10.2. Naming</a> <a href="#ref-for-concept-sensor-48">(2)</a> <a href="#ref-for-concept-sensor-49">(3)</a>
+    <li><a href="#ref-for-concept-sensor-50">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor-51">(2)</a>
     <li><a href="#ref-for-concept-sensor-52">10.8. Example WebIDL</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
    <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activated-sensor-objects-1">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-activated-sensor-objects-2">9.3. Unregister a Sensor</a> <a href="#ref-for-activated-sensor-objects-3">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects-4">9.6. Find Current Reporting Mode of a Sensor</a>
-    <li><a href="#ref-for-activated-sensor-objects-5">9.7. Find the polling frequency of a Sensor</a>
-    <li><a href="#ref-for-activated-sensor-objects-6">9.8. Update Current Reading</a>
+    <li><a href="#ref-for-activated-sensor-objects-1">9.3. Register a Sensor Object</a>
+    <li><a href="#ref-for-activated-sensor-objects-2">9.4. Unregister a Sensor</a> <a href="#ref-for-activated-sensor-objects-3">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects-4">9.7. Is Current Reporting Mode Periodic</a>
+    <li><a href="#ref-for-activated-sensor-objects-5">9.8. Find the polling frequency of a Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-reading">
-   <b><a href="#current-reading">#current-reading</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="latest-reading">
+   <b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-reading-1">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-current-reading-2">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-current-reading-3">9.8. Update Current Reading</a>
+    <li><a href="#ref-for-latest-reading-1">7.2. Sensor</a> <a href="#ref-for-latest-reading-2">(2)</a> <a href="#ref-for-latest-reading-3">(3)</a> <a href="#ref-for-latest-reading-4">(4)</a> <a href="#ref-for-latest-reading-5">(5)</a> <a href="#ref-for-latest-reading-6">(6)</a> <a href="#ref-for-latest-reading-7">(7)</a>
+    <li><a href="#ref-for-latest-reading-8">8.1.3. Sensor.timestamp</a>
+    <li><a href="#ref-for-latest-reading-9">9.9. Update latest reading</a> <a href="#ref-for-latest-reading-10">(2)</a> <a href="#ref-for-latest-reading-11">(3)</a> <a href="#ref-for-latest-reading-12">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="supports-periodic-reporting-mode">
@@ -3314,29 +3391,29 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="reporting-flag">
    <b><a href="#reporting-flag">#reporting-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reporting-flag-1">9.8. Update Current Reading</a> <a href="#ref-for-reporting-flag-2">(2)</a> <a href="#ref-for-reporting-flag-3">(3)</a>
+    <li><a href="#ref-for-reporting-flag-1">9.9. Update latest reading</a> <a href="#ref-for-reporting-flag-2">(2)</a> <a href="#ref-for-reporting-flag-3">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-reporting-mode">
-   <b><a href="#current-reporting-mode">#current-reporting-mode</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-reporting-mode-flag">
+   <b><a href="#periodic-reporting-mode-flag">#periodic-reporting-mode-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-reporting-mode-1">9.3. Unregister a Sensor</a>
-    <li><a href="#ref-for-current-reporting-mode-2">9.4. Set Sensor Settings</a> <a href="#ref-for-current-reporting-mode-3">(2)</a>
-    <li><a href="#ref-for-current-reporting-mode-4">9.5. Observe a Sensor</a> <a href="#ref-for-current-reporting-mode-5">(2)</a>
+    <li><a href="#ref-for-periodic-reporting-mode-flag-1">9.4. Unregister a Sensor</a>
+    <li><a href="#ref-for-periodic-reporting-mode-flag-2">9.5. Set Sensor Settings</a> <a href="#ref-for-periodic-reporting-mode-flag-3">(2)</a> <a href="#ref-for-periodic-reporting-mode-flag-4">(3)</a> <a href="#ref-for-periodic-reporting-mode-flag-5">(4)</a>
+    <li><a href="#ref-for-periodic-reporting-mode-flag-6">9.6. Observe a Sensor</a> <a href="#ref-for-periodic-reporting-mode-flag-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-polling-frequency">
    <b><a href="#current-polling-frequency">#current-polling-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-polling-frequency-1">9.3. Unregister a Sensor</a>
-    <li><a href="#ref-for-current-polling-frequency-2">9.4. Set Sensor Settings</a> <a href="#ref-for-current-polling-frequency-3">(2)</a>
-    <li><a href="#ref-for-current-polling-frequency-4">9.5. Observe a Sensor</a> <a href="#ref-for-current-polling-frequency-5">(2)</a>
+    <li><a href="#ref-for-current-polling-frequency-1">9.4. Unregister a Sensor</a>
+    <li><a href="#ref-for-current-polling-frequency-2">9.5. Set Sensor Settings</a> <a href="#ref-for-current-polling-frequency-3">(2)</a>
+    <li><a href="#ref-for-current-polling-frequency-4">9.6. Observe a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="retrieve-the-sensor-permission">
    <b><a href="#retrieve-the-sensor-permission">#retrieve-the-sensor-permission</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-retrieve-the-sensor-permission-1">9.11. Request Sensor Access</a>
+    <li><a href="#ref-for-retrieve-the-sensor-permission-1">9.12. Request Sensor Access</a>
     <li><a href="#ref-for-retrieve-the-sensor-permission-2">10.6. Definition Requirements</a>
    </ul>
   </aside>
@@ -3345,59 +3422,63 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-sensor-1">3. Background</a>
     <li><a href="#ref-for-sensor-2">4. A note on Feature Detection of Hardware Features</a>
-    <li><a href="#ref-for-sensor-3">7.1. Sensor Type</a>
-    <li><a href="#ref-for-sensor-4">7.2. Sensor</a>
-    <li><a href="#ref-for-sensor-5">8.1. The Sensor Interface</a> <a href="#ref-for-sensor-6">(2)</a> <a href="#ref-for-sensor-7">(3)</a> <a href="#ref-for-sensor-8">(4)</a>
-    <li><a href="#ref-for-sensor-9">8.1.1. Sensor.state</a>
-    <li><a href="#ref-for-sensor-10">8.1.2. Sensor.reading</a> <a href="#ref-for-sensor-11">(2)</a>
+    <li><a href="#ref-for-sensor-3">7.1. Sensor Type</a> <a href="#ref-for-sensor-4">(2)</a>
+    <li><a href="#ref-for-sensor-5">7.2. Sensor</a>
+    <li><a href="#ref-for-sensor-6">8.1. The Sensor Interface</a> <a href="#ref-for-sensor-7">(2)</a>
+    <li><a href="#ref-for-sensor-8">8.1.1. Sensor internal slots</a> <a href="#ref-for-sensor-9">(2)</a> <a href="#ref-for-sensor-10">(3)</a> <a href="#ref-for-sensor-11">(4)</a>
     <li><a href="#ref-for-sensor-12">9.1. Construct Sensor Object</a> <a href="#ref-for-sensor-13">(2)</a> <a href="#ref-for-sensor-14">(3)</a>
-    <li><a href="#ref-for-sensor-15">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-sensor-16">9.3. Unregister a Sensor</a>
-    <li><a href="#ref-for-sensor-17">9.9. Update Reading</a>
-    <li><a href="#ref-for-sensor-18">9.10. Handle Errors</a>
-    <li><a href="#ref-for-sensor-19">9.11. Request Sensor Access</a>
-    <li><a href="#ref-for-sensor-20">10.2. Naming</a> <a href="#ref-for-sensor-21">(2)</a>
-    <li><a href="#ref-for-sensor-22">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor-15">9.3. Register a Sensor Object</a>
+    <li><a href="#ref-for-sensor-16">9.4. Unregister a Sensor</a>
+    <li><a href="#ref-for-sensor-17">9.6. Observe a Sensor</a> <a href="#ref-for-sensor-18">(2)</a>
+    <li><a href="#ref-for-sensor-19">9.10. Update Observers</a>
+    <li><a href="#ref-for-sensor-20">9.11. Handle Errors</a>
+    <li><a href="#ref-for-sensor-21">9.12. Request Sensor Access</a>
+    <li><a href="#ref-for-sensor-22">10.2. Naming</a> <a href="#ref-for-sensor-23">(2)</a> <a href="#ref-for-sensor-24">(3)</a>
+    <li><a href="#ref-for-sensor-25">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor-26">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-reading">
-   <b><a href="#dom-sensor-reading">#dom-sensor-reading</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-sensor-state">
+   <b><a href="#dom-sensor-state">#dom-sensor-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-reading-1">8.1.2. Sensor.reading</a> <a href="#ref-for-dom-sensor-reading-2">(2)</a>
-    <li><a href="#ref-for-dom-sensor-reading-3">8.1.4. Sensor.stop()</a>
-    <li><a href="#ref-for-dom-sensor-reading-4">9.1. Construct Sensor Object</a>
-    <li><a href="#ref-for-dom-sensor-reading-5">9.9. Update Reading</a>
-    <li><a href="#ref-for-dom-sensor-reading-6">9.10. Handle Errors</a>
+    <li><a href="#ref-for-dom-sensor-state-1">8.1.2. Sensor.state</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-sensor-timestamp">
+   <b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-sensor-timestamp-1">8.1.3. Sensor.timestamp</a>
+    <li><a href="#ref-for-dom-sensor-timestamp-2">9.1. Construct Sensor Object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-start">
    <b><a href="#dom-sensor-start">#dom-sensor-start</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-start-1">8.1.3. Sensor.start()</a>
+    <li><a href="#ref-for-dom-sensor-start-1">8.1.4. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-stop">
    <b><a href="#dom-sensor-stop">#dom-sensor-stop</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-stop-1">8.1.4. Sensor.stop()</a>
+    <li><a href="#ref-for-dom-sensor-stop-1">8.1.5. Sensor.stop()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onchange">
    <b><a href="#dom-sensor-onchange">#dom-sensor-onchange</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onchange-1">8.1.5. Sensor.onchange</a>
+    <li><a href="#ref-for-dom-sensor-onchange-1">8.1.6. Sensor.onchange</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onactivate">
    <b><a href="#dom-sensor-onactivate">#dom-sensor-onactivate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onactivate-1">8.1.6. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensor-onactivate-1">8.1.7. Sensor.onactivate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onerror">
    <b><a href="#dom-sensor-onerror">#dom-sensor-onerror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onerror-1">8.1.7. Sensor.onerror</a>
+    <li><a href="#ref-for-dom-sensor-onerror-1">8.1.8. Sensor.onerror</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensoroptions">
@@ -3410,7 +3491,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="dom-sensoroptions-frequency">
    <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensoroptions-frequency-1">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency-1">9.1. Construct Sensor Object</a> <a href="#ref-for-dom-sensoroptions-frequency-2">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-sensorstate">
@@ -3419,61 +3500,46 @@ for their editorial input.</p>
     <li><a href="#ref-for-enumdef-sensorstate-1">8.1. The Sensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensorstate-idle">
-   <b><a href="#dom-sensorstate-idle">#dom-sensorstate-idle</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-sensorstate-unconnected">
+   <b><a href="#dom-sensorstate-unconnected">#dom-sensorstate-unconnected</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorstate-idle-1">8.1. The Sensor Interface</a> <a href="#ref-for-dom-sensorstate-idle-2">(2)</a>
-    <li><a href="#ref-for-dom-sensorstate-idle-3">8.1.3. Sensor.start()</a>
-    <li><a href="#ref-for-dom-sensorstate-idle-4">8.1.4. Sensor.stop()</a> <a href="#ref-for-dom-sensorstate-idle-5">(2)</a>
-    <li><a href="#ref-for-dom-sensorstate-idle-6">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-dom-sensorstate-unconnected-1">8.1.1. Sensor internal slots</a> <a href="#ref-for-dom-sensorstate-unconnected-2">(2)</a>
+    <li><a href="#ref-for-dom-sensorstate-unconnected-3">8.1.4. Sensor.start()</a>
+    <li><a href="#ref-for-dom-sensorstate-unconnected-4">9.1. Construct Sensor Object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorstate-activating">
    <b><a href="#dom-sensorstate-activating">#dom-sensorstate-activating</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorstate-activating-1">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-dom-sensorstate-activating-2">8.1.3. Sensor.start()</a>
-    <li><a href="#ref-for-dom-sensorstate-activating-3">8.1.6. Sensor.onactivate</a>
-    <li><a href="#ref-for-dom-sensorstate-activating-4">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-dom-sensorstate-activating-5">9.9. Update Reading</a>
+    <li><a href="#ref-for-dom-sensorstate-activating-1">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensorstate-activating-2">8.1.4. Sensor.start()</a> <a href="#ref-for-dom-sensorstate-activating-3">(2)</a>
+    <li><a href="#ref-for-dom-sensorstate-activating-4">8.1.5. Sensor.stop()</a>
+    <li><a href="#ref-for-dom-sensorstate-activating-5">8.1.7. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensorstate-activating-6">9.10. Update Observers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorstate-activated">
    <b><a href="#dom-sensorstate-activated">#dom-sensorstate-activated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorstate-activated-1">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-dom-sensorstate-activated-2">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-dom-sensorstate-activated-3">8.1.6. Sensor.onactivate</a>
-    <li><a href="#ref-for-dom-sensorstate-activated-4">9.9. Update Reading</a>
+    <li><a href="#ref-for-dom-sensorstate-activated-1">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensorstate-activated-2">8.1.4. Sensor.start()</a>
+    <li><a href="#ref-for-dom-sensorstate-activated-3">8.1.5. Sensor.stop()</a>
+    <li><a href="#ref-for-dom-sensorstate-activated-4">8.1.7. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensorstate-activated-5">9.10. Update Observers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-sensorstate-idle">
+   <b><a href="#dom-sensorstate-idle">#dom-sensorstate-idle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-sensorstate-idle-1">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensorstate-idle-2">8.1.5. Sensor.stop()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorstate-errored">
    <b><a href="#dom-sensorstate-errored">#dom-sensorstate-errored</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorstate-errored-1">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-dom-sensorstate-errored-2">8.1.3. Sensor.start()</a>
-    <li><a href="#ref-for-dom-sensorstate-errored-3">8.1.4. Sensor.stop()</a>
-    <li><a href="#ref-for-dom-sensorstate-errored-4">9.10. Handle Errors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="state">
-   <b><a href="#state">#state</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-state-1">8.1.1. Sensor.state</a> <a href="#ref-for-state-2">(2)</a>
-    <li><a href="#ref-for-state-3">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-state-4">8.1.3. Sensor.start()</a> <a href="#ref-for-state-5">(2)</a>
-    <li><a href="#ref-for-state-6">8.1.4. Sensor.stop()</a> <a href="#ref-for-state-7">(2)</a>
-    <li><a href="#ref-for-state-8">8.1.6. Sensor.onactivate</a>
-    <li><a href="#ref-for-state-9">9.1. Construct Sensor Object</a>
-    <li><a href="#ref-for-state-10">9.9. Update Reading</a> <a href="#ref-for-state-11">(2)</a>
-    <li><a href="#ref-for-state-12">9.10. Handle Errors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="desired-frequency">
-   <b><a href="#desired-frequency">#desired-frequency</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-desired-frequency-1">9.1. Construct Sensor Object</a>
-    <li><a href="#ref-for-desired-frequency-2">9.7. Find the polling frequency of a Sensor</a>
+    <li><a href="#ref-for-dom-sensorstate-errored-1">8.1.1. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensorstate-errored-2">9.11. Handle Errors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-task-source">
@@ -3482,110 +3548,136 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-task-source-1">8.1. The Sensor Interface</a> <a href="#ref-for-sensor-task-source-2">(2)</a> <a href="#ref-for-sensor-task-source-3">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensorreading">
-   <b><a href="#sensorreading">#sensorreading</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="state">
+   <b><a href="#state">#state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensorreading-1">7.1. Sensor Type</a>
-    <li><a href="#ref-for-sensorreading-2">7.2. Sensor</a>
-    <li><a href="#ref-for-sensorreading-3">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensorreading-4">8.1.2. Sensor.reading</a>
-    <li><a href="#ref-for-sensorreading-5">8.2. The SensorReading Interface</a>
-    <li><a href="#ref-for-sensorreading-6">9.5. Observe a Sensor</a>
-    <li><a href="#ref-for-sensorreading-7">9.9. Update Reading</a>
-    <li><a href="#ref-for-sensorreading-8">10.2. Naming</a>
+    <li><a href="#ref-for-state-1">8.1.4. Sensor.start()</a> <a href="#ref-for-state-2">(2)</a>
+    <li><a href="#ref-for-state-3">8.1.5. Sensor.stop()</a> <a href="#ref-for-state-4">(2)</a>
+    <li><a href="#ref-for-state-5">8.1.7. Sensor.onactivate</a>
+    <li><a href="#ref-for-state-6">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-state-7">9.10. Update Observers</a> <a href="#ref-for-state-8">(2)</a>
+    <li><a href="#ref-for-state-9">9.11. Handle Errors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensorreading-timestamp">
-   <b><a href="#dom-sensorreading-timestamp">#dom-sensorreading-timestamp</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="desiredpollingfrequency">
+   <b><a href="#desiredpollingfrequency">#desiredpollingfrequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorreading-timestamp-1">9.5. Observe a Sensor</a>
+    <li><a href="#ref-for-desiredpollingfrequency-1">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-desiredpollingfrequency-2">9.7. Is Current Reporting Mode Periodic</a>
+    <li><a href="#ref-for-desiredpollingfrequency-3">9.8. Find the polling frequency of a Sensor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="lasteventfiredat">
+   <b><a href="#lasteventfiredat">#lasteventfiredat</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-lasteventfiredat-1">9.10. Update Observers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="waitingforupdate">
+   <b><a href="#waitingforupdate">#waitingforupdate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-waitingforupdate-1">9.10. Update Observers</a> <a href="#ref-for-waitingforupdate-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="identifyingparameters">
+   <b><a href="#identifyingparameters">#identifyingparameters</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-identifyingparameters-1">9.1. Construct Sensor Object</a>
+    <li><a href="#ref-for-identifyingparameters-2">9.2. Connect to Sensor</a> <a href="#ref-for-identifyingparameters-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensorerrorevent">
    <b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensorerrorevent-1">9.10. Handle Errors</a>
+    <li><a href="#ref-for-sensorerrorevent-1">9.11. Handle Errors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorerrorevent-error">
    <b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorerrorevent-error-1">9.10. Handle Errors</a>
+    <li><a href="#ref-for-dom-sensorerrorevent-error-1">9.11. Handle Errors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensorerroreventinit">
    <b><a href="#dictdef-sensorerroreventinit">#dictdef-sensorerroreventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-sensorerroreventinit-1">8.3. The SensorErrorEvent Interface</a>
+    <li><a href="#ref-for-dictdef-sensorerroreventinit-1">8.2. The SensorErrorEvent Interface</a>
+    <li><a href="#ref-for-dictdef-sensorerroreventinit-2">8.2.1. SensorErrorEvent.error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register-a-sensor">
-   <b><a href="#register-a-sensor">#register-a-sensor</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="connect-to-sensor">
+   <b><a href="#connect-to-sensor">#connect-to-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-register-a-sensor-1">8.1.3. Sensor.start()</a>
+    <li><a href="#ref-for-connect-to-sensor-1">8.1.4. Sensor.start()</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="register-a-sensor-object">
+   <b><a href="#register-a-sensor-object">#register-a-sensor-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-register-a-sensor-object-1">8.1.4. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unregister-a-sensor">
    <b><a href="#unregister-a-sensor">#unregister-a-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unregister-a-sensor-1">8.1.4. Sensor.stop()</a>
+    <li><a href="#ref-for-unregister-a-sensor-1">8.1.5. Sensor.stop()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="set-sensor-settings">
    <b><a href="#set-sensor-settings">#set-sensor-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-set-sensor-settings-1">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-set-sensor-settings-2">9.3. Unregister a Sensor</a>
+    <li><a href="#ref-for-set-sensor-settings-1">9.3. Register a Sensor Object</a>
+    <li><a href="#ref-for-set-sensor-settings-2">9.4. Unregister a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="observe-a-sensor">
    <b><a href="#observe-a-sensor">#observe-a-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-observe-a-sensor-1">9.4. Set Sensor Settings</a>
+    <li><a href="#ref-for-observe-a-sensor-1">9.5. Set Sensor Settings</a> <a href="#ref-for-observe-a-sensor-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-current-reporting-mode-of-a-sensor">
-   <b><a href="#find-current-reporting-mode-of-a-sensor">#find-current-reporting-mode-of-a-sensor</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="is-current-reporting-mode-periodic">
+   <b><a href="#is-current-reporting-mode-periodic">#is-current-reporting-mode-periodic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-current-reporting-mode-of-a-sensor-1">9.4. Set Sensor Settings</a>
+    <li><a href="#ref-for-is-current-reporting-mode-periodic-1">9.5. Set Sensor Settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="find-the-polling-frequency-of-a-sensor">
    <b><a href="#find-the-polling-frequency-of-a-sensor">#find-the-polling-frequency-of-a-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-the-polling-frequency-of-a-sensor-1">9.4. Set Sensor Settings</a>
+    <li><a href="#ref-for-find-the-polling-frequency-of-a-sensor-1">9.5. Set Sensor Settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-current-reading">
-   <b><a href="#update-current-reading">#update-current-reading</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="update-latest-reading">
+   <b><a href="#update-latest-reading">#update-latest-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-current-reading-1">9.5. Observe a Sensor</a> <a href="#ref-for-update-current-reading-2">(2)</a>
+    <li><a href="#ref-for-update-latest-reading-1">9.6. Observe a Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-reading">
-   <b><a href="#update-reading">#update-reading</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="update-observers">
+   <b><a href="#update-observers">#update-observers</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-reading-1">9.2. Register a Sensor</a>
-    <li><a href="#ref-for-update-reading-2">9.8. Update Current Reading</a>
+    <li><a href="#ref-for-update-observers-1">9.6. Observe a Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-errors">
    <b><a href="#handle-errors">#handle-errors</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-handle-errors-1">8.1.3. Sensor.start()</a>
+    <li><a href="#ref-for-handle-errors-1">8.1.4. Sensor.start()</a>
+    <li><a href="#ref-for-handle-errors-2">9.2. Connect to Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-sensor-access">
    <b><a href="#request-sensor-access">#request-sensor-access</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-sensor-access-1">8.1.3. Sensor.start()</a>
+    <li><a href="#ref-for-request-sensor-access-1">8.1.4. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="equivalent">
    <b><a href="#equivalent">#equivalent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-equivalent-1">8.1.3. Sensor.start()</a>
-    <li><a href="#ref-for-equivalent-2">8.1.4. Sensor.stop()</a>
+    <li><a href="#ref-for-equivalent-1">8.1.4. Sensor.start()</a>
+    <li><a href="#ref-for-equivalent-2">8.1.5. Sensor.stop()</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This fixes a number of pending issues listed below,
for which there was consensus, but editing was still pending.

This introduces a dependency on the infra standard [[INFRA]],
to define precisely the low-level data structures
used by slots and concepts.

This also specifies slots more clearly.

Additionally, this rewrite sprinkles inline issues
in areas of the specs which require more work.

* Handle GC issues by getting rid of the SensorReading interface. 
  Closes #153. Closes #101.
* Check sensor existence before requesting permission. Closes #145.
* Remove side effects from constructors. Closes #138.
* Move default sensor check to start() and add "unconnected" state.
  Closes #128 and closes #104.
* Throttle update frequency to 60Hz by relying on
  requestAnimationFrame. Closes #100.