### PR TITLE
Add definition for optimal sampling frequency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,7 @@ Indent: 2
 Repository: w3c/sensors
 Markup Shorthands: markdown on
 Boilerplate: omit issues-index, omit conformance, omit feedback-header
+Ignored Vars: activated_sensors
 Inline GitHub Issues: yes
 Default Biblio Status: current
 </pre>
@@ -410,12 +411,12 @@ etc.
 <h4 id="limit-max-freqency" dfn>Limit maximum sampling frequency</h4>
 
 User agents may mitigate certain threats by
-limiting the maximum sampling frequency.
+limiting the maximum [=sampling frequency=].
 What upper limit to choose depends on the [=sensor type=],
 the kind of threats the user agent is trying to protect against,
 the expected resources of the attacker, etc.
 
-Limiting the maximum sampling frequency prevents use cases
+Limiting the maximum [=sampling frequency=] prevents use cases
 which rely on low latency or high data density.
 
 
@@ -434,7 +435,7 @@ An alternative to [=limit maximum sampling frequency|limiting the maximum sampli
 limit the number of [=sensor readings=] delivered to Web application developer,
 regardless of what frequency the sensor is polled at.
 This allows use cases which have low latency requirement
-to increase sampling frequency
+to increase [=sampling frequency=]
 without increasing the amount of data provided.
 
 Discarding intermediary readings prevents certain use cases,
@@ -490,7 +491,6 @@ through a process called [=sensor fusion=].
 
 [=calibration|Calibrated=] [=raw sensor readings=] are referred to as <dfn>sensor readings</dfn>,
 whether or not they have undergone [=sensor fusion=].
-
 
 <h3 id="concepts-sensor-types">Sensor Types</h3>
 
@@ -630,6 +630,10 @@ Issue: A definition of sensor accuracy and
 how it affects threshold,
 and thus "on change" sensors would be useful.
 
+## Sampling Frequency ## {#concepts-sampling-frequency}
+
+For the purpose of this specification, <dfn>sampling frequency</dfn> for a [=sensor=] is defined
+as a frequency at which the UA obtains [=sensor readings=] from the underlying platform.
 
 <h2 id="model">Model</h2>
 
@@ -714,6 +718,16 @@ A [=sensor=] has an associated <dfn>reporting flag</dfn> which is initially unse
 A [=sensor=] has an associated <dfn>periodic reporting mode flag</dfn> which is initially unset.
 
 A [=sensor=] has an associated <dfn>current sampling frequency</dfn> which is initially null.
+
+For a non[=set/is empty|empty=] [=ordered set|set=] of [=activated sensor objects=] the
+[=current sampling frequency=] is equal to <dfn>optimal sampling frequency</dfn>, which is estimated
+by the UA taking into account {{[[desiredSamplingFrequency]]|desired sampling frequencies}} of
+[=activated sensor objects|activated=] {{Sensor|Sensors}} and [=sampling frequency=] bounds defined
+by the underlying platform.
+
+Note: For example, the UA may estimate [=optimal sampling frequency=] as a Least Common Denominator
+(LCD) for a set of {{[[desiredSamplingFrequency]]|desired sampling frequencies}} capped by
+[=sampling frequency=] bounds defined by the underlying platform.
 
 <h2 id="api">API</h2>
 
@@ -841,7 +855,7 @@ with the internal slots described in the following table:
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[desiredSamplingFrequency]]</dfn></td>
-            <td>The requested sampling frequency. It is initially unset.</td>
+            <td>The requested [=sampling frequency=]. It is initially unset.</td>
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[lastEventFiredAt]]</dfn></td>
@@ -1146,11 +1160,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     1.  Otherwise if |is_periodic| is true and the [=periodic reporting mode flag=] is unset, then
         1.  set |settings_changed| to true.
         1.  Set the [=periodic reporting mode flag=].
-    1.  Let |frequency| be the result of invoking [=find the sampling frequency of a sensor=]
-        with |sensor| as argument.
-    1.  If |frequency| is different from |sensor|'s [=current sampling frequency=],
-        1.  set |settings_changed| to true.
-        1.  Set [=current sampling frequency=] to |frequency|.
+    1.  Set [=current sampling frequency=] to [=optimal sampling frequency=].
     1.  Return |settings_changed|.
 </div>
 
@@ -1177,7 +1187,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 
     1.  If |sensor|'s [=periodic reporting mode flag=] is set,
         1.  let |frequency| be the [=current sampling frequency=],
-            capped by the upper and lower bounds of the underlying hardware.
+            capped by the [=sampling frequency=] bounds of the underlying platform.
 
             Issue: Should this max sampling frequency be reflected in the {{Sensor}} interface?
             E.g. Through a dedicated attribute?
@@ -1219,25 +1229,6 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
             1. set |result| to true, then [=break=].
     1. return |result|.
 </div>
