### PR TITLE
Sensor objects fire 'change' event considering their own frequency hint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -852,9 +852,9 @@ with the internal slots described in the following table:
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[waitingForUpdate]]</dfn></td>
-            <td>A boolean which indicates wether the observers have been updated
+            <td>A boolean which indicates whether the observers have been updated
                 or whether the object is waiting for a new reading to do so.
-                It is initially true.</td>
+                It is initially `false`.</td>
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[identifyingParameters]]</dfn></td>
@@ -925,8 +925,8 @@ and "timestamp" as arguments.
 
 ### Sensor.onchange ### {#sensor-onchange}
 
-{{Sensor/onchange}} is an {{EventHandler}} which is called
-whenever a new [=sensor reading|reading=] is available.
+{{Sensor/onchange}} is an {{EventHandler}} which is called to notify that new [=sensor reading|reading=] is available.
+
 
 Issue(205):
 
@@ -1267,6 +1267,9 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
         value of |reading| to see if there's a change
         that needs to be propagated.
     1.  Unset |sensor|’s [=reporting flag=].
+    1.  [=set/For each=] |s| of |activated_sensors|,
+        1.  Invoke the [=Report Latest Reading updated=] abstract operation,
+            passing it |s| as argument.
 </div>
 
 
@@ -1325,6 +1328,74 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 Note: user agents are encouraged to stop sensor sampling
 when [=security check=] would return "insecure"
 in order to reduce resource consumption, notably battery usage.
+
+
+<h3 dfn>Find the reporting frequency of a Sensor</h3>
+
+<div algorithm="find the reporting frequency of a sensor">
+
+    : input
+    :: |sensor_instance|, a {{Sensor}} object.
+    : output
+    :: |frequency|, a [=frequency=].
+    1.  Let |frequency| be `null`.
+    1.  Let |f| be |sensor_instance|.{{[[desiredPollingFrequency]]}}.
+        1. if |f| is set,
+            1. set |frequency| to |f| capped by the upper and lower [=current polling frequency=]
+               bounds for the associated [=sensor=].
+        1.  Otherwise,
+            1. user agent can assign |frequency| to an appropriate value.
+    1. return |frequency|.
+</div>
+
+
+<h3 dfn>Report Latest Reading updated</h3>
+
+<div algorithm="report latest reading updated">
+
+    : input
+    :: |sensor_instance|, a {{Sensor}} object.
+    : output
+    :: None
+
+    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is `true`,
+        1. Abort these steps. 
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `true`.
+    1.  Let |lastReportedTimestamp| be the value of |sensor_instance|.{{[[lastEventFiredAt]]}}.
+    1.  If |lastReportedTimestamp| is not set
+        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
+            passing it |sensor_instance| as argument.
+        1.  Abort these steps.
+    1.  Let |reportingFrequency| be result of invoking the [=Find the reporting frequency of a Sensor=]
+        abstract operation.
+    1.  If |reportingFrequency| is `null`
+        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
+            passing it |sensor_instance| as argument.
+        1.  Abort these steps.
+    1.  Let |reportingInterval| be the result of 1 / |reportingFrequency|.
+    1.  Let |timestampDelta| be the result of [=latest reading=]["timestamp"] - |lastReportedTimestamp|.
+    1.  If  |timestampDelta| is greater than or equal to |reportingInterval|
+        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
+            passing it |sensor_instance| as argument.
+        1.  Abort these steps.
+    1.  Let |deferUpdateTime| be the result of |reportingInterval| - |timestampDelta|.
+    1.  User agent must defer queueing a task to run the [=Notify Sensor Object about new reading=] abstract
+        operation for a period of time equal to |deferUpdateTime|.
+</div>
+
+<h3 dfn>Notify Sensor Object about new reading</h3>
+
+<div algorithm="notify sensor object about new reading">
+
+    : input
+    :: |sensor_instance|, a {{Sensor}} object.
+    : output
+    :: None
+
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `false`.
+    1.  Set |sensor_instance|.{{[[lastEventFiredAt]]}} to [=latest reading=]["timestamp"].
+    1.  [=Fire an event=] named "change" at |sensor_instance|.
+</div>
 
 
 <h3 dfn>Handle errors</h3>

--- a/index.bs
+++ b/index.bs
@@ -855,7 +855,7 @@ with the internal slots described in the following table:
             <td><dfn attribute for=Sensor>\[[waitingForUpdate]]</dfn></td>
             <td>A boolean which indicates whether the observers have been updated
                 or whether the object is waiting for a new reading to do so.
