### PR TITLE
A Sensor instance sends 'onchange' considering its frequency hint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -757,6 +757,12 @@ with the internal slots described in the following table:
             </td>
         </tr>
         <tr>
+            <td><dfn attribute for=Sensor>\[[lastReading]]</dfn></td>
+            <td>The snapshot of the [=latest reading=] [=ordered map|map=] taken
+                at {{[[lastEventFiredAt]]}}. It is initially `null`.
+            </td>
+        </tr>
+        <tr>
             <td><dfn attribute for=Sensor>\[[waitingForUpdate]]</dfn></td>
             <td>A boolean which indicates wether the observers have been updated
                 or whether the object is waiting for a new reading to do so.
@@ -787,7 +793,7 @@ with the internal slots described in the following table:
 ### Sensor.timestamp ### {#sensor-timestamp}
 
 The getter of the {{Sensor/timestamp!!attribute}} attribute returns
-[=latest reading=]["timestamp"].
+|sensor_instance|.{{[[lastReading]]}}["timestamp"].
 
 ### Sensor.start() ### {#sensor-start}
 
@@ -827,7 +833,8 @@ The {{Sensor/stop()}} method must run these steps or their [=equivalent=]:
 ### Sensor.onchange ### {#sensor-onchange}
 
 {{Sensor/onchange}} is an {{EventHandler}} which is called
-whenever a new [=sensor reading|reading=] is available.
+when a new [=sensor reading|reading=] is available and
+taking into account |sensor_instance|.{{[[desiredPollingFrequency]]}}.
 
 Issue: Should this be renamed `onreading`?
 Should we instead add an `ondata` {{EventHandler}} for continuous data


### PR DESCRIPTION
Fixes #152. Each Sensor instance reads the sensor readings considering its individual
frequency hint, sends 'onchange' and caches the sensor latest reading at this moment.
The Sensor's attributes return values from the cached reading.
Thus we achieve:
1) appearance of a new Sensor instance with a higher frequency hint does not affect the behavior of the existing Sensor instances of the same type.
2) consistency between the Sensor's 'onchange' notification and its attribute values.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/fix_#152.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/2d22842...pozdnyakov:7808b71.html)