-
-
-<h3 dfn>Find the sampling frequency of a sensor</h3>
-
-<div algorithm="find the sampling frequency of a sensor">
-
-    : input
-    :: |sensor|, a [=sensor=].
-    : output
-    :: A [=frequency=].
-
-    1.  Let |frequency| be null.
-    1.  [=set/For each=] |sensor_instance| in |sensor|'s set of [=activated sensor objects=]:
-        1. let |f| be |sensor_instance|.{{[[desiredSamplingFrequency]]}}.
-        1. if |f| is set and |f| is greater than |frequency|,
-            1. set |frequency| to |f|.
-    1. return |frequency|.
-</div>
-
 
 <h3 dfn>Update latest reading</h3>
 

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
+  <meta content="Bikeshed version 78add57678334db281af36bf567919103e7c1e66" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
 <style>
     emu-val {
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-28">28 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1550,6 +1550,7 @@ that can be extended to accommodate different sensor types.</p>
       <li><a href="#concepts-sensors"><span class="secno">6.1</span> <span class="content">Sensors</span></a>
       <li><a href="#concepts-sensor-types"><span class="secno">6.2</span> <span class="content">Sensor Types</span></a>
       <li><a href="#concepts-reporting-modes"><span class="secno">6.3</span> <span class="content">Reporting Modes</span></a>
+      <li><a href="#concepts-sampling-frequency"><span class="secno">6.4</span> <span class="content">Sampling Frequency</span></a>
      </ol>
     <li>
      <a href="#model"><span class="secno">7</span> <span class="content">Model</span></a>
@@ -1591,16 +1592,15 @@ that can be extended to accommodate different sensor types.</p>
       <li><a href="#set-sensor-settings"><span class="secno">9.6</span> <span class="content">Set sensor settings</span></a>
       <li><a href="#observe-a-sensor"><span class="secno">9.7</span> <span class="content">Observe a sensor</span></a>
       <li><a href="#is-current-reporting-mode-periodic"><span class="secno">9.8</span> <span class="content">Is current reporting mode periodic</span></a>
-      <li><a href="#find-the-sampling-frequency-of-a-sensor"><span class="secno">9.9</span> <span class="content">Find the sampling frequency of a sensor</span></a>
-      <li><a href="#update-latest-reading"><span class="secno">9.10</span> <span class="content">Update latest reading</span></a>
-      <li><a href="#update-observers"><span class="secno">9.11</span> <span class="content">Update observers</span></a>
-      <li><a href="#security-check"><span class="secno">9.12</span> <span class="content">Security check</span></a>
-      <li><a href="#find-the-reporting-frequency-of-a-sensor-object"><span class="secno">9.13</span> <span class="content">Find the reporting frequency of a sensor object</span></a>
-      <li><a href="#report-latest-reading-updated"><span class="secno">9.14</span> <span class="content">Report latest reading updated</span></a>
-      <li><a href="#notify-sensor-object-about-new-reading"><span class="secno">9.15</span> <span class="content">Notify sensor object about new reading</span></a>
-      <li><a href="#handle-errors"><span class="secno">9.16</span> <span class="content">Handle errors</span></a>
-      <li><a href="#get-value-from-latest-reading"><span class="secno">9.17</span> <span class="content">Get value from latest reading</span></a>
-      <li><a href="#request-sensor-access"><span class="secno">9.18</span> <span class="content">Request sensor access</span></a>
+      <li><a href="#update-latest-reading"><span class="secno">9.9</span> <span class="content">Update latest reading</span></a>
+      <li><a href="#update-observers"><span class="secno">9.10</span> <span class="content">Update observers</span></a>
+      <li><a href="#security-check"><span class="secno">9.11</span> <span class="content">Security check</span></a>
+      <li><a href="#find-the-reporting-frequency-of-a-sensor-object"><span class="secno">9.12</span> <span class="content">Find the reporting frequency of a sensor object</span></a>
+      <li><a href="#report-latest-reading-updated"><span class="secno">9.13</span> <span class="content">Report latest reading updated</span></a>
+      <li><a href="#notify-sensor-object-about-new-reading"><span class="secno">9.14</span> <span class="content">Notify sensor object about new reading</span></a>
+      <li><a href="#handle-errors"><span class="secno">9.15</span> <span class="content">Handle errors</span></a>
+      <li><a href="#get-value-from-latest-reading"><span class="secno">9.16</span> <span class="content">Get value from latest reading</span></a>
+      <li><a href="#request-sensor-access"><span class="secno">9.17</span> <span class="content">Request sensor access</span></a>
      </ol>
     <li>
      <a href="#extensibility"><span class="secno">10</span> <span class="content">Extensibility</span></a>
@@ -1887,11 +1887,11 @@ when other APIs which are known to amplify the level of the threat are in use,
 etc.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="5.2.1" data-lt="Limit maximum sampling frequency" data-noexport="" id="limit-max-freqency"><span class="secno">5.2.1. </span><span class="content">Limit maximum sampling frequency</span></h4>
    <p>User agents may mitigate certain threats by
-limiting the maximum sampling frequency.
+limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-1">sampling frequency</a>.
 What upper limit to choose depends on the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-9">sensor type</a>,
 the kind of threats the user agent is trying to protect against,
 the expected resources of the attacker, etc.</p>
-   <p>Limiting the maximum sampling frequency prevents use cases
+   <p>Limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-2">sampling frequency</a> prevents use cases
 which rely on low latency or high data density.</p>
    <h4 class="heading settled" data-dfn-type="dfn" data-level="5.2.2" data-lt="Stopping the sensor altogether" data-noexport="" id="stopping-sensor"><span class="secno">5.2.2. </span><span class="content">Stopping the sensor altogether</span><a class="self-link" href="#stopping-sensor"></a></h4>
    <p>This is obviously a last-resort solution,
@@ -1904,8 +1904,7 @@ or in a different application.</p>
 limit the number of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-11">sensor readings</a> delivered to Web application developer,
 regardless of what frequency the sensor is polled at.
 This allows use cases which have low latency requirement
-to increase sampling frequency
-without increasing the amount of data provided.</p>
+to increase <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-3">sampling frequency</a> without increasing the amount of data provided.</p>
    <p>Discarding intermediary readings prevents certain use cases,
 such as those relying on certain kinds of filters.</p>
    <h4 class="heading settled" data-dfn-type="dfn" data-level="5.2.4" data-lt="Reducing accuracy" data-noexport="" id="reducing-accuracy"><span class="secno">5.2.4. </span><span class="content">Reducing accuracy</span><a class="self-link" href="#reducing-accuracy"></a></h4>
@@ -2031,13 +2030,16 @@ how increased sensor sampling frequency decreases latency.</p>
    <p class="issue" id="issue-38946dd2"><a class="self-link" href="#issue-38946dd2"></a> A definition of sensor accuracy and
 how it affects threshold,
 and thus "on change" sensors would be useful.</p>
+   <h3 class="heading settled" data-level="6.4" id="concepts-sampling-frequency"><span class="secno">6.4. </span><span class="content">Sampling Frequency</span><a class="self-link" href="#concepts-sampling-frequency"></a></h3>
+   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a> is defined
+as a frequency at which the UA obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor readings</a> from the underlying platform.</p>
    <h2 class="heading settled" data-level="7" id="model"><span class="secno">7. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p class="issue" id="issue-d36d1a2e"><a class="self-link" href="#issue-d36d1a2e"></a> A diagram would really help here.</p>
    <h3 class="heading settled" data-level="7.1" id="model-sensor-type"><span class="secno">7.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-3">Sensor</a></code>.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-21">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
-   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a>,
-it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> objects.</p>
+   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a>,
+it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> objects.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-23">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-24">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
    <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-25">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
@@ -2060,15 +2062,15 @@ it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" da
    <h3 class="heading settled" data-level="7.2" id="model-sensor"><span class="secno">7.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
 This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a>.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor readings</a>.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">sensor readings</a>.</p>
    <p class="issue" id="issue-504d2531"><a class="self-link" href="#issue-504d2531"></a> does the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-1">latest reading</a> map need to be
 tied to an origin?</p>
    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-2">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "timestamp" and
 whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> is a high resolution timestamp of the time
 at which the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-3">latest reading</a> was obtained
 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>. <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-4">latest reading</a>["timestamp"] is initially set to null,
-unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-5">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">reading</a>.</p>
-   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-6">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a>.
+unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-5">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-27">reading</a>.</p>
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-6">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a>.
 The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> must match
 the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> defined by
 the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-27">sensor type</a>'s associated interface.
@@ -2076,11 +2078,16 @@ The return value of the <a data-link-type="dfn" href="https://heycam.github.io/w
 easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-1">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-28">sensor type</a>'s associated interface
 and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-7">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> is initially set to null.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="supports-periodic-reporting-mode">supports periodic reporting mode</dfn> if
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-26">sensor</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="supports-periodic-reporting-mode">supports periodic reporting mode</dfn> if
 its associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-29">sensor type</a> does.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-26">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-flag">reporting flag</dfn> which is initially unset.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic-reporting-mode-flag">periodic reporting mode flag</dfn> which is initially unset.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-28">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-flag">reporting flag</dfn> which is initially unset.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-28">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic-reporting-mode-flag">periodic reporting mode flag</dfn> which is initially unset.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-29">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
+   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-1">activated sensor objects</a> the <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-1">current sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
+by the UA taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-1">desired sampling frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-2">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-4">sampling frequency</a> bounds defined
+by the underlying platform.</p>
+   <p class="note" role="note"><span>Note:</span> For example, the UA may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency-1">optimal sampling frequency</a> as a Least Common Denominator
+(LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-2">desired sampling frequencies</a></code> capped by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-5">sampling frequency</a> bounds defined by the underlying platform.</p>
    <h2 class="heading settled" data-level="8" id="api"><span class="secno">8. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="8.1" id="the-sensor-interface"><span class="secno">8.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
@@ -2098,7 +2105,7 @@ its associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-ty
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-29">sensor</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a>.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> mentioned in this specification is the <dfn data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source<a class="self-link" href="#sensor-task-source"></a></dfn>.</p>
    <h4 class="heading settled" data-level="8.1.1" id="sensor-lifecycle"><span class="secno">8.1.1. </span><span class="content">Sensor lifecycle</span><a class="self-link" href="#sensor-lifecycle"></a></h4>
    <svg height="79pt" viewBox="0.00 0.00 351.00 78.51" width="351pt" xmlns="http://www.w3.org/2000/svg">
@@ -2172,7 +2179,7 @@ its associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-ty
     </g>
    </svg>
    <h4 class="heading settled" data-level="8.1.2" id="sensor-internal-slots"><span class="secno">8.1.2. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
-   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> are created
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
    <table class="vert data" id="sensor-slots">
     <thead>
@@ -2182,17 +2189,17 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> object which is one of
+      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
                 It is initially "idle". 
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-desiredsamplingfrequency-slot"><code>[[desiredSamplingFrequency]]</code></dfn>
-      <td>The requested sampling frequency. It is initially unset.
+      <td>The requested <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-6">sampling frequency</a>. It is initially unset.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-27">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> object,
+      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-28">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>.
                 It is initially null. 
      <tr>
@@ -2202,7 +2209,7 @@ with the internal slots described in the following table:</p>
                 It is initially false.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-identifyingparameters-slot"><code>[[identifyingParameters]]</code></dfn>
-      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object. 
+      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code> object. 
    </table>
    <h4 class="heading settled" data-level="8.1.3" id="sensor-activated"><span class="secno">8.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
@@ -2273,7 +2280,7 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
    </div>
    <h4 class="heading settled" data-level="8.1.7" id="sensor-onchange"><span class="secno">8.1.7. </span><span class="content">Sensor.onchange</span><a class="self-link" href="#sensor-onchange"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onchange" id="ref-for-dom-sensor-onchange-1">onchange</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called
-to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-28">reading</a> is available.</p>
+to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-29">reading</a> is available.</p>
    <div class="issue no-marker" id="issue-d41d8cd9">
     <a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/w3c/sensors/issues/205">Issue #205 on GitHub: “Agree on event names”</a>
     <p>Right now, no one's happy with <code>onchange</code>.</p>
@@ -2288,7 +2295,7 @@ to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-s
 an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type">exception</a> cannot be handled synchronously.</p>
    <h4 class="heading settled" data-level="8.1.10" id="event-handlers"><span class="secno">8.1.10. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code> interface:</p>
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> interface:</p>
    <table class="simple">
     <thead>
      <tr>
@@ -2326,7 +2333,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-1">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-12">Sensor</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2342,14 +2349,14 @@ that must be supported as attributes by the objects implementing the <code class
         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-12">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> object,</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a> <a data-link-type="dfn" href="#supports-periodic-reporting-mode" id="ref-for-supports-periodic-reporting-mode-1">supports periodic reporting mode</a> and <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>, then</p>
+      <p>If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-32">sensor</a> <a data-link-type="dfn" href="#supports-periodic-reporting-mode" id="ref-for-supports-periodic-reporting-mode-1">supports periodic reporting mode</a> and <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-1">[[desiredSamplingFrequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-2">frequency</a></code>.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-3">[[desiredSamplingFrequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-2">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-3">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-3">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-2">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-3">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-3">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-2">timestamp</a></code> attributes.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-1">identifying parameters</a> in <var>options</var> are set, then:</p>
       <ol>
@@ -2367,26 +2374,26 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-15">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-32">sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-2">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-3">[[identifyingParameters]]</a></code> allows
-  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a> to be identified, then:</p>
+  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a> to be identified, then:</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a>,</p>
+        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a>,</p>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a> on the device, then</p>
+      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a> on the device, then</p>
       <ol>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-2">default sensor</a>.</p>
@@ -2407,16 +2414,16 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-15">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-16">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-1">activated sensor objects</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-3">activated sensor objects</a>.</p>
      <li data-md="">
       <p>Let <var>settings_changed</var> be the result of invoking <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings-1">set sensor settings</a> with <var>sensor</var> as argument.</p>
      <li data-md="">
@@ -2428,27 +2435,27 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-16">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-2">activated sensor objects</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated sensor objects</a>.</p>
      <li data-md="">
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-waitingforupdate-slot" id="ref-for-dom-sensor-waitingforupdate-slot-1">[[waitingForUpdate]]</a></code> to false.</p>
      <li data-md="">
-      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-3">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>,</p>
+      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>,</p>
       <ol>
        <li data-md="">
         <p>Unset the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-1">periodic reporting mode flag</a>.</p>
        <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-1">current sampling frequency</a> to null.</p>
+        <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-2">current sampling frequency</a> to null.</p>
        <li data-md="">
-        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-29">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-30">readings</a>.</p>
+        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-30">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-31">readings</a>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
@@ -2464,14 +2471,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated sensor objects</a>.</p>
+      <p>let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-6">activated sensor objects</a>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>s</var> of <var>activated_sensors</var>,</p>
       <ol>
@@ -2485,9 +2492,9 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p>Unset <var>sensor</var>’s <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-2">periodic reporting mode flag</a>.</p>
      <li data-md="">
-      <p>Set <var>sensor</var>’s <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-2">current sampling frequency</a> to null.</p>
+      <p>Set <var>sensor</var>’s <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-3">current sampling frequency</a> to null.</p>
      <li data-md="">
-      <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-31">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-32">readings</a>.</p>
+      <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-32">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-33">readings</a>.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.6" data-lt="Set sensor settings" data-noexport="" id="set-sensor-settings"><span class="secno">9.6. </span><span class="content">Set sensor settings</span></h3>
@@ -2495,7 +2502,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>True if the settings were modified, false otherwise.</p>
@@ -2522,15 +2529,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>Set the <a data-link-type="dfn" href="#periodic-reporting-mode-flag" id="ref-for-periodic-reporting-mode-flag-6">periodic reporting mode flag</a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>frequency</var> be the result of invoking <a data-link-type="dfn" href="#find-the-sampling-frequency-of-a-sensor" id="ref-for-find-the-sampling-frequency-of-a-sensor-1">find the sampling frequency of a sensor</a> with <var>sensor</var> as argument.</p>
-     <li data-md="">
-      <p>If <var>frequency</var> is different from <var>sensor</var>’s <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-3">current sampling frequency</a>,</p>
-      <ol>
-       <li data-md="">
-        <p>set <var>settings_changed</var> to true.</p>
-       <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-4">current sampling frequency</a> to <var>frequency</var>.</p>
-      </ol>
+      <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-4">current sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency-2">optimal sampling frequency</a>.</p>
      <li data-md="">
       <p>Return <var>settings_changed</var>.</p>
     </ol>
@@ -2540,14 +2539,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s <var>latest reading</var>["timestamp"] is not null,
   invoke <a data-link-type="dfn" href="#update-observers" id="ref-for-update-observers-1">update observers</a> with <var>sensor_instance</var> and <var>latest reading</var>["timestamp"] as arguments.</p>
@@ -2564,8 +2563,8 @@ that must be supported as attributes by the objects implementing the <code class
       <ol>
        <li data-md="">
         <p>let <var>frequency</var> be the <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-5">current sampling frequency</a>,
-  capped by the upper and lower bounds of the underlying hardware.</p>
-        <p class="issue" id="issue-848364a4"><a class="self-link" href="#issue-848364a4"></a> Should this max sampling frequency be reflected in the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> interface?
+  capped by the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-7">sampling frequency</a> bounds of the underlying platform.</p>
+        <p class="issue" id="issue-848364a4"><a class="self-link" href="#issue-848364a4"></a> Should this max sampling frequency be reflected in the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> interface?
   E.g. Through a dedicated attribute?</p>
         <p class="issue" id="issue-5221142a"><a class="self-link" href="#issue-5221142a"></a> Does the max sampling frequency affect the reporting frequency?
   If so, should we advise the developer of this issue?
@@ -2574,7 +2573,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>Poll <var>sensor</var> at <var>frequency</var>.</p>
        <li data-md="">
         <p class="issue" id="issue-1f946fcb"><a class="self-link" href="#issue-1f946fcb"></a> Hook into the <code>requestAnimationFrame</code> framework <a data-link-type="biblio" href="#biblio-html">[HTML]</a> to invoke <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading-1">update latest reading</a> for every new frame
-  with <var>sensor</var> and the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-33">sensor reading</a> as arguments.</p>
+  with <var>sensor</var> and the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-34">sensor reading</a> as arguments.</p>
         <p class="issue" id="issue-c1d5eff3"><a class="self-link" href="#issue-c1d5eff3"></a> Relying on <code>requestAnimationFrame</code> gives us a perfect point
   to buffer readings > 60Hz and to pass them to together with every new frame.
   That’s a level 2 feature.</p>
@@ -2596,7 +2595,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-42">sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A boolean.</p>
@@ -2605,10 +2604,10 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p>Let <var>result</var> be false.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated sensor objects</a>:</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-7">activated sensor objects</a>:</p>
       <ol>
        <li data-md="">
-        <p>if <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-2">[[desiredSamplingFrequency]]</a></code> is set,</p>
+        <p>if <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-4">[[desiredSamplingFrequency]]</a></code> is set,</p>
         <ol>
          <li data-md="">
           <p>set <var>result</var> to true, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break">break</a>.</p>
@@ -2618,43 +2617,14 @@ that must be supported as attributes by the objects implementing the <code class
       <p>return <var>result</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.9" data-lt="Find the sampling frequency of a sensor" data-noexport="" id="find-the-sampling-frequency-of-a-sensor"><span class="secno">9.9. </span><span class="content">Find the sampling frequency of a sensor</span></h3>
-   <div class="algorithm" data-algorithm="find the sampling frequency of a sensor">
-    <dl>
-     <dt data-md="">input
-     <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-42">sensor</a>.</p>
-     <dt data-md="">output
-     <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-4">frequency</a>.</p>
-    </dl>
-    <ol>
-     <li data-md="">
-      <p>Let <var>frequency</var> be null.</p>
-     <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor_instance</var> in <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-6">activated sensor objects</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-3">[[desiredSamplingFrequency]]</a></code>.</p>
-       <li data-md="">
-        <p>if <var>f</var> is set and <var>f</var> is greater than <var>frequency</var>,</p>
-        <ol>
-         <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var>.</p>
-        </ol>
-      </ol>
-     <li data-md="">
-      <p>return <var>frequency</var>.</p>
-    </ol>
-   </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.10" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">9.10. </span><span class="content">Update latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.9" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">9.9. </span><span class="content">Update latest reading</span></h3>
    <div class="algorithm" data-algorithm="update latest reading">
     <dl>
      <dt data-md="">input
      <dd data-md="">
       <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-43">sensor</a>.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-34">sensor reading</a>.</p>
+      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-35">sensor reading</a>.</p>
      <dd data-md="">
       <p><var>reading_timestamp</var>, the timestamp at which <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-44">sensor</a> was polled.</p>
     </dl>
@@ -2711,12 +2681,12 @@ that must be supported as attributes by the objects implementing the <code class
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.11" data-lt="Update observers" data-noexport="" id="update-observers"><span class="secno">9.11. </span><span class="content">Update observers</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.10" data-lt="Update observers" data-noexport="" id="update-observers"><span class="secno">9.10. </span><span class="content">Update observers</span></h3>
    <div class="algorithm" data-algorithm="update observers">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>timestamp</var>, a high resolution timestamp.</p>
      <dt data-md="">output
@@ -2769,7 +2739,7 @@ that must be supported as attributes by the objects implementing the <code class
       </div>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.12" data-lt="Security check" data-noexport="" id="security-check"><span class="secno">9.12. </span><span class="content">Security check</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.11" data-lt="Security check" data-noexport="" id="security-check"><span class="secno">9.11. </span><span class="content">Security check</span></h3>
    <div class="algorithm" data-algorithm="security check">
     <dl>
      <dt data-md="">input
@@ -2809,21 +2779,21 @@ that must be supported as attributes by the objects implementing the <code class
    <p class="note" role="note"><span>Note:</span> user agents are encouraged to stop sensor sampling
 when <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-4">security check</a> would return "insecure"
 in order to reduce resource consumption, notably battery usage.</p>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.13" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">9.13. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.12" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">9.12. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
    <div class="algorithm" data-algorithm="find the reporting frequency of a sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-5">frequency</a>.</p>
+      <p>A <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-4">frequency</a>.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>Let <var>frequency</var> be null.</p>
      <li data-md="">
-      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-4">[[desiredSamplingFrequency]]</a></code>.</p>
+      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-5">[[desiredSamplingFrequency]]</a></code>.</p>
       <ol>
        <li data-md="">
         <p>if <var>f</var> is set,</p>
@@ -2842,12 +2812,12 @@ in order to reduce resource consumption, notably battery usage.</p>
       <p>return <var>frequency</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.14" data-lt="Report latest reading updated" data-noexport="" id="report-latest-reading-updated"><span class="secno">9.14. </span><span class="content">Report latest reading updated</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.13" data-lt="Report latest reading updated" data-noexport="" id="report-latest-reading-updated"><span class="secno">9.13. </span><span class="content">Report latest reading updated</span></h3>
    <div class="algorithm" data-algorithm="report latest reading updated">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2905,12 +2875,12 @@ in order to reduce resource consumption, notably battery usage.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.15" data-lt="Notify sensor object about new reading" data-noexport="" id="notify-sensor-object-about-new-reading"><span class="secno">9.15. </span><span class="content">Notify sensor object about new reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.14" data-lt="Notify sensor object about new reading" data-noexport="" id="notify-sensor-object-about-new-reading"><span class="secno">9.14. </span><span class="content">Notify sensor object about new reading</span></h3>
    <div class="algorithm" data-algorithm="notify sensor object about new reading">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-23">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2924,12 +2894,12 @@ in order to reduce resource consumption, notably battery usage.</p>
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "change" at <var>sensor_instance</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.16" data-lt="Handle errors" data-noexport="" id="handle-errors"><span class="secno">9.16. </span><span class="content">Handle errors</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.15" data-lt="Handle errors" data-noexport="" id="handle-errors"><span class="secno">9.15. </span><span class="content">Handle errors</span></h3>
    <div class="algorithm" data-algorithm="handle errors">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-23">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-24">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>.</p>
      <dt data-md="">output
@@ -2943,17 +2913,17 @@ in order to reduce resource consumption, notably battery usage.</p>
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent-1">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error-1">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.17" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">9.17. </span><span class="content">Get value from latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.16" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">9.16. </span><span class="content">Get value from latest reading</span></h3>
    <div class="algorithm" data-algorithm="get value from latest reading">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-24">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-25">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-35">sensor reading</a> value or null.</p>
+      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-36">sensor reading</a> value or null.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2968,12 +2938,12 @@ in order to reduce resource consumption, notably battery usage.</p>
       <p>Otherwise, return null.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.18" data-lt="Request sensor access" data-noexport="" id="request-sensor-access"><span class="secno">9.18. </span><span class="content">Request sensor access</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.17" data-lt="Request sensor access" data-noexport="" id="request-sensor-access"><span class="secno">9.17. </span><span class="content">Request sensor access</span></h3>
    <div class="algorithm" data-algorithm="request sensor access">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-25">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-26">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state">permission state</a>.</p>
@@ -3001,25 +2971,25 @@ as appropriate.</p>
    <p>All interfaces defined by extension specifications
 should only be available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
    <h3 class="heading settled" data-level="10.2" id="naming"><span class="secno">10.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-26">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> sensors should be
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-27">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> sensors should be
 named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-48">sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-27">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors should be
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-28">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors should be
 named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-49">sensor</a> measures
 with the "Sensor" suffix.
 For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-50">sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-28">Sensor</a></code> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-36">sensor readings</a> values
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-29">Sensor</a></code> subclass that
+hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-37">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
-the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-37">sensor reading</a>'s value in
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-38">sensor reading</a>'s value in
 a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp</code> attribute).
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="10.3" id="unit"><span class="secno">10.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-38">sensor readings</a>.</p>
+   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-39">sensor readings</a>.</p>
    <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
@@ -3064,7 +3034,7 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-13">low
     <li data-md="">
      <p>allow multiple sensors of the same type to be instantiated,</p>
     <li data-md="">
-     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-29">Sensor</a></code>,</p>
+     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-30">Sensor</a></code>,</p>
     <li data-md="">
      <p>add constructor parameters to tweak sensors settings (e.g. setting required accuracy).</p>
    </ul>
@@ -3073,11 +3043,11 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-13">low
 each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-35">sensor type</a> in extension specifications:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-30">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-31">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor">Constructor</a></code>] must take, as argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-2">SensorOptions</a></code>.