-                It is initially `false`.</td>
+                It is initially false.</td>
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[identifyingParameters]]</dfn></td>
@@ -926,7 +926,8 @@ and "timestamp" as arguments.
 
 ### Sensor.onchange ### {#sensor-onchange}
 
-{{Sensor/onchange}} is an {{EventHandler}} which is called to notify that new [=sensor reading|reading=] is available.
+{{Sensor/onchange}} is an {{EventHandler}} which is called
+to notify that new [=sensor reading|reading=] is available.
 
 
 Issue(205):
@@ -1091,7 +1092,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 
     1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
     1.  [=set/Remove=] |sensor_instance| from |sensor|'s set of [=activated sensor objects=].
-    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `false`.
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to false.
     1.  If |sensor|'s set of [=activated sensor objects=] [=set/is empty=],
         1.  Unset the [=periodic reporting mode flag=].
         1.  Set [=current sampling frequency=] to null.
@@ -1270,8 +1271,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
         that needs to be propagated.
     1.  Unset |sensor|’s [=reporting flag=].
     1.  [=set/For each=] |s| in |activated_sensors|,
-        1.  Invoke the [=Report Latest Reading updated=] abstract operation,
-            passing it |s| as an argument.
+        1.  Invoke [=report latest reading updated=] with |s| as an argument.
 </div>
 
 
@@ -1332,18 +1332,18 @@ when [=security check=] would return "insecure"
 in order to reduce resource consumption, notably battery usage.
 
 
-<h3 dfn>Find the reporting frequency of a Sensor</h3>
+<h3 dfn>Find the reporting frequency of a sensor object</h3>
 
-<div algorithm="find the reporting frequency of a sensor">
+<div algorithm="find the reporting frequency of a sensor object">
 
     : input
     :: |sensor_instance|, a {{Sensor}} object.
     : output
-    :: |frequency|, a [=frequency=].
-    1.  Let |frequency| be `null`.
-    1.  Let |f| be |sensor_instance|.{{[[desiredPollingFrequency]]}}.
+    :: A [=frequency=].
+    1.  Let |frequency| be null.
+    1.  Let |f| be |sensor_instance|.{{[[desiredSamplingFrequency]]}}.
         1. if |f| is set,
-            1. set |frequency| to |f| capped by the upper and lower [=current polling frequency=]
+            1. set |frequency| to |f| capped by the upper and lower [=current sampling frequency=]
                bounds for the associated [=sensor=].
         1.  Otherwise,
             1. user agent can assign |frequency| to an appropriate value.
@@ -1351,7 +1351,7 @@ in order to reduce resource consumption, notably battery usage.
 </div>
 
 
-<h3 dfn>Report Latest Reading updated</h3>
+<h3 dfn>Report latest reading updated</h3>
 
 <div algorithm="report latest reading updated">
 
@@ -1360,34 +1360,33 @@ in order to reduce resource consumption, notably battery usage.
     : output
     :: None
 
-    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is `true`,
-        1. Abort these steps. 
-    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `true`.
+    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is true,
+        1. Return.
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to true.
     1.  Let |lastReportedTimestamp| be the value of |sensor_instance|.{{[[lastEventFiredAt]]}}.
     1.  If |lastReportedTimestamp| is not set
-        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as an argument.
-        1.  Abort these steps.
-    1.  Let |reportingFrequency| be result of invoking the [=Find the reporting frequency of a Sensor=]
-        abstract operation.
-    1.  If |reportingFrequency| is `null`
-        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as an argument.
-        1.  Abort these steps.
+        1.  Queue a task to run [=Notify sensor object about new reading=] with |sensor_instance|
+            as an argument.
+        1.  Return.
+    1.  Let |reportingFrequency| be result of invoking [=Find the reporting frequency of a sensor object=].
+    1.  If |reportingFrequency| is null
+        1.  Queue a task to run [=Notify sensor object about new reading=] with |sensor_instance|
+            as an argument.
+        1.  Return.
     1.  Let |reportingInterval| be the result of 1 / |reportingFrequency|.
     1.  Let |timestampDelta| be the result of [=latest reading=]["timestamp"] - |lastReportedTimestamp|.
     1.  If  |timestampDelta| is greater than or equal to |reportingInterval|
