### PR TITLE
Introduce "sensor task source"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -738,6 +738,8 @@ dictionary SensorOptions {
 
 A {{Sensor}} object has an associated [=sensor=].
 
+The [=task source=] for the [=tasks=] mentioned in this specification is the <dfn>sensor task source</dfn>.
+
 ### Sensor lifecycle ### {#sensor-lifecycle}
 
 <style>


### PR DESCRIPTION
Fixes #216

This change introduces a single dedicated task source for Sensor objects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/sensor_task_source.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/79b1b34...pozdnyakov:e998818.html)