-  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-39">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only">read only</a> and
+  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-40">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-3">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> as arguments.</p>
     <li data-md="">
      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
@@ -3388,8 +3358,7 @@ for their editorial input.</p>
      <li><a href="#dom-sensorerroreventinit-error">dict-member for SensorErrorEventInit</a><span>, in §8.2</span>
     </ul>
    <li><a href="#fallback">fallback</a><span>, in §6.3</span>
-   <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §9.12</span>
-   <li><a href="#find-the-sampling-frequency-of-a-sensor">Find the sampling frequency of a sensor</a><span>, in §9.8</span>
+   <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §9.11</span>
    <li>
     frequency
     <ul>
@@ -3397,8 +3366,8 @@ for their editorial input.</p>
      <li><a href="#dom-sensoroptions-frequency">dict-member for SensorOptions</a><span>, in §8.1</span>
     </ul>
    <li><a href="#generic-sensor-permission-revocation-algorithm">generic sensor permission revocation algorithm</a><span>, in §7.1</span>
-   <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §9.16</span>
-   <li><a href="#handle-errors">Handle errors</a><span>, in §9.15</span>
+   <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §9.15</span>
+   <li><a href="#handle-errors">Handle errors</a><span>, in §9.14</span>
    <li><a href="#high-level">high-level</a><span>, in §6.2</span>
    <li><a href="#identifying-parameters">identifying parameters</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-identifyingparameters-slot">[[identifyingParameters]]</a><span>, in §8.1.2</span>