-        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as an argument.
-        1.  Abort these steps.
+        1.  Queue a task to run [=Notify sensor object about new reading=] with |sensor_instance|
+            as an argument.
+        1.  Return.
     1.  Let |deferUpdateTime| be the result of |reportingInterval| - |timestampDelta|.
     1.  [=Spin the event loop=] for a period of time equal to |deferUpdateTime|.
-    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is `true`,
-        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as an argument.
+    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is true,
+        1.  Queue a task to run [=Notify sensor object about new reading=] with |sensor_instance|
+            as an argument.
 </div>
 
-<h3 dfn>Notify Sensor Object about new reading</h3>
+<h3 dfn>Notify sensor object about new reading</h3>
 
 <div algorithm="notify sensor object about new reading">
 
@@ -1396,7 +1395,7 @@ in order to reduce resource consumption, notably battery usage.
     : output
     :: None
 
-    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `false`.
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to false.
     1.  Set |sensor_instance|.{{[[lastEventFiredAt]]}} to [=latest reading=]["timestamp"].
     1.  [=Fire an event=] named "change" at |sensor_instance|.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -36,6 +36,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
       text: task; url: concept-task
       text: fire a simple event
       text: trusted; url: concept-events-trusted
+      text: spin the event loop; url: spin-the-event-loop
     urlPrefix: browsers.html
       text: origin; url: origin-2
       text: navigating; url: navigate
@@ -1090,6 +1091,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 
     1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
     1.  [=set/Remove=] |sensor_instance| from |sensor|'s set of [=activated sensor objects=].
+    1.  Set |sensor_instance|.{{[[waitingForUpdate]]}} to `false`.
     1.  If |sensor|'s set of [=activated sensor objects=] [=set/is empty=],
         1.  Unset the [=periodic reporting mode flag=].
         1.  Set [=current sampling frequency=] to null.
@@ -1267,9 +1269,9 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
         value of |reading| to see if there's a change
         that needs to be propagated.
     1.  Unset |sensor|’s [=reporting flag=].
-    1.  [=set/For each=] |s| of |activated_sensors|,
+    1.  [=set/For each=] |s| in |activated_sensors|,
         1.  Invoke the [=Report Latest Reading updated=] abstract operation,
-            passing it |s| as argument.
+            passing it |s| as an argument.
 </div>
 
 
@@ -1364,23 +1366,25 @@ in order to reduce resource consumption, notably battery usage.
     1.  Let |lastReportedTimestamp| be the value of |sensor_instance|.{{[[lastEventFiredAt]]}}.
     1.  If |lastReportedTimestamp| is not set
         1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as argument.
+            passing it |sensor_instance| as an argument.
         1.  Abort these steps.
     1.  Let |reportingFrequency| be result of invoking the [=Find the reporting frequency of a Sensor=]
         abstract operation.
     1.  If |reportingFrequency| is `null`
         1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as argument.
+            passing it |sensor_instance| as an argument.
         1.  Abort these steps.
     1.  Let |reportingInterval| be the result of 1 / |reportingFrequency|.
     1.  Let |timestampDelta| be the result of [=latest reading=]["timestamp"] - |lastReportedTimestamp|.
     1.  If  |timestampDelta| is greater than or equal to |reportingInterval|
         1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
-            passing it |sensor_instance| as argument.
+            passing it |sensor_instance| as an argument.
         1.  Abort these steps.
     1.  Let |deferUpdateTime| be the result of |reportingInterval| - |timestampDelta|.
-    1.  User agent must defer queueing a task to run the [=Notify Sensor Object about new reading=] abstract
-        operation for a period of time equal to |deferUpdateTime|.
+    1.  [=Spin the event loop=] for a period of time equal to |deferUpdateTime|.
+    1.  If |sensor_instance|.{{[[waitingForUpdate]]}} is `true`,
+        1.  Queue a task to run the [=Notify Sensor Object about new reading=] abstract operation,
+            passing it |sensor_instance| as an argument.
 </div>
 
 <h3 dfn>Notify Sensor Object about new reading</h3>


### PR DESCRIPTION
Fixes #152. Each Sensor instance fires 'change' event considering its individual
frequency hint. Thus we achieve that  appearance of a new Sensor instance with a
higher frequency hint does not affect the 'onchange' notification of the existing
Sensor instances of the same type.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/Sensor.reading.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/c478764...pozdnyakov:70e9f8f.html)