### PR TITLE
Update Sensor.timestamp description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -878,7 +878,8 @@ with the internal slots described in the following table:
 ### Sensor.timestamp ### {#sensor-timestamp}
 
 The getter of the {{Sensor/timestamp!!attribute}} attribute returns
-[=latest reading=]["timestamp"].
+the result of invoking [=get value from latest reading=] with <emu-val>this</emu-val>
+and "timestamp" as arguments.
 
 
 ### Sensor.start() ### {#sensor-start}


### PR DESCRIPTION
The timestamp attribute should rely on the [=get value from latest reading=] abstract operation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/timestamp_attribute_uses_operation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/0dcf4a8...pozdnyakov:f49216f.html)