@@ -3409,11 +3378,12 @@ for their editorial input.</p>
    <li><a href="#limit-max-freqency">Limit maximum sampling frequency</a><span>, in §5.2</span>
    <li><a href="#limit-number-of-delivered-readings">Limit number of delivered readings</a><span>, in §5.2.2</span>
    <li><a href="#low-level">low-level</a><span>, in §6.2</span>
-   <li><a href="#notify-sensor-object-about-new-reading">Notify sensor object about new reading</a><span>, in §9.14</span>
+   <li><a href="#notify-sensor-object-about-new-reading">Notify sensor object about new reading</a><span>, in §9.13</span>
    <li><a href="#observe-a-sensor">Observe a sensor</a><span>, in §9.6</span>
    <li><a href="#dom-sensor-onactivate">onactivate</a><span>, in §8.1</span>
    <li><a href="#dom-sensor-onchange">onchange</a><span>, in §8.1</span>
    <li><a href="#dom-sensor-onerror">onerror</a><span>, in §8.1</span>
+   <li><a href="#optimal-sampling-frequency">optimal sampling frequency</a><span>, in §7.2</span>
    <li><a href="#periodic">periodic</a><span>, in §6.3</span>
    <li><a href="#periodic-reporting-mode-flag">periodic reporting mode flag</a><span>, in §7.2</span>
    <li><a href="#raw-sensor-readings">raw sensor readings</a><span>, in §6.1</span>
@@ -3422,10 +3392,11 @@ for their editorial input.</p>
    <li><a href="#register-a-sensor-object">Register a sensor object</a><span>, in §9.2</span>
    <li><a href="#reporting-flag">reporting flag</a><span>, in §7.2</span>
    <li><a href="#reporting-modes">reporting modes</a><span>, in §6.3</span>
-   <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §9.13</span>
-   <li><a href="#request-sensor-access">Request sensor access</a><span>, in §9.17</span>
+   <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §9.12</span>
+   <li><a href="#request-sensor-access">Request sensor access</a><span>, in §9.16</span>
    <li><a href="#revoke-sensor-permission">Revoke sensor permission</a><span>, in §9.4</span>
-   <li><a href="#security-check">Security check</a><span>, in §9.11</span>
+   <li><a href="#sampling-frequency">sampling frequency</a><span>, in §6.4</span>
+   <li><a href="#security-check">Security check</a><span>, in §9.10</span>
    <li><a href="#sensor">Sensor</a><span>, in §8.1</span>
    <li><a href="#concept-sensor">sensor</a><span>, in §7.2</span>
    <li><a href="#sensorerrorevent">SensorErrorEvent</a><span>, in §8.2</span>
@@ -3446,8 +3417,8 @@ for their editorial input.</p>
    <li><a href="#supports-periodic-reporting-mode">supports periodic reporting mode</a><span>, in §7.2</span>
    <li><a href="#dom-sensor-timestamp">timestamp</a><span>, in §8.1</span>
    <li><a href="#unregister-a-sensor-object">Unregister a sensor object</a><span>, in §9.3</span>
-   <li><a href="#update-latest-reading">Update latest reading</a><span>, in §9.9</span>
-   <li><a href="#update-observers">Update observers</a><span>, in §9.10</span>
+   <li><a href="#update-latest-reading">Update latest reading</a><span>, in §9.8</span>
+   <li><a href="#update-observers">Update observers</a><span>, in §9.9</span>
    <li><a href="#dom-sensor-waitingforupdate-slot">[[waitingForUpdate]]</a><span>, in §8.1.2</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -3650,17 +3621,18 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings-14">5.2.5. Keeping the user informed about API use</a>
     <li><a href="#ref-for-sensor-readings-15">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings-16">(2)</a> <a href="#ref-for-sensor-readings-17">(3)</a> <a href="#ref-for-sensor-readings-18">(4)</a> <a href="#ref-for-sensor-readings-19">(5)</a>
     <li><a href="#ref-for-sensor-readings-20">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings-21">(2)</a> <a href="#ref-for-sensor-readings-22">(3)</a> <a href="#ref-for-sensor-readings-23">(4)</a> <a href="#ref-for-sensor-readings-24">(5)</a>
-    <li><a href="#ref-for-sensor-readings-25">7.2. Sensor</a> <a href="#ref-for-sensor-readings-26">(2)</a>
-    <li><a href="#ref-for-sensor-readings-27">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-sensor-readings-28">8.1.7. Sensor.onchange</a>
-    <li><a href="#ref-for-sensor-readings-29">9.4. Unregister a sensor object</a> <a href="#ref-for-sensor-readings-30">(2)</a>
-    <li><a href="#ref-for-sensor-readings-31">9.5. Revoke sensor permission</a> <a href="#ref-for-sensor-readings-32">(2)</a>
-    <li><a href="#ref-for-sensor-readings-33">9.7. Observe a sensor</a>
-    <li><a href="#ref-for-sensor-readings-34">9.10. Update latest reading</a>
-    <li><a href="#ref-for-sensor-readings-35">9.17. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-readings-36">10.2. Naming</a> <a href="#ref-for-sensor-readings-37">(2)</a>
-    <li><a href="#ref-for-sensor-readings-38">10.3. Unit</a>
-    <li><a href="#ref-for-sensor-readings-39">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor-readings-25">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-sensor-readings-26">7.2. Sensor</a> <a href="#ref-for-sensor-readings-27">(2)</a>
+    <li><a href="#ref-for-sensor-readings-28">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-sensor-readings-29">8.1.7. Sensor.onchange</a>
+    <li><a href="#ref-for-sensor-readings-30">9.4. Unregister a sensor object</a> <a href="#ref-for-sensor-readings-31">(2)</a>
+    <li><a href="#ref-for-sensor-readings-32">9.5. Revoke sensor permission</a> <a href="#ref-for-sensor-readings-33">(2)</a>
+    <li><a href="#ref-for-sensor-readings-34">9.7. Observe a sensor</a>
+    <li><a href="#ref-for-sensor-readings-35">9.9. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings-36">9.16. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-readings-37">10.2. Naming</a> <a href="#ref-for-sensor-readings-38">(2)</a>
+    <li><a href="#ref-for-sensor-readings-39">10.3. Unit</a>
+    <li><a href="#ref-for-sensor-readings-40">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
@@ -3714,8 +3686,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-frequency-1">6.3. Reporting Modes</a> <a href="#ref-for-frequency-2">(2)</a>
     <li><a href="#ref-for-frequency-3">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-frequency-4">9.9. Find the sampling frequency of a sensor</a>
-    <li><a href="#ref-for-frequency-5">9.13. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-frequency-4">9.12. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic">
@@ -3729,6 +3700,16 @@ for their editorial input.</p>
    <b><a href="#implementation-specific">#implementation-specific</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-specific-1">6.3. Reporting Modes</a> <a href="#ref-for-implementation-specific-2">(2)</a> <a href="#ref-for-implementation-specific-3">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="sampling-frequency">
+   <b><a href="#sampling-frequency">#sampling-frequency</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sampling-frequency-1">5.2.1. Limit maximum sampling frequency</a> <a href="#ref-for-sampling-frequency-2">(2)</a>
+    <li><a href="#ref-for-sampling-frequency-3">5.2.3. Limit number of delivered readings</a>
+    <li><a href="#ref-for-sampling-frequency-4">7.2. Sensor</a> <a href="#ref-for-sampling-frequency-5">(2)</a>
+    <li><a href="#ref-for-sampling-frequency-6">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-sampling-frequency-7">9.7. Observe a sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-type">
@@ -3779,23 +3760,23 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-sensor-13">6.1. Sensors</a> <a href="#ref-for-concept-sensor-14">(2)</a>
     <li><a href="#ref-for-concept-sensor-15">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor-16">(2)</a> <a href="#ref-for-concept-sensor-17">(3)</a>
     <li><a href="#ref-for-concept-sensor-18">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor-19">(2)</a> <a href="#ref-for-concept-sensor-20">(3)</a>
-    <li><a href="#ref-for-concept-sensor-21">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-22">(2)</a>
-    <li><a href="#ref-for-concept-sensor-23">7.2. Sensor</a> <a href="#ref-for-concept-sensor-24">(2)</a> <a href="#ref-for-concept-sensor-25">(3)</a> <a href="#ref-for-concept-sensor-26">(4)</a> <a href="#ref-for-concept-sensor-27">(5)</a> <a href="#ref-for-concept-sensor-28">(6)</a>
-    <li><a href="#ref-for-concept-sensor-29">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-concept-sensor-30">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-sensor-31">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-concept-sensor-32">9.2. Connect to sensor</a> <a href="#ref-for-concept-sensor-33">(2)</a> <a href="#ref-for-concept-sensor-34">(3)</a> <a href="#ref-for-concept-sensor-35">(4)</a>
-    <li><a href="#ref-for-concept-sensor-36">9.3. Register a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-37">9.4. Unregister a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-38">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-sensor-39">9.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-sensor-40">9.7. Observe a sensor</a>
-    <li><a href="#ref-for-concept-sensor-41">9.8. Is current reporting mode periodic</a>
-    <li><a href="#ref-for-concept-sensor-42">9.9. Find the sampling frequency of a sensor</a>
-    <li><a href="#ref-for-concept-sensor-43">9.10. Update latest reading</a> <a href="#ref-for-concept-sensor-44">(2)</a>
-    <li><a href="#ref-for-concept-sensor-45">9.13. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-46">9.17. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-sensor-47">9.18. Request sensor access</a>
+    <li><a href="#ref-for-concept-sensor-21">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-concept-sensor-22">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-23">(2)</a>
+    <li><a href="#ref-for-concept-sensor-24">7.2. Sensor</a> <a href="#ref-for-concept-sensor-25">(2)</a> <a href="#ref-for-concept-sensor-26">(3)</a> <a href="#ref-for-concept-sensor-27">(4)</a> <a href="#ref-for-concept-sensor-28">(5)</a> <a href="#ref-for-concept-sensor-29">(6)</a>
+    <li><a href="#ref-for-concept-sensor-30">8.1. The Sensor Interface</a>
+    <li><a href="#ref-for-concept-sensor-31">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-sensor-32">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-concept-sensor-33">9.2. Connect to sensor</a> <a href="#ref-for-concept-sensor-34">(2)</a> <a href="#ref-for-concept-sensor-35">(3)</a> <a href="#ref-for-concept-sensor-36">(4)</a>
+    <li><a href="#ref-for-concept-sensor-37">9.3. Register a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-38">9.4. Unregister a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-39">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-sensor-40">9.6. Set sensor settings</a>
+    <li><a href="#ref-for-concept-sensor-41">9.7. Observe a sensor</a>
+    <li><a href="#ref-for-concept-sensor-42">9.8. Is current reporting mode periodic</a>
+    <li><a href="#ref-for-concept-sensor-43">9.9. Update latest reading</a> <a href="#ref-for-concept-sensor-44">(2)</a>
+    <li><a href="#ref-for-concept-sensor-45">9.12. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-46">9.16. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-sensor-47">9.17. Request sensor access</a>
     <li><a href="#ref-for-concept-sensor-48">10.2. Naming</a> <a href="#ref-for-concept-sensor-49">(2)</a> <a href="#ref-for-concept-sensor-50">(3)</a>
     <li><a href="#ref-for-concept-sensor-51">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor-52">(2)</a>
     <li><a href="#ref-for-concept-sensor-53">10.8. Example WebIDL</a>
@@ -3804,21 +3785,21 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
    <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activated-sensor-objects-1">9.3. Register a sensor object</a>
-    <li><a href="#ref-for-activated-sensor-objects-2">9.4. Unregister a sensor object</a> <a href="#ref-for-activated-sensor-objects-3">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects-4">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-activated-sensor-objects-5">9.8. Is current reporting mode periodic</a>
-    <li><a href="#ref-for-activated-sensor-objects-6">9.9. Find the sampling frequency of a sensor</a>
+    <li><a href="#ref-for-activated-sensor-objects-1">7.2. Sensor</a> <a href="#ref-for-activated-sensor-objects-2">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects-3">9.3. Register a sensor object</a>
+    <li><a href="#ref-for-activated-sensor-objects-4">9.4. Unregister a sensor object</a> <a href="#ref-for-activated-sensor-objects-5">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects-6">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-activated-sensor-objects-7">9.8. Is current reporting mode periodic</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="latest-reading">
    <b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading-1">7.2. Sensor</a> <a href="#ref-for-latest-reading-2">(2)</a> <a href="#ref-for-latest-reading-3">(3)</a> <a href="#ref-for-latest-reading-4">(4)</a> <a href="#ref-for-latest-reading-5">(5)</a> <a href="#ref-for-latest-reading-6">(6)</a> <a href="#ref-for-latest-reading-7">(7)</a>
-    <li><a href="#ref-for-latest-reading-8">9.10. Update latest reading</a> <a href="#ref-for-latest-reading-9">(2)</a> <a href="#ref-for-latest-reading-10">(3)</a> <a href="#ref-for-latest-reading-11">(4)</a>
-    <li><a href="#ref-for-latest-reading-12">9.14. Report latest reading updated</a>
-    <li><a href="#ref-for-latest-reading-13">9.15. Notify sensor object about new reading</a>
-    <li><a href="#ref-for-latest-reading-14">9.17. Get value from latest reading</a>
+    <li><a href="#ref-for-latest-reading-8">9.9. Update latest reading</a> <a href="#ref-for-latest-reading-9">(2)</a> <a href="#ref-for-latest-reading-10">(3)</a> <a href="#ref-for-latest-reading-11">(4)</a>
+    <li><a href="#ref-for-latest-reading-12">9.13. Report latest reading updated</a>
+    <li><a href="#ref-for-latest-reading-13">9.14. Notify sensor object about new reading</a>
+    <li><a href="#ref-for-latest-reading-14">9.16. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="supports-periodic-reporting-mode">
@@ -3830,7 +3811,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="reporting-flag">
    <b><a href="#reporting-flag">#reporting-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reporting-flag-1">9.10. Update latest reading</a> <a href="#ref-for-reporting-flag-2">(2)</a> <a href="#ref-for-reporting-flag-3">(3)</a>
+    <li><a href="#ref-for-reporting-flag-1">9.9. Update latest reading</a> <a href="#ref-for-reporting-flag-2">(2)</a> <a href="#ref-for-reporting-flag-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic-reporting-mode-flag">
@@ -3845,11 +3826,19 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="current-sampling-frequency">
    <b><a href="#current-sampling-frequency">#current-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-sampling-frequency-1">9.4. Unregister a sensor object</a>
-    <li><a href="#ref-for-current-sampling-frequency-2">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-current-sampling-frequency-3">9.6. Set sensor settings</a> <a href="#ref-for-current-sampling-frequency-4">(2)</a>
+    <li><a href="#ref-for-current-sampling-frequency-1">7.2. Sensor</a>
+    <li><a href="#ref-for-current-sampling-frequency-2">9.4. Unregister a sensor object</a>
+    <li><a href="#ref-for-current-sampling-frequency-3">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-current-sampling-frequency-4">9.6. Set sensor settings</a>
     <li><a href="#ref-for-current-sampling-frequency-5">9.7. Observe a sensor</a>
-    <li><a href="#ref-for-current-sampling-frequency-6">9.13. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-current-sampling-frequency-6">9.12. Find the reporting frequency of a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="optimal-sampling-frequency">
+   <b><a href="#optimal-sampling-frequency">#optimal-sampling-frequency</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-optimal-sampling-frequency-1">7.2. Sensor</a>
+    <li><a href="#ref-for-optimal-sampling-frequency-2">9.6. Set sensor settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor">
@@ -3858,24 +3847,25 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-1">3. Background</a>
     <li><a href="#ref-for-sensor-2">4. A note on Feature Detection of Hardware Features</a>
     <li><a href="#ref-for-sensor-3">7.1. Sensor Type</a> <a href="#ref-for-sensor-4">(2)</a>
-    <li><a href="#ref-for-sensor-5">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor-6">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-7">(2)</a> <a href="#ref-for-sensor-8">(3)</a> <a href="#ref-for-sensor-9">(4)</a>
-    <li><a href="#ref-for-sensor-10">8.1.10. Event handlers</a>
-    <li><a href="#ref-for-sensor-11">9.1. Construct sensor object</a> <a href="#ref-for-sensor-12">(2)</a> <a href="#ref-for-sensor-13">(3)</a>
-    <li><a href="#ref-for-sensor-14">9.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-15">9.3. Register a sensor object</a>
-    <li><a href="#ref-for-sensor-16">9.4. Unregister a sensor object</a>
-    <li><a href="#ref-for-sensor-17">9.7. Observe a sensor</a> <a href="#ref-for-sensor-18">(2)</a>
-    <li><a href="#ref-for-sensor-19">9.11. Update observers</a>
-    <li><a href="#ref-for-sensor-20">9.13. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor-21">9.14. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor-22">9.15. Notify sensor object about new reading</a>
-    <li><a href="#ref-for-sensor-23">9.16. Handle errors</a>
-    <li><a href="#ref-for-sensor-24">9.17. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-25">9.18. Request sensor access</a>
-    <li><a href="#ref-for-sensor-26">10.2. Naming</a> <a href="#ref-for-sensor-27">(2)</a> <a href="#ref-for-sensor-28">(3)</a>
-    <li><a href="#ref-for-sensor-29">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
-    <li><a href="#ref-for-sensor-30">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor-5">7.2. Sensor</a>
+    <li><a href="#ref-for-sensor-6">8.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor-7">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-8">(2)</a> <a href="#ref-for-sensor-9">(3)</a> <a href="#ref-for-sensor-10">(4)</a>
+    <li><a href="#ref-for-sensor-11">8.1.10. Event handlers</a>
+    <li><a href="#ref-for-sensor-12">9.1. Construct sensor object</a> <a href="#ref-for-sensor-13">(2)</a> <a href="#ref-for-sensor-14">(3)</a>
+    <li><a href="#ref-for-sensor-15">9.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-16">9.3. Register a sensor object</a>
+    <li><a href="#ref-for-sensor-17">9.4. Unregister a sensor object</a>
+    <li><a href="#ref-for-sensor-18">9.7. Observe a sensor</a> <a href="#ref-for-sensor-19">(2)</a>
+    <li><a href="#ref-for-sensor-20">9.10. Update observers</a>
+    <li><a href="#ref-for-sensor-21">9.12. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor-22">9.13. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor-23">9.14. Notify sensor object about new reading</a>
+    <li><a href="#ref-for-sensor-24">9.15. Handle errors</a>
+    <li><a href="#ref-for-sensor-25">9.16. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-26">9.17. Request sensor access</a>
+    <li><a href="#ref-for-sensor-27">10.2. Naming</a> <a href="#ref-for-sensor-28">(2)</a> <a href="#ref-for-sensor-29">(3)</a>
+    <li><a href="#ref-for-sensor-30">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor-31">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
@@ -3942,35 +3932,35 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-sensor-state-slot-4">8.1.6. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot-5">(2)</a>
     <li><a href="#ref-for-dom-sensor-state-slot-6">8.1.8. Sensor.onactivate</a>
     <li><a href="#ref-for-dom-sensor-state-slot-7">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-8">9.11. Update observers</a> <a href="#ref-for-dom-sensor-state-slot-9">(2)</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-10">9.16. Handle errors</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-11">9.17. Get value from latest reading</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-8">9.10. Update observers</a> <a href="#ref-for-dom-sensor-state-slot-9">(2)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-10">9.15. Handle errors</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-11">9.16. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-desiredsamplingfrequency-slot">
    <b><a href="#dom-sensor-desiredsamplingfrequency-slot">#dom-sensor-desiredsamplingfrequency-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-1">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-2">9.8. Is current reporting mode periodic</a>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-3">9.9. Find the sampling frequency of a sensor</a>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-4">9.13. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-1">7.2. Sensor</a> <a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-2">(2)</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-3">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-4">9.8. Is current reporting mode periodic</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-5">9.12. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot">
    <b><a href="#dom-sensor-lasteventfiredat-slot">#dom-sensor-lasteventfiredat-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-1">9.11. Update observers</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-2">9.14. Report latest reading updated</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-3">9.15. Notify sensor object about new reading</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-1">9.10. Update observers</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-2">9.13. Report latest reading updated</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-3">9.14. Notify sensor object about new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-waitingforupdate-slot">
    <b><a href="#dom-sensor-waitingforupdate-slot">#dom-sensor-waitingforupdate-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-1">9.4. Unregister a sensor object</a>
-    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-2">9.11. Update observers</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-3">(2)</a>
-    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-4">9.14. Report latest reading updated</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-5">(2)</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-6">(3)</a>
-    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-7">9.15. Notify sensor object about new reading</a>
+    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-2">9.10. Update observers</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-3">(2)</a>
+    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-4">9.13. Report latest reading updated</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-5">(2)</a> <a href="#ref-for-dom-sensor-waitingforupdate-slot-6">(3)</a>
+    <li><a href="#ref-for-dom-sensor-waitingforupdate-slot-7">9.14. Notify sensor object about new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-identifyingparameters-slot">
@@ -3983,13 +3973,13 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="sensorerrorevent">
    <b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensorerrorevent-1">9.16. Handle errors</a>
+    <li><a href="#ref-for-sensorerrorevent-1">9.15. Handle errors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorerrorevent-error">
    <b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorerrorevent-error-1">9.16. Handle errors</a>
+    <li><a href="#ref-for-dom-sensorerrorevent-error-1">9.15. Handle errors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensorerroreventinit">
@@ -4043,12 +4033,6 @@ for their editorial input.</p>
     <li><a href="#ref-for-is-current-reporting-mode-periodic-1">9.6. Set sensor settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-the-sampling-frequency-of-a-sensor">
-   <b><a href="#find-the-sampling-frequency-of-a-sensor">#find-the-sampling-frequency-of-a-sensor</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-find-the-sampling-frequency-of-a-sensor-1">9.6. Set sensor settings</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="update-latest-reading">
    <b><a href="#update-latest-reading">#update-latest-reading</a></b><b>Referenced in:</b>
    <ul>
@@ -4066,26 +4050,26 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-security-check-1">5.1.3. Losing Focus</a>
     <li><a href="#ref-for-security-check-2">5.1.4. Visibility State</a>
-    <li><a href="#ref-for-security-check-3">9.10. Update latest reading</a>
-    <li><a href="#ref-for-security-check-4">9.12. Security check</a>
+    <li><a href="#ref-for-security-check-3">9.9. Update latest reading</a>
+    <li><a href="#ref-for-security-check-4">9.11. Security check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="find-the-reporting-frequency-of-a-sensor-object">
    <b><a href="#find-the-reporting-frequency-of-a-sensor-object">#find-the-reporting-frequency-of-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object-1">9.14. Report latest reading updated</a>
+    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object-1">9.13. Report latest reading updated</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="report-latest-reading-updated">
    <b><a href="#report-latest-reading-updated">#report-latest-reading-updated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-report-latest-reading-updated-1">9.10. Update latest reading</a>
+    <li><a href="#ref-for-report-latest-reading-updated-1">9.9. Update latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-sensor-object-about-new-reading">
    <b><a href="#notify-sensor-object-about-new-reading">#notify-sensor-object-about-new-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-sensor-object-about-new-reading-1">9.14. Report latest reading updated</a> <a href="#ref-for-notify-sensor-object-about-new-reading-2">(2)</a> <a href="#ref-for-notify-sensor-object-about-new-reading-3">(3)</a> <a href="#ref-for-notify-sensor-object-about-new-reading-4">(4)</a>
+    <li><a href="#ref-for-notify-sensor-object-about-new-reading-1">9.13. Report latest reading updated</a> <a href="#ref-for-notify-sensor-object-about-new-reading-2">(2)</a> <a href="#ref-for-notify-sensor-object-about-new-reading-3">(3)</a> <a href="#ref-for-notify-sensor-object-about-new-reading-4">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-errors">


### PR DESCRIPTION
This PR adds definition for optimal sampling frequency which is used from "Set sensor settings" algorithm.

Fixes #240


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/sensors/set_optimal_frequency.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/c3f93a8...alexshalamov:f1807c3.html)