### PR TITLE
Add `Level: none` to the metadata block

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,7 @@
 <pre class="metadata">
 Title: Generic Sensor API
 Shortname: generic-sensor
+Level: none
 Status: ED
 Group: dap
 ED: https://w3c.github.io/sensors/

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 760cc1c5c9221f585aba069d03f7e9f2a0ecb1df" name="generator">
+  <meta content="Bikeshed version 63e2d3f6cc034d9b09cfdb2d391c527b191584bc" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
 <style>
     emu-val {
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-04">4 August 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-09">9 August 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1645,13 +1645,13 @@ This is especially true on mobile devices where new sensors are added regularly.
 has so far been both slow-paced and ad-hoc.
 Few sensors are already exposed to the Web.
 When they are, it is often in ways that limit their possible use cases
-(for example by exposing abstractions that are too <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-1">high-level</a> and which don’t perform well enough).
+(for example by exposing abstractions that are too <a data-link-type="dfn" href="#high-level" id="ref-for-high-level">high-level</a> and which don’t perform well enough).
 APIs also vary greatly from one sensor to the next
 which increases the cognitive burden of Web application developers
 and slows development.</p>
    <p>The goal of the Generic Sensor API is to
 promote consistency across sensor APIs,
-enable advanced use cases thanks to performant <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-1">low-level</a> APIs,
+enable advanced use cases thanks to performant <a data-link-type="dfn" href="#low-level" id="ref-for-low-level">low-level</a> APIs,
 and increase the pace at which new sensors can be exposed to the Web
 by simplifying the specification and implementation processes.</p>
    <p class="issue" id="issue-77d9d95c"><a class="self-link" href="#issue-77d9d95c"></a> This lacks an informative section with examples for developers.
@@ -1687,15 +1687,15 @@ either to another section of the spec
 or to an external explainer document.</p>
    <p>The Generic Sensor API is designed to make the most common use cases straightforward
 while still enabling more complex use cases.</p>
-   <p>Most devices deployed today do not carry more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-1">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-1">sensor types</a>.
+   <p>Most devices deployed today do not carry more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type">sensor types</a>.
 This shouldn’t come as a surprise since use cases for more than
-a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-2">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-2">type</a> are rare
-and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-3">sensor types</a>,
+a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-0">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-0">type</a> are rare
+and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-1">sensor types</a>,
 such as proximity sensors.</p>
    <p>The API therefore makes it easy to interact with
-the device’s default (and often unique) <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-3">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-4">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-1">Sensor</a></code> subclass.</p>
-   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-4">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-5">type</a>,
-the default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-5">sensor</a> is chosen.</p>
+the device’s default (and often unique) <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-1">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-2">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor">Sensor</a></code> subclass.</p>
+   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-2">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-3">type</a>,
+the default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-3">sensor</a> is chosen.</p>
    <div class="example" id="example-2b740ace">
     <a class="self-link" href="#example-2b740ace"></a> Listening to geolocation changes: 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">({</span> accuracy<span class="o">:</span> <span class="s2">"high"</span> <span class="p">});</span>
@@ -1713,10 +1713,10 @@ sensor<span class="p">.</span>start<span class="p">();</span>
    </div>
    <p class="note" role="note"><span>Note:</span> extension to this specification may choose not to define a default sensor
 when doing so wouldn’t make sense.
-For example, it might be difficult to agree on an obvious default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-6">sensor</a> for
-proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-7">sensors</a>.</p>
+For example, it might be difficult to agree on an obvious default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-4">sensor</a> for
+proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-5">sensors</a>.</p>
    <p>In cases where
-multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-8">sensors</a> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-6">type</a> may coexist on the same device,
+multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-6">sensors</a> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-4">type</a> may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.</p>
    <div class="example" id="example-fdd94e11">
@@ -1773,7 +1773,7 @@ which checks whether an API for the sought-after sensor actually exists,
 and defensive programming which includes:</p>
    <ol>
     <li data-md="">
-     <p>checking for error thrown when instantiating a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-2">Sensor</a></code> object,</p>
+     <p>checking for error thrown when instantiating a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-0">Sensor</a></code> object,</p>
     <li data-md="">
      <p>listening to errors emitted by it,</p>
     <li data-md="">
@@ -1798,7 +1798,7 @@ and defensive programming which includes:</p>
 It probably needs a section that lists threats
 and one that lists mitigation strategies,
 with links between both.</p>
-   <p>Privacy risks can arise when <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-9">sensors</a> are used
+   <p>Privacy risks can arise when <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-7">sensors</a> are used
 with each other,
 in combination with other functionality,
 or when used over time,
@@ -1809,27 +1809,27 @@ consider how this information might be correlated with other information
 and the privacy risks that might be created.
 The potential risks of collection of such data over a longer period of time
 should also be considered.</p>
-   <p>Variations in <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-1">sensor readings</a> as well as event firing rates
+   <p>Variations in <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings">sensor readings</a> as well as event firing rates
 offer the possibility of fingerprinting to identify users.
 User agents may reduce the risk by
 limiting event rates available to web application developers.</p>
    <p class="note" role="note"><span>Note:</span> do we really want this mitigation strategy?</p>
-   <p>Frequency polling in <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-1">periodic</a> <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-1">reporting mode</a> might allow the fingerprinting of hardware or implementation types,
+   <p>Frequency polling in <a data-link-type="dfn" href="#periodic" id="ref-for-periodic">periodic</a> <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes">reporting mode</a> might allow the fingerprinting of hardware or implementation types,
 by probing which actual frequencies are supported by the platform.</p>
    <p>Minimizing the accuracy of a sensor’s readout
 generally decreases the risk of fingerprinting.
 User agents should not provide unnecessarily verbose readouts of sensors data.
-Each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-7">sensor type</a> should be assessed individually.</p>
+Each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-5">sensor type</a> should be assessed individually.</p>
    <p>If the same JavaScript code using the API can be
 used simultaneously in different window contexts on the same device
 it may be possible for that code to correlate the user across those two contexts,
 creating unanticipated tracking mechanisms.</p>
    <p>User agents should consider providing the user
-an indication of when the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-10">sensor</a> is used
+an indication of when the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-8">sensor</a> is used
 and allowing the user to disable it.
 Additionally, user agents may consider
 allowing the user to verify past and current sensor use patterns.</p>
-   <p>Web application developers that use <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-11">sensors</a> should
+   <p>Web application developers that use <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-9">sensors</a> should
 perform a privacy impact assessment of their application
 taking all aspects of their application into consideration.</p>
    <p>Ability to detect a full working set of sensors on a device can form an
@@ -1842,38 +1842,38 @@ band communication channel between devices.</p>
    <p>This section gives a high-level presentation of some of the mitigation strategies
 specified in the normative sections of this specification.</p>
    <h4 class="heading settled" data-level="5.1.1" id="secure-context"><span class="secno">5.1.1. </span><span class="content">Secure Context</span><a class="self-link" href="#secure-context"></a></h4>
-   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-2">Sensor readings</a> are explicitly flagged by the
+   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-0">Sensor readings</a> are explicitly flagged by the
 Secure Contexts specification <a data-link-type="biblio" href="#biblio-powerful-features">[POWERFUL-FEATURES]</a> as a high-value target for network attackers.
 Thus all interfaces defined by this specification
 or extension specifications
-are only available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
+are only available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context">secure context</a>.</p>
    <h4 class="heading settled" data-level="5.1.2" id="top-level-browsing-context"><span class="secno">5.1.2. </span><span class="content">Top-Level Browsing Context</span><span id="browsing-context"></span><a class="self-link" href="#top-level-browsing-context"></a></h4>
    <p>To avoid the privacy risk of
-sharing <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-3">sensor readings</a> with contexts unfamiliar to the user, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-4">sensor readings</a> are only available in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>.</p>
+sharing <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-1">sensor readings</a> with contexts unfamiliar to the user, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-2">sensor readings</a> are only available in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>.</p>
    <p class="note" role="note"><span>Note:</span> <a href="https://docs.google.com/document/d/1k0Ua-ZWlM_PsFCFdLMa8kaVTo32PeNZ4G7FFHqpFx4E/edit">Feature Policy</a> will allow securely relaxing those restrictions once it matures.</p>
    <h4 class="heading settled" data-level="5.1.3" id="losing-focus"><span class="secno">5.1.3. </span><span class="content">Losing Focus</span><a class="self-link" href="#losing-focus"></a></h4>
-   <p>When the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> loses focus,
-or when a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a> of a different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#gain-focus">gains focus</a> (for example when the user carries out an in-game purchase
+   <p>When the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-0">top-level browsing context</a> loses focus,
+or when a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a> of a different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2">origin</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#gain-focus" id="ref-for-gain-focus">gains focus</a> (for example when the user carries out an in-game purchase
 using a third party payment service from within an iframe)
-the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing contexts</a> suddenly becomes in a position
-to carry out a skimming attack against the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> that has <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#gain-focus">gained focus</a>.</p>
-   <p>To mitigate this threat, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-5">readings</a> of <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-12">sensors</a> running in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing contexts</a> are not delivered in such cases.
-A <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-1">security check</a> is run before <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-6">sensor readings</a> are delivered to ensure that.</p>
+the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-1">top-level browsing contexts</a> suddenly becomes in a position
+to carry out a skimming attack against the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a> that has <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#gain-focus" id="ref-for-gain-focus-0">gained focus</a>.</p>
+   <p>To mitigate this threat, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-3">readings</a> of <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-10">sensors</a> running in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-2">top-level browsing contexts</a> are not delivered in such cases.
+A <a data-link-type="dfn" href="#security-check" id="ref-for-security-check">security check</a> is run before <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-4">sensor readings</a> are delivered to ensure that.</p>
    <h4 class="heading settled" data-level="5.1.4" id="visibility-state"><span class="secno">5.1.4. </span><span class="content">Visibility State</span><a class="self-link" href="#visibility-state"></a></h4>
-   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-7">Sensor readings</a> are only available
-in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">browsing contexts</a> that are visible to the user,
-that is, whose <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-steps-to-determine-the-visibility-state">visibility state</a> is "visible".
-A <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-2">security check</a> is run before <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-8">sensor readings</a> are delivered to ensure that.</p>
+   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-5">Sensor readings</a> are only available
+in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-3">browsing contexts</a> that are visible to the user,
+that is, whose <a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dfn-steps-to-determine-the-visibility-state" id="ref-for-dfn-steps-to-determine-the-visibility-state">visibility state</a> is "visible".
+A <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-0">security check</a> is run before <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-6">sensor readings</a> are delivered to ensure that.</p>
    <p class="issue" id="issue-a175b438"><a class="self-link" href="#issue-a175b438"></a> certain use cases require sensors to have background access.
-Using a more complex <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-(e.g. with a boolean <code>allowBackgroundUsage = false</code>; <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary member</a>),
+Using a more complex <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+(e.g. with a boolean <code>allowBackgroundUsage = false</code>; <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member">dictionary member</a>),
 might be the solution to relax this restriction.</p>
    <h4 class="heading settled" data-level="5.1.5" id="permissions"><span class="secno">5.1.5. </span><span class="content">Permissions API</span><span id="permissioning"></span><a class="self-link" href="#permissions"></a></h4>
-   <p>Access to <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-9">sensor readings</a> are controlled by the Permissions API <a data-link-type="biblio" href="#biblio-permissions">[PERMISSIONS]</a>.
-User agents use a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#new-information-about-the-users-intent">number of criteria</a> to grant access to the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-10">readings</a>.
+   <p>Access to <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-7">sensor readings</a> are controlled by the Permissions API <a data-link-type="biblio" href="#biblio-permissions">[PERMISSIONS]</a>.
+User agents use a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#new-information-about-the-users-intent" id="ref-for-new-information-about-the-users-intent">number of criteria</a> to grant access to the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-8">readings</a>.
 Note that access can be granted without prompting the user.</p>
    <h3 class="heading settled" data-level="5.2" id="mitigation-strategies-case-by-case"><span class="secno">5.2. </span><span class="content">Mitigation strategies applied on a case by case basis</span><a class="self-link" href="#mitigation-strategies-case-by-case"></a></h3>
-   <p>Each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-8">sensor type</a> will need to be assessed individually,
+   <p>Each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-6">sensor type</a> will need to be assessed individually,
 taking into account the use cases it enables
 and its particular threat profile.
 While some of the below mitigation strategies
@@ -1885,11 +1885,11 @@ when other APIs which are known to amplify the level of the threat are in use,
 etc.</p>
    <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="5.2.1" data-lt="Limit maximum sampling frequency" data-noexport="" id="limit-max-freqency"><span class="secno">5.2.1. </span><span class="content">Limit maximum sampling frequency</span></h4>
    <p>User agents may mitigate certain threats by
-limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-1">sampling frequency</a>.
-What upper limit to choose depends on the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-9">sensor type</a>,
+limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency">sampling frequency</a>.
+What upper limit to choose depends on the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-7">sensor type</a>,
 the kind of threats the user agent is trying to protect against,
 the expected resources of the attacker, etc.</p>
-   <p>Limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-2">sampling frequency</a> prevents use cases
+   <p>Limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-0">sampling frequency</a> prevents use cases
 which rely on low latency or high data density.</p>
    <h4 class="heading settled" data-dfn-type="dfn" data-level="5.2.2" data-lt="Stopping the sensor altogether" data-noexport="" id="stopping-sensor"><span class="secno">5.2.2. </span><span class="content">Stopping the sensor altogether</span><a class="self-link" href="#stopping-sensor"></a></h4>
    <p>This is obviously a last-resort solution,
@@ -1898,15 +1898,15 @@ for example to prevent password skimming attempts
 when the user is entering credentials on a different origin (<a data-link-type="biblio" href="#biblio-rfc6454">[rfc6454]</a>)
 or in a different application.</p>
    <h4 class="heading settled" data-dfn-type="dfn" data-level="5.2.3" data-lt="Limit number of delivered readings" data-noexport="" id="limit-number-of-delivered-readings"><span class="secno">5.2.3. </span><span class="content">Limit number of delivered readings</span><a class="self-link" href="#limit-number-of-delivered-readings"></a></h4>
-   <p>An alternative to <a data-link-type="dfn" href="#limit-max-freqency" id="ref-for-limit-max-freqency-1">limiting the maximum sampling frequency</a> is to
-limit the number of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-11">sensor readings</a> delivered to Web application developer,
+   <p>An alternative to <a data-link-type="dfn" href="#limit-max-freqency" id="ref-for-limit-max-freqency">limiting the maximum sampling frequency</a> is to
+limit the number of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-9">sensor readings</a> delivered to Web application developer,
 regardless of what frequency the sensor is polled at.
 This allows use cases which have low latency requirement
-to increase <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-3">sampling frequency</a> without increasing the amount of data provided.</p>
+to increase <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-1">sampling frequency</a> without increasing the amount of data provided.</p>
    <p>Discarding intermediary readings prevents certain use cases,
 such as those relying on certain kinds of filters.</p>
    <h4 class="heading settled" data-dfn-type="dfn" data-level="5.2.4" data-lt="Reducing accuracy" data-noexport="" id="reducing-accuracy"><span class="secno">5.2.4. </span><span class="content">Reducing accuracy</span><a class="self-link" href="#reducing-accuracy"></a></h4>
-   <p>Reducing the accuracy of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-12">sensor readings</a> or sensor reading timestamps
+   <p>Reducing the accuracy of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-10">sensor readings</a> or sensor reading timestamps
 might also help mitigate certain threats,
 thus user agents should not provide
 unnecessarily verbose readouts of sensors data.</p>
@@ -1914,32 +1914,32 @@ unnecessarily verbose readouts of sensors data.</p>
 especially when operations carried out on the readings,
 or time deltas calculated from the timestamps,
 increase inaccuracies exponentially.</p>
-   <p class="note" role="note"><span>Note:</span> while adding random bias to <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-13">sensor readings</a> has similar effects,
+   <p class="note" role="note"><span>Note:</span> while adding random bias to <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-11">sensor readings</a> has similar effects,
 it shouldn’t be used in practice
 as it is easy to filter out the added noise.</p>
    <h4 class="heading settled" data-level="5.2.5" id="informing-user"><span class="secno">5.2.5. </span><span class="content">Keeping the user informed about API use</span><a class="self-link" href="#informing-user"></a></h4>
    <p>User agents may choose to keep the user informed
 about current and past use of the API.</p>
-   <p class="note" role="note"><span>Note:</span> this does not imply keeping a log of the actual <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-14">sensor readings</a> which would have issues of its own.</p>
+   <p class="note" role="note"><span>Note:</span> this does not imply keeping a log of the actual <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-12">sensor readings</a> which would have issues of its own.</p>
    <h2 class="heading settled" data-level="6" id="concepts"><span class="secno">6. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="concepts-sensors"><span class="secno">6.1. </span><span class="content">Sensors</span><a class="self-link" href="#concepts-sensors"></a></h3>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-13">sensor</a> measures different physical quantities
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-11">sensor</a> measures different physical quantities
 and provide corresponding <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="raw-sensor-readings">raw sensor readings</dfn> which are a source of information about the user and their environment.</p>
-   <p>Each <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-1">reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the different physical quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-14">sensor</a> at time <var>t<sub>n</sub></var>.</p>
-   <p>Known, <em>predictable</em> discrepancies between <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-2">raw sensor readings</a> and the corresponding physical quantities being measured
+   <p>Each <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings">reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the different physical quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-12">sensor</a> at time <var>t<sub>n</sub></var>.</p>
+   <p>Known, <em>predictable</em> discrepancies between <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-0">raw sensor readings</a> and the corresponding physical quantities being measured
 are corrected through <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="calibration">calibration</dfn>.</p>
    <p>Known but <em>unpredictable</em> discrepancies need to be addressed dynamically
-through a process called <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-1">sensor fusion</a>.</p>
-   <p><a data-link-type="dfn" href="#calibration" id="ref-for-calibration-1">Calibrated</a> <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-3">raw sensor readings</a> are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-readings">sensor readings</dfn>,
-whether or not they have undergone <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-2">sensor fusion</a>.</p>
+through a process called <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion">sensor fusion</a>.</p>
+   <p><a data-link-type="dfn" href="#calibration" id="ref-for-calibration">Calibrated</a> <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings-1">raw sensor readings</a> are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-readings">sensor readings</dfn>,
+whether or not they have undergone <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-0">sensor fusion</a>.</p>
    <h3 class="heading settled" data-level="6.2" id="concepts-sensor-types"><span class="secno">6.2. </span><span class="content">Sensor Types</span><a class="self-link" href="#concepts-sensor-types"></a></h3>
-   <p>Different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-10">sensor types</a> measure different physical quantities
+   <p>Different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-8">sensor types</a> measure different physical quantities
 such as temperature, air pressure, heart-rate, or luminosity.</p>
-   <p>For the purpose of this specification we distinguish between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-2">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-2">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-11">sensor types</a>.</p>
-   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-12">Sensor types</a> which are characterized by their implementation
+   <p>For the purpose of this specification we distinguish between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-0">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-0">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-9">sensor types</a>.</p>
+   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-10">Sensor types</a> which are characterized by their implementation
 are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="low-level">low-level</dfn> sensors.
-For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-3">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-13">sensor type</a>.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-15">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-15">readings</a>,
+For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-1">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-11">sensor type</a>.</p>
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-13">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-13">readings</a>,
 regardless of the implementation,
 are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-level">high-level</dfn> sensors.
 For instance, geolocation sensors provide information about the user’s location,
@@ -1947,34 +1947,34 @@ but the precise means by which this data is obtained
 is purposefully left opaque
 (it could come from a GPS chip, network cell triangulation,
 wifi networks, etc. or any combination of the above)
-and depends on various, implementation-specific heuristics. <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-3">High-level</a> sensors are generally the fruits of
-applying algorithms to <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-4">low-level</a> sensors—<wbr>for example, a pedometer can be built using only the output of a gyroscope—<wbr>or of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-3">sensor fusion</a>.</p>
-   <p>That said, the distinction between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-4">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-5">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-14">sensor types</a> is somewhat arbitrary and the line between the two is often blurred.
+and depends on various, implementation-specific heuristics. <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-1">High-level</a> sensors are generally the fruits of
+applying algorithms to <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-2">low-level</a> sensors—<wbr>for example, a pedometer can be built using only the output of a gyroscope—<wbr>or of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-1">sensor fusion</a>.</p>
+   <p>That said, the distinction between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-2">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-3">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-12">sensor types</a> is somewhat arbitrary and the line between the two is often blurred.
 For instance, a barometer, which measures air pressure,
-would be considered <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-6">low-level</a> for most common purposes,
-even though it is the product of the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-4">sensor fusion</a> of
+would be considered <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-4">low-level</a> for most common purposes,
+even though it is the product of the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-2">sensor fusion</a> of
 resistive piezo-electric pressure and temperature sensors.
 Exposing the sensors that compose it would serve no practical purpose;
 who cares about the temperature of a piezo-electric sensor?
 A pressure-altimeter would probably fall in the same category,
-while a nondescript altimeter—<wbr>which could get its data from either a barometer or a GPS signal—<wbr>would clearly be categorized as a <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-5">high-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-15">sensor type</a>.</p>
+while a nondescript altimeter—<wbr>which could get its data from either a barometer or a GPS signal—<wbr>would clearly be categorized as a <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-3">high-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-13">sensor type</a>.</p>
    <p>Because the distinction is somewhat blurry,
 extensions to this specification (see <a href="#extensibility">§10 Extensibility</a>)
-are encouraged to provide domain-specific definitions of <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-6">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-7">low-level</a> sensors
-for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-16">sensor types</a> they are targeting.</p>
-   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-16">Sensor readings</a> from different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-17">sensor types</a> can be combined together
+are encouraged to provide domain-specific definitions of <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-4">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-5">low-level</a> sensors
+for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-14">sensor types</a> they are targeting.</p>
+   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-14">Sensor readings</a> from different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-15">sensor types</a> can be combined together
 through a process called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-fusion">sensor fusion</dfn>.
-This process provides <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-7">higher-level</a> or
+This process provides <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-5">higher-level</a> or
 more accurate data (often at the cost of increased latency).
-For example, the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-17">readings</a> of a three-axis magnetometer
-needs to be combined with the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-18">readings</a> of an accelerometer
+For example, the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-15">readings</a> of a three-axis magnetometer
+needs to be combined with the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-16">readings</a> of an accelerometer
 to provide a correct bearing.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="smart-sensors">Smart sensors</dfn> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-hubs">sensor hubs</dfn> have built-in compute resources which allow them
-to carry out <a data-link-type="dfn" href="#calibration" id="ref-for-calibration-2">calibration</a> and <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-5">sensor fusion</a> at the hardware level,
+to carry out <a data-link-type="dfn" href="#calibration" id="ref-for-calibration-0">calibration</a> and <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-3">sensor fusion</a> at the hardware level,
 freeing up CPU resources
 and lowering battery consumption
 in the process.</p>
-   <p>But <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-6">sensor fusion</a> can also be carried out in software.
+   <p>But <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-4">sensor fusion</a> can also be carried out in software.
 This is particularly useful when performance requirements can only be met
 by relying on application-specific data.
 For example, head tracking for virtual or augmented reality applications
@@ -1984,39 +1984,39 @@ That low-latency is best provided
 by using the raw output of a gyroscope
 and waiting for quick rotational movements of the head
 to compensate for drift.</p>
-   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-16">sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-7">sensor fusion</a> are sometimes
+   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-14">sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion-5">sensor fusion</a> are sometimes
 called virtual or synthetic sensors.
 However, the specification doesn’t make any practical differences between them,
-preferring instead to differentiate <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-17">sensors</a> as to whether they describe
-the kind of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-19">readings</a> produced--these are <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-8">high-level</a> sensors—<wbr>or how the sensor is implemented (<a data-link-type="dfn" href="#low-level" id="ref-for-low-level-8">low-level</a> sensors).</p>
+preferring instead to differentiate <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-15">sensors</a> as to whether they describe
+the kind of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-17">readings</a> produced--these are <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-6">high-level</a> sensors—<wbr>or how the sensor is implemented (<a data-link-type="dfn" href="#low-level" id="ref-for-low-level-6">low-level</a> sensors).</p>
    <h3 class="heading settled" data-level="6.3" id="concepts-reporting-modes"><span class="secno">6.3. </span><span class="content">Reporting Modes</span><a class="self-link" href="#concepts-reporting-modes"></a></h3>
    <p class="issue" id="issue-f240c7ff"><a class="self-link" href="#issue-f240c7ff"></a> <strong>This feature is at risk.</strong> It is not clear whether there is value
-in splitting up <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-18">sensor types</a> between
+in splitting up <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-16">sensor types</a> between
 those that fire events at regular intervals
 and those which don’t.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-18">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
-When <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-20">sensor readings</a> are reported at regular intervals,
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-16">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
+When <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-18">sensor readings</a> are reported at regular intervals,
 at an adjustable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frequency">frequency</dfn> measured in hertz (Hz),
-the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-2">reporting mode</a> is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic">periodic</dfn>.
-On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-19">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-2">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-3">periodic reporting mode</a> is triggered
-by requesting a specific <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-1">frequency</a>.</p>
-   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-20">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-4">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
-When the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-3">reporting mode</a> is <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-1">implementation specific</a>, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-21">sensor readings</a> may be provided at regular intervals, irregularly,
-or only when a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-22">reading</a> change is observed.
+the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-0">reporting mode</a> is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic">periodic</dfn>.
+On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-17">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-0">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-1">periodic reporting mode</a> is triggered
+by requesting a specific <a data-link-type="dfn" href="#frequency" id="ref-for-frequency">frequency</a>.</p>
+   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-18">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-2">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
+When the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-1">reporting mode</a> is <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific">implementation specific</a>, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-19">sensor readings</a> may be provided at regular intervals, irregularly,
+or only when a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-20">reading</a> change is observed.
 This allows user agents more latitude to
 carry out power- or CPU-saving strategies,
-and support multiple hardware configurations. <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-5">Periodic reporting mode</a>, on the other hand,
+and support multiple hardware configurations. <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-3">Periodic reporting mode</a>, on the other hand,
 allows a much more fine-grained approach
 and is essential for use cases with, for example,
 low latency requirements.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-19">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-6">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-2">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-2">frequency</a> they should operate at.</p>
-   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-4">reporting mode</a> is distinct from,
-but related to, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-23">sensor readings</a> acquisition.
-If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-20">sensors</a> are polled at regular interval,
-as is generally the case, <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-5">reporting mode</a> can be either <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-7">periodic</a> or <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-3">implementation specific</a>.
-However, when the underlying implementation itself only provides <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-24">sensor readings</a> when it measures change,
-perhaps because is is relying on <a data-link-type="dfn" href="#smart-sensors" id="ref-for-smart-sensors-1">smart sensors</a> or a <a data-link-type="dfn" href="#sensor-hubs" id="ref-for-sensor-hubs-1">sensor hubs</a>,
-the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-6">reporting mode</a> cannot be <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-8">periodic</a>,
+   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-17">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-4">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-0">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-0">frequency</a> they should operate at.</p>
+   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-2">reporting mode</a> is distinct from,
+but related to, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-21">sensor readings</a> acquisition.
+If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-18">sensors</a> are polled at regular interval,
+as is generally the case, <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-3">reporting mode</a> can be either <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-5">periodic</a> or <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific-1">implementation specific</a>.
+However, when the underlying implementation itself only provides <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-22">sensor readings</a> when it measures change,
+perhaps because is is relying on <a data-link-type="dfn" href="#smart-sensors" id="ref-for-smart-sensors">smart sensors</a> or a <a data-link-type="dfn" href="#sensor-hubs" id="ref-for-sensor-hubs">sensor hubs</a>,
+the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes-4">reporting mode</a> cannot be <a data-link-type="dfn" href="#periodic" id="ref-for-periodic-6">periodic</a>,
 as that would require data inference.</p>
    <p class="issue" id="issue-ac15beaf"><a class="self-link" href="#issue-ac15beaf"></a> This lacks a description of
 the different data acquisition modes,
@@ -2029,85 +2029,85 @@ how increased sensor sampling frequency decreases latency.</p>
 how it affects threshold,
 and thus "on change" sensors would be useful.</p>
    <h3 class="heading settled" data-level="6.4" id="concepts-sampling-frequency"><span class="secno">6.4. </span><span class="content">Sampling Frequency</span><a class="self-link" href="#concepts-sampling-frequency"></a></h3>
-   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a> is defined
-as a frequency at which the UA obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor readings</a> from the underlying platform.</p>
+   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-19">sensor</a> is defined
+as a frequency at which the UA obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-23">sensor readings</a> from the underlying platform.</p>
    <h2 class="heading settled" data-level="7" id="model"><span class="secno">7. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p class="issue" id="issue-d36d1a2e"><a class="self-link" href="#issue-d36d1a2e"></a> A diagram would really help here.</p>
    <h3 class="heading settled" data-level="7.1" id="model-sensor-type"><span class="secno">7.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-3">Sensor</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-21">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
-   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a>,
-it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> objects.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-23">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-24">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
-   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-25">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-26">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm">permission revocation algorithm</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-1">Sensor</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-19">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
+   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-20">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-20">sensor</a>,
+it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-21">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-2">Sensor</a></code> objects.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-21">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-22">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code>.</p>
+   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-23">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname-0">PermissionName</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-24">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
    <div class="algorithm" data-algorithm="permission revocation algorithm">
-    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
+    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname-1">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
     <ol>
      <li data-md="">
-      <p>For each <var>sensor_type</var> which has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> <var>permission_name</var>:</p>
+      <p>For each <var>sensor_type</var> which has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname-2">PermissionName</a></code> <var>permission_name</var>:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>sensor</var> in <var>sensor_type</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#associated-sensors" id="ref-for-associated-sensors-1">associated sensors</a>,</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>sensor</var> in <var>sensor_type</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set-0">set</a> of <a data-link-type="dfn" href="#associated-sensors" id="ref-for-associated-sensors">associated sensors</a>,</p>
         <ol>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#revoke-sensor-permission" id="ref-for-revoke-sensor-permission-1">revoke sensor permission</a> with <var>sensor</var> as argument.</p>
+          <p>Invoke <a data-link-type="dfn" href="#revoke-sensor-permission" id="ref-for-revoke-sensor-permission">revoke sensor permission</a> with <var>sensor</var> as argument.</p>
         </ol>
       </ol>
     </ol>
    </div>
    <h3 class="heading settled" data-level="7.2" id="model-sensor"><span class="secno">7.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
-This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a>.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">sensor readings</a>.</p>
-   <p>Any time the UA obtains a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-27">sensor reading</a> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a> from the underlying platform,
-it invokes <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading-1">update latest reading</a> with the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-26">sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-28">sensor reading</a> as arguments.</p>
-   <p class="issue" id="issue-504d2531"><a class="self-link" href="#issue-504d2531"></a> does the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-1">latest reading</a> map need to be
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set-1">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
+This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-22">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-24">sensor readings</a>.</p>
+   <p>Any time the UA obtains a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-25">sensor reading</a> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-23">sensor</a> from the underlying platform,
+it invokes <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> with the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-24">sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-26">sensor reading</a> as arguments.</p>
+   <p class="issue" id="issue-504d2531"><a class="self-link" href="#issue-504d2531"></a> does the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> map need to be
 tied to an origin?</p>
-   <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-2">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "timestamp" and
-whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> is a high resolution timestamp of the time
-at which the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-3">latest reading</a> was obtained
-expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>. <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-4">latest reading</a>["timestamp"] is initially set to null,
-unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-5">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-29">reading</a>.</p>
-   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-6">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a>.
-The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> must match
-the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> defined by
-the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-27">sensor type</a>'s associated interface.
-The return value of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> getter is
-easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-1">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-28">sensor type</a>'s associated interface
-and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> as arguments.</p>
-   <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-7">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> is initially set to null.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-28">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
-   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-1">activated sensor objects</a> the <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-1">current sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
-by the UA taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-1">desired sampling frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-2">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-4">sampling frequency</a> bounds defined
+   <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-0">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map-0">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is "timestamp" and
+whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> is a high resolution timestamp of the time
+at which the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-1">latest reading</a> was obtained
+expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin">time origin</a>. <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-2">latest reading</a>["timestamp"] is initially set to null,
+unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-3">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map-1">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-27">reading</a>.</p>
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry-0">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-4">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map-2">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-25">sensor</a>.
+The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key-0">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry-1">entries</a> must match
+the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier">identifier</a> defined by
+the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-25">sensor type</a>'s associated interface.
+The return value of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute-0">attribute</a> getter is
+easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-26">sensor type</a>'s associated interface
+and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute-1">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier-0">identifier</a> as arguments.</p>
+   <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value-0">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-5">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry-2">entries</a> is initially set to null.</p>
+   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-26">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
+   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty-0">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set-2">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> the <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency">current sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
+by the UA taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot">desired sampling frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-0">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-3">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-2">sampling frequency</a> bounds defined
 by the underlying platform.</p>
-   <p class="note" role="note"><span>Note:</span> For example, the UA may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency-1">optimal sampling frequency</a> as a Least Common Denominator
-(LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-2">desired sampling frequencies</a></code> capped by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-5">sampling frequency</a> bounds defined by the underlying platform.</p>
+   <p class="note" role="note"><span>Note:</span> For example, the UA may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency">optimal sampling frequency</a> as a Least Common Denominator
+(LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-0">desired sampling frequencies</a></code> capped by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-3">sampling frequency</a> bounds defined by the underlying platform.</p>
    <h2 class="heading settled" data-level="8" id="api"><span class="secno">8. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="8.1" id="the-sensor-interface"><span class="secno">8.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensor"><code>Sensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-sensor-activated"><code>activated</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMHighResTimeStamp?" id="dom-sensor-timestamp"><code>timestamp</code></dfn>;
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensor"><code>Sensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget">EventTarget</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-sensor-activated"><code>activated</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp">DOMHighResTimeStamp</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMHighResTimeStamp?" id="dom-sensor-timestamp"><code>timestamp</code></dfn>;
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="start()" id="dom-sensor-start"><code>start</code></dfn>();
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="stop()" id="dom-sensor-stop"><code>stop</code></dfn>();
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onreading"><code>onreading</code></dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onactivate"><code>onactivate</code></dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onerror"><code>onerror</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onreading"><code>onreading</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onactivate"><code>onactivate</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-1">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onerror"><code>onerror</code></dfn>;
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensoroptions"><code>SensorOptions</code></dfn> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-29">sensor</a>.</p>
-   <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-4">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-27">sensor</a>.</p>
+   <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
    <div class="example" id="example-b77a6b87">
-    <a class="self-link" href="#example-b77a6b87"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event">events</a> for <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a> activation, error
-    conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-30">sensor readings</a>. The example measures
-    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a>. 
-    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
+    <a class="self-link" href="#example-b77a6b87"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-28">sensor</a> activation, error
+    conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-28">sensor readings</a>. The example measures
+    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-29">sensor</a>. 
+    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
 <pre class="highlight"><span class="kd">let</span> acl <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">30</span><span class="p">});</span>
 <span class="kd">let</span> max_magnitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'activate'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Ready to measure.'</span><span class="p">));</span>
@@ -2193,10 +2193,10 @@ acl<span class="p">.</span>start<span class="p">();</span>
      </g>
     </g>
    </svg>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> object is eligible for garbage collection, the user agent must
-invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object-1">deactivate a sensor object</a> with this object as argument.</p>
+   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-5">Sensor</a></code> object is eligible for garbage collection, the user agent must
+invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor object</a> with this object as argument.</p>
    <h4 class="heading settled" data-level="8.1.2" id="sensor-internal-slots"><span class="secno">8.1.2. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
-   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> are created
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-6">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
    <table class="vert data" id="sensor-slots">
     <thead>
@@ -2206,115 +2206,115 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object which is one of
+      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-7">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
                 It is initially "idle". 
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-desiredsamplingfrequency-slot"><code>[[desiredSamplingFrequency]]</code></dfn>
-      <td>The requested <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-6">sampling frequency</a>. It is initially unset.
+      <td>The requested <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency-4">sampling frequency</a>. It is initially unset.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-31">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code> object,
-                expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin">time origin</a>.
+      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-29">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-8">Sensor</a></code> object,
+                expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin-0">time origin</a>.
                 It is initially null. 
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-pendingreadingnotification-slot"><code>[[pendingReadingNotification]]</code></dfn>
       <td>A boolean which indicates whether the observers need to be
-                notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-32">sensor reading</a> was reported.
+                notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-30">sensor reading</a> was reported.
                 It is initially false.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-identifyingparameters-slot"><code>[[identifyingParameters]]</code></dfn>
-      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-29">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-32">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> object. 
+      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-27">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member-0">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-30">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-9">Sensor</a></code> object. 
    </table>
    <h4 class="heading settled" data-level="8.1.3" id="sensor-activated"><span class="secno">8.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
-    <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-activated" id="ref-for-dom-sensor-activated-1">activated</a></code> attribute must run these steps:</p>
+    <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-activated" id="ref-for-dom-sensor-activated">activated</a></code> attribute must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If <emu-val>this</emu-val>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-1">[[state]]</a></code> is "activated",
+      <p>If <emu-val>this</emu-val>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot">[[state]]</a></code> is "activated",
   return true.</p>
      <li data-md="">
       <p>Otherwise, return false.</p>
     </ol>
    </div>
    <h4 class="heading settled" data-level="8.1.4" id="sensor-timestamp"><span class="secno">8.1.4. </span><span class="content">Sensor.timestamp</span><a class="self-link" href="#sensor-timestamp"></a></h4>
-   <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-1">timestamp</a></code> attribute returns
-the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-2">get value from latest reading</a> with <emu-val>this</emu-val> and "timestamp" as arguments.</p>
+   <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp">timestamp</a></code> attribute returns
+the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-0">get value from latest reading</a> with <emu-val>this</emu-val> and "timestamp" as arguments.</p>
    <h4 class="heading settled" data-level="8.1.5" id="sensor-start"><span class="secno">8.1.5. </span><span class="content">Sensor.start()</span><a class="self-link" href="#sensor-start"></a></h4>
    <div class="algorithm" data-algorithm="to start a sensor">
-    <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-start" id="ref-for-dom-sensor-start-1">start()</a></code> method must run these steps:</p>
+    <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-start" id="ref-for-dom-sensor-start">start()</a></code> method must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor_state</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-2">[[state]]</a></code>.</p>
+      <p>Let <var>sensor_state</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-0">[[state]]</a></code>.</p>
      <li data-md="">
       <p>If <var>sensor_state</var> is either "activating"
   or "activated", then return.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-3">[[state]]</a></code> to "activating".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-1">[[state]]</a></code> to "activating".</p>
      <li data-md="">
-      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>let <var>connected</var> be the result of invoking <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor-1">connect to sensor</a>.</p>
+        <p>let <var>connected</var> be the result of invoking <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor">connect to sensor</a>.</p>
        <li data-md="">
         <p>If <var>connected</var> is false, then</p>
         <ol>
          <li data-md="">
-          <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating</a> a
-  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+          <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception">creating</a> a
+  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notreadableerror" id="ref-for-notreadableerror">NotReadableError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
          <li data-md="">
-          <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error-1">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
+          <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
          <li data-md="">
           <p>Return.</p>
         </ol>
        <li data-md="">
-        <p>Let <var>permission_state</var> be the result of invoking <a data-link-type="dfn" href="#request-sensor-access" id="ref-for-request-sensor-access-1">request sensor access</a> with <var>sensor_instance</var> as argument.</p>
+        <p>Let <var>permission_state</var> be the result of invoking <a data-link-type="dfn" href="#request-sensor-access" id="ref-for-request-sensor-access">request sensor access</a> with <var>sensor_instance</var> as argument.</p>
        <li data-md="">
         <p>If <var>permission_state</var> is "granted",</p>
         <ol>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#activate-a-sensor-object" id="ref-for-activate-a-sensor-object-1">activate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
+          <p>Invoke <a data-link-type="dfn" href="#activate-a-sensor-object" id="ref-for-activate-a-sensor-object">activate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
         </ol>
        <li data-md="">
         <p>Otherwise, if <var>permission_state</var> is "denied",</p>
         <ol>
          <li data-md="">
-          <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+          <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception-0">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException-0">DOMException</a></code>.</p>
          <li data-md="">
-          <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error-2">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
+          <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error-0">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
         </ol>
       </ol>
     </ol>
    </div>
    <h4 class="heading settled" data-level="8.1.6" id="sensor-stop"><span class="secno">8.1.6. </span><span class="content">Sensor.stop()</span><a class="self-link" href="#sensor-stop"></a></h4>
    <div class="algorithm" data-algorithm="to stop a sensor">
-    <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-stop" id="ref-for-dom-sensor-stop-1">stop()</a></code> method must run these steps:</p>
+    <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-stop" id="ref-for-dom-sensor-stop">stop()</a></code> method must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-4">[[state]]</a></code> is "idle", then return.</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-2">[[state]]</a></code> is "idle", then return.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-5">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-3">[[state]]</a></code> to "idle".</p>
      <li data-md="">
-      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel-0">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object-2">deactivate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
+        <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object-0">deactivate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
       </ol>
     </ol>
    </div>
    <h4 class="heading settled" data-level="8.1.7" id="sensor-onreading"><span class="secno">8.1.7. </span><span class="content">Sensor.onreading</span><a class="self-link" href="#sensor-onreading"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading-1">onreading</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called
-to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-33">reading</a> is available.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading">onreading</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-2">EventHandler</a></code> which is called
+to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-31">reading</a> is available.</p>
    <h4 class="heading settled" data-level="8.1.8" id="sensor-onactivate"><span class="secno">8.1.8. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate-1">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called when <emu-val>this</emu-val>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-6">[[state]]</a></code> transitions from "activating" to "activated".</p>
+   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-3">EventHandler</a></code> which is called when <emu-val>this</emu-val>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-4">[[state]]</a></code> transitions from "activating" to "activated".</p>
    <h4 class="heading settled" data-level="8.1.9" id="sensor-onerror"><span class="secno">8.1.9. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onerror" id="ref-for-dom-sensor-onerror-1">onerror</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a></code> which is called whenever
-an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type">exception</a> cannot be handled synchronously.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onerror" id="ref-for-dom-sensor-onerror">onerror</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-4">EventHandler</a></code> which is called whenever
+an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type" id="ref-for-dfn-exception-type">exception</a> cannot be handled synchronously.</p>
    <h4 class="heading settled" data-level="8.1.10" id="event-handlers"><span class="secno">8.1.10. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
-   <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-12">Sensor</a></code> interface:</p>
+   <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers-0">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type-0">event handler event types</a>)
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-10">Sensor</a></code> interface:</p>
    <table class="def">
     <thead>
      <tr>
@@ -2332,58 +2332,58 @@ that must be supported as attributes by the objects implementing the <code class
       <td><code>error</code>
    </table>
    <h3 class="heading settled" data-level="8.2" id="the-sensor-error-event-interface"><span class="secno">8.2. </span><span class="content">The SensorErrorEvent Interface</span><a class="self-link" href="#the-sensor-error-event-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="constructor" data-export="" data-lt="SensorErrorEvent(type, errorEventInitDict)" id="dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-1">SensorErrorEventInit</a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensorerrorevent"><code>SensorErrorEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error"><span class="kt">Error</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Error" id="dom-sensorerrorevent-error"><code>error</code></dfn>;
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext-0">SecureContext</a>, <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="constructor" data-export="" data-lt="SensorErrorEvent(type, errorEventInitDict)" id="dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit">SensorErrorEventInit</a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensorerrorevent"><code>SensorErrorEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error" id="ref-for-idl-Error"><span class="kt">Error</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Error" id="dom-sensorerrorevent-error"><code>error</code></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error"><span class="kt">Error</span></a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEventInit" data-dfn-type="dict-member" data-export="" data-type="Error " id="dom-sensorerroreventinit-error"><code>error</code><a class="self-link" href="#dom-sensorerroreventinit-error"></a></dfn>;
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit">EventInit</a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error" id="ref-for-idl-Error-0"><span class="kt">Error</span></a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEventInit" data-dfn-type="dict-member" data-export="" data-type="Error " id="dom-sensorerroreventinit-error"><code>error</code><a class="self-link" href="#dom-sensorerroreventinit-error"></a></dfn>;
 };
 </pre>
    <h4 class="heading settled" data-level="8.2.1" id="sensor-error-event-error"><span class="secno">8.2.1. </span><span class="content">SensorErrorEvent.error</span><a class="self-link" href="#sensor-error-event-error"></a></h4>
-   <p>Gets the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Error">Error</a></code> object passed to <code class="idl"><a data-link-type="idl" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-2">SensorErrorEventInit</a></code>.</p>
+   <p>Gets the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Error" id="ref-for-idl-Error-1">Error</a></code> object passed to <code class="idl"><a data-link-type="idl" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-0">SensorErrorEventInit</a></code>.</p>
    <h2 class="heading settled" data-level="9" id="abstract-operations"><span class="secno">9. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="9.1" data-lt="Construct sensor object" id="construct-sensor-object"><span class="secno">9.1. </span><span class="content">Construct sensor object</span><a class="self-link" href="#construct-sensor-object"></a></h3>
    <div class="algorithm" data-algorithm="construct sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-1">SensorOptions</a></code> object.</p>
+      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-11">Sensor</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, then:</p>
+      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object" id="ref-for-incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context-0">secure context</a>, then:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>, then:</p>
+      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context-0">browsing context</a> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-4">top-level browsing context</a>, then:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>.</p>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw-0">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror-0">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-12">Sensor</a></code> object,</p>
      <li data-md="">
-      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>, then</p>
+      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-3">[[desiredSamplingFrequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-2">frequency</a></code>.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-1">[[desiredSamplingFrequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-0">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-3">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-3">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-15">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-2">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency-1">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-1">frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-13">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp-0">timestamp</a></code> attributes.</p>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-1">identifying parameters</a> in <var>options</var> are set, then:</p>
+      <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters">identifying parameters</a> in <var>options</var> are set, then:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-1">[[identifyingParameters]]</a></code> to <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-2">identifying parameters</a>.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot">[[identifyingParameters]]</a></code> to <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-0">identifying parameters</a>.</p>
       </ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-7">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-5">[[state]]</a></code> to "idle".</p>
      <li data-md="">
       <p>Return <var>sensor_instance</var>.</p>
     </ol>
@@ -2393,29 +2393,29 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-16">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-14">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-31">sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-2">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-3">[[identifyingParameters]]</a></code> allows
-  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a> to be identified, then:</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-0">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot-1">[[identifyingParameters]]</a></code> allows
+  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-32">sensor</a> to be identified, then:</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a>,</p>
+        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-33">sensor</a>,</p>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a> on the device, then</p>
+      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-28">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-34">sensor</a> on the device, then</p>
       <ol>
        <li data-md="">
-        <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-2">default sensor</a>.</p>
+        <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-0">default sensor</a>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
@@ -2428,20 +2428,20 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-15">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-35">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-3">activated sensor objects</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-1">activated sensor objects</a>.</p>
      <li data-md="">
-      <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings-1">set sensor settings</a> with <var>sensor</var> as argument.</p>
+      <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings">set sensor settings</a> with <var>sensor</var> as argument.</p>
      <li data-md="">
-      <p>Queue a task to run <a data-link-type="dfn" href="#notify-activated-state" id="ref-for-notify-activated-state-1">notify activated state</a> with <var>sensor_instance</var> as an argument.</p>
+      <p>Queue a task to run <a data-link-type="dfn" href="#notify-activated-state" id="ref-for-notify-activated-state">notify activated state</a> with <var>sensor_instance</var> as an argument.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.4" data-lt="Deactivate a sensor object" data-noexport="" id="deactivate-a-sensor-object"><span class="secno">9.4. </span><span class="content">Deactivate a sensor object</span></h3>
@@ -2449,28 +2449,28 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-16">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-task-queue">task queue</a> associated
-  with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source-1">sensor task source</a>.</p>
+      <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task-0">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue">task queue</a> associated
+  with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-36">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <var>sensor_instance</var>,</p>
+      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-2">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>sensor_instance</var>,</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated sensor objects</a>.</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-3">activated sensor objects</a>.</p>
        <li data-md="">
-        <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings-2">set sensor settings</a> with <var>sensor</var> as argument.</p>
+        <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings-0">set sensor settings</a> with <var>sensor</var> as argument.</p>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-1">[[pendingReadingNotification]]</a></code> to false.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a></code> to false.</p>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot-1">[[lastEventFiredAt]]</a></code> to null.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a></code> to null.</p>
       </ol>
     </ol>
    </div>
@@ -2479,23 +2479,23 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-37">sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-6">activated sensor objects</a>.</p>
+      <p>let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set-3">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-4">activated sensor objects</a>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>s</var> of <var>activated_sensors</var>,</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate-0">For each</a> <var>s</var> of <var>activated_sensors</var>,</p>
       <ol>
        <li data-md="">
-        <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object-3">deactivate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
+        <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object-1">deactivate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
        <li data-md="">
-        <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+        <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception-1">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror-0">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException-1">DOMException</a></code>.</p>
        <li data-md="">
-        <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error-3">notify error</a> with <var>e</var> and <var>s</var> as arguments.</p>
+        <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error-1">notify error</a> with <var>e</var> and <var>s</var> as arguments.</p>
       </ol>
     </ol>
    </div>
@@ -2504,30 +2504,30 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-38">sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-7">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>,</p>
+      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects-5">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty-1">is empty</a>,</p>
       <ol>
        <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-2">current sampling frequency</a> to null.</p>
+        <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-0">current sampling frequency</a> to null.</p>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-8">latest reading</a>.</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-6">latest reading</a>.</p>
         <ol>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-9">latest reading</a>[<var>key</var>] to null.</p>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-7">latest reading</a>[<var>key</var>] to null.</p>
         </ol>
        <li data-md="">
-        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-34">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-35">readings</a>.</p>
+        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-32">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-33">readings</a>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
      <li data-md="">
-      <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-3">current sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency-2">optimal sampling frequency</a>.</p>
+      <p>Set <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-1">current sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency-0">optimal sampling frequency</a>.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.7" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">9.7. </span><span class="content">Update latest reading</span></h3>
@@ -2535,9 +2535,9 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-39">sensor</a>.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-36">sensor reading</a>.</p>
+      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-34">sensor reading</a>.</p>
     </dl>
     <p class="issue" id="issue-d62b5d37"><a class="self-link" href="#issue-d62b5d37"></a> The timestamp needs to be specified more precisely,
     see <a href="https://github.com/w3c/sensors/issues/155">issue #155</a>.</p>
@@ -2548,7 +2548,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>If the result of invoking the <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-3">security check</a> is "insecure",
+      <p>If the result of invoking the <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-1">security check</a> is "insecure",
   then return.</p>
       <div class="issue no-marker" id="issue-d41d8cd9">
        <a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/w3c/sensors/issues/223">Issue #223 on GitHub: “Should a "suspended" state be added”</a>
@@ -2563,23 +2563,23 @@ that must be supported as attributes by the objects implementing the <code class
        </ul>
       </div>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-10">latest reading</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate-0">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-8">latest reading</a>.</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-11">latest reading</a>[<var>key</var>] to the corresponding
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set-0">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-9">latest reading</a>[<var>key</var>] to the corresponding
   value of <var>reading</var>.</p>
       </ol>
       <p class="issue" id="issue-0a097748"><a class="self-link" href="#issue-0a097748"></a> Maybe compare <var>value</var> with corresponding
   value of <var>reading</var> to see if there’s a change
   that needs to be propagated.</p>
      <li data-md="">
-      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel-1">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate">For each</a> <var>s</var> in <var>activated_sensors</var>,</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate-1">For each</a> <var>s</var> in <var>activated_sensors</var>,</p>
         <ol>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#report-latest-reading-updated" id="ref-for-report-latest-reading-updated-1">report latest reading updated</a> with <var>s</var> as an argument.</p>
+          <p>Invoke <a data-link-type="dfn" href="#report-latest-reading-updated" id="ref-for-report-latest-reading-updated">report latest reading updated</a> with <var>s</var> as an argument.</p>
         </ol>
       </ol>
     </ol>
@@ -2596,7 +2596,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>document</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>.</p>
+      <p>Let <var>document</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-5">top-level browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>.</p>
      <li data-md="">
       <p>Let <var>current_visibility_state</var> be the result of running
   the [= steps to determine the visibility state=] of <var>document</var>.</p>
@@ -2604,16 +2604,16 @@ that must be supported as attributes by the objects implementing the <code class
       <p>If <var>current_visibility_state</var> is not "visible",
   then return "insecure".</p>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">currently focused area</a> of the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">same origin-domain</a> as <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>,
+      <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context" id="ref-for-currently-focused-area-of-a-top-level-browsing-context">currently focused area</a> of the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context-6">top-level browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context-0">nested browsing context</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document-0">active document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2-0">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a> as <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2-1">origin</a>,
   then return "insecure".</p>
      <li data-md="">
-      <p>Let <var>has_focus</var> be the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a> with <var>document</var> as argument.</p>
+      <p>Let <var>has_focus</var> be the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps" id="ref-for-has-focus-steps">has focus steps</a> with <var>document</var> as argument.</p>
      <li data-md="">
       <p>If <var>has_focus</var> is false, then return "insecure".</p>
      <li data-md="">
       <p>If the user agent loses focus, then return "insecure".</p>
-      <div class="issue no-marker" id="issue-d41d8cd90">
-       <a class="self-link" href="#issue-d41d8cd90"></a><a class="marker" href="https://github.com/whatwg/html/issues/2716">Issue #2716 on GitHub: “Focus state is unspecified when user agent itself loses focus.”</a>
+      <div class="issue no-marker" id="issue-d41d8cd9-0">
+       <a class="self-link" href="#issue-d41d8cd9-0"></a><a class="marker" href="https://github.com/whatwg/html/issues/2716">Issue #2716 on GitHub: “Focus state is unspecified when user agent itself loses focus.”</a>
        <p>This makes it difficult to normatively stop certain behaviors (such as collecting sensor readings) when the app is unfocused but stays visible.</p>
        <p>This can notably allow PIN skimming attacks using sensors.</p>
       </div>
@@ -2622,29 +2622,29 @@ that must be supported as attributes by the objects implementing the <code class
     </ol>
    </div>
    <p class="note" role="note"><span>Note:</span> user agents are encouraged to stop sensor sampling
-when <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-4">security check</a> would return "insecure"
+when <a data-link-type="dfn" href="#security-check" id="ref-for-security-check-2">security check</a> would return "insecure"
 in order to reduce resource consumption, notably battery usage.</p>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.9" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">9.9. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
    <div class="algorithm" data-algorithm="find the reporting frequency of a sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-17">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-4">frequency</a>.</p>
+      <p>A <a data-link-type="dfn" href="#frequency" id="ref-for-frequency-2">frequency</a>.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>Let <var>frequency</var> be null.</p>
      <li data-md="">
-      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-4">[[desiredSamplingFrequency]]</a></code>.</p>
+      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot-2">[[desiredSamplingFrequency]]</a></code>.</p>
       <ol>
        <li data-md="">
         <p>if <var>f</var> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-4">current sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-42">sensor</a>.</p>
+          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency-2">current sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-40">sensor</a>.</p>
         </ol>
        <li data-md="">
         <p>Otherwise,</p>
@@ -2662,24 +2662,46 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-18">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-2">[[pendingReadingNotification]]</a></code> is true,</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-0">[[pendingReadingNotification]]</a></code> is true,</p>
       <ol>
        <li data-md="">
         <p>Return.</p>
       </ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-3">[[pendingReadingNotification]]</a></code> to true.</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-1">[[pendingReadingNotification]]</a></code> to true.</p>
      <li data-md="">
-      <p>Let <var>lastReportedTimestamp</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot-2">[[lastEventFiredAt]]</a></code>.</p>
+      <p>Let <var>lastReportedTimestamp</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot-0">[[lastEventFiredAt]]</a></code>.</p>
      <li data-md="">
       <p>If <var>lastReportedTimestamp</var> is not set</p>
+      <ol>
+       <li data-md="">
+        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
+       <li data-md="">
+        <p>Return.</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>reportingFrequency</var> be result of invoking <a data-link-type="dfn" href="#find-the-reporting-frequency-of-a-sensor-object" id="ref-for-find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a>.</p>
+     <li data-md="">
+      <p>If <var>reportingFrequency</var> is null</p>
+      <ol>
+       <li data-md="">
+        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-0">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
+       <li data-md="">
+        <p>Return.</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>reportingInterval</var> be the result of 1 / <var>reportingFrequency</var>.</p>
+     <li data-md="">
+      <p>Let <var>timestampDelta</var> be the result of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-10">latest reading</a>["timestamp"] - <var>lastReportedTimestamp</var>.</p>
+     <li data-md="">
+      <p>If <var>timestampDelta</var> is greater than or equal to <var>reportingInterval</var></p>
       <ol>
        <li data-md="">
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-1">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
@@ -2687,36 +2709,14 @@ in order to reduce resource consumption, notably battery usage.</p>
         <p>Return.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>reportingFrequency</var> be result of invoking <a data-link-type="dfn" href="#find-the-reporting-frequency-of-a-sensor-object" id="ref-for-find-the-reporting-frequency-of-a-sensor-object-1">Find the reporting frequency of a sensor object</a>.</p>
+      <p>Let <var>deferUpdateTime</var> be the result of <var>reportingInterval</var> - <var>timestampDelta</var>.</p>
      <li data-md="">
-      <p>If <var>reportingFrequency</var> is null</p>
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop" id="ref-for-spin-the-event-loop">Spin the event loop</a> for a period of time equal to <var>deferUpdateTime</var>.</p>
+     <li data-md="">
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-2">[[pendingReadingNotification]]</a></code> is true,</p>
       <ol>
        <li data-md="">
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-2">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
-       <li data-md="">
-        <p>Return.</p>
-      </ol>
-     <li data-md="">
-      <p>Let <var>reportingInterval</var> be the result of 1 / <var>reportingFrequency</var>.</p>
-     <li data-md="">
-      <p>Let <var>timestampDelta</var> be the result of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-12">latest reading</a>["timestamp"] - <var>lastReportedTimestamp</var>.</p>
-     <li data-md="">
-      <p>If <var>timestampDelta</var> is greater than or equal to <var>reportingInterval</var></p>
-      <ol>
-       <li data-md="">
-        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-3">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
-       <li data-md="">
-        <p>Return.</p>
-      </ol>
-     <li data-md="">
-      <p>Let <var>deferUpdateTime</var> be the result of <var>reportingInterval</var> - <var>timestampDelta</var>.</p>
-     <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">Spin the event loop</a> for a period of time equal to <var>deferUpdateTime</var>.</p>
-     <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-4">[[pendingReadingNotification]]</a></code> is true,</p>
-      <ol>
-       <li data-md="">
-        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-4">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
       </ol>
     </ol>
    </div>
@@ -2725,18 +2725,18 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-19">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-5">[[pendingReadingNotification]]</a></code> to false.</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot-3">[[pendingReadingNotification]]</a></code> to false.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot-3">[[lastEventFiredAt]]</a></code> to <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-13">latest reading</a>["timestamp"].</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot-1">[[lastEventFiredAt]]</a></code> to <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-11">latest reading</a>["timestamp"].</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
+      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.12" data-lt="Notify activated state" data-noexport="" id="notify-activated-state"><span class="secno">9.12. </span><span class="content">Notify activated state</span></h3>
@@ -2744,23 +2744,23 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-20">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-8">[[state]]</a></code> to "activated".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-6">[[state]]</a></code> to "activated".</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
+      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire-0">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-43">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-41">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-14">latest reading</a>["timestamp"] is not null,</p>
+      <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-12">latest reading</a>["timestamp"] is not null,</p>
       <ol>
        <li data-md="">
-        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-5">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
+        <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading-3">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
       </ol>
     </ol>
    </div>
@@ -2769,18 +2769,18 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-23">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-21">Sensor</a></code> object.</p>
      <dd data-md="">
-      <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>.</p>
+      <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception">exception</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-9">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-7">[[state]]</a></code> to "idle".</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent-1">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error-1">error</a></code> attribute initialized to <var>error</var>.</p>
+      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire-1">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="9.14" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">9.14. </span><span class="content">Get value from latest reading</span></h3>
@@ -2788,19 +2788,19 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-24">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-22">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-37">sensor reading</a> value or null.</p>
+      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-35">sensor reading</a> value or null.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-10">[[state]]</a></code> is "activated",</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot-8">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
-        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-15">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-44">sensor</a>.</p>
+        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading-13">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-42">sensor</a>.</p>
        <li data-md="">
         <p>Return <var>readings</var>[<var>key</var>].</p>
       </ol>
@@ -2813,18 +2813,18 @@ in order to reduce resource consumption, notably battery usage.</p>
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-25">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-23">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state">permission state</a>.</p>
+      <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-45">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-43">sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>permission_name</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> associated with <var>sensor</var>.</p>
+      <p>Let <var>permission_name</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname-3">PermissionName</a></code> associated with <var>sensor</var>.</p>
      <li data-md="">
-      <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use">requesting permission to use</a> <var>permission_name</var>.</p>
+      <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use">requesting permission to use</a> <var>permission_name</var>.</p>
      <li data-md="">
       <p>Return <var>state</var>.</p>
     </ol>
@@ -2833,33 +2833,33 @@ in order to reduce resource consumption, notably battery usage.</p>
    <p><em>This section is non-normative.</em></p>
    <p>Its purpose is to describe
 how this specification can be extended to specify APIs for
-different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">sensor types</a>.</p>
-   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-32">sensor type</a>,
-exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-9">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-9">low</a> level
+different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-29">sensor types</a>.</p>
+   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-30">sensor type</a>,
+exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-7">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-7">low</a> level
 as appropriate.</p>
    <h3 class="heading settled" data-level="10.1" id="security"><span class="secno">10.1. </span><span class="content">Security</span><a class="self-link" href="#security"></a></h3>
    <p>All interfaces defined by extension specifications
-should only be available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
+should only be available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context-1">secure context</a>.</p>
    <h3 class="heading settled" data-level="10.2" id="naming"><span class="secno">10.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-26">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-46">sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-24">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-8">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-44">sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-27">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-47">sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-25">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-8">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-45">sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-48">sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-46">sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-28">Sensor</a></code> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-38">sensor readings</a> values
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-26">Sensor</a></code> subclass that
+hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-36">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
-the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-39">sensor reading</a>'s value in
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-37">sensor reading</a>'s value in
 a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp</code> attribute).
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="10.3" id="unit"><span class="secno">10.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-40">sensor readings</a>.</p>
+   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-38">sensor readings</a>.</p>
    <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
@@ -2871,9 +2871,9 @@ Non-SI units accepted for use with the SI,
 as described in the SI Brochure <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <h3 class="heading settled" data-level="10.4" id="high-vs-low-level"><span class="secno">10.4. </span><span class="content">Exposing High-Level vs. Low-Level Sensors</span><a class="self-link" href="#high-vs-low-level"></a></h3>
    <p>So far, specifications exposing sensors to the Web platform
-have focused on <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-11">high-level</a> sensors APIs. <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> <a data-link-type="biblio" href="#biblio-orientation-event">[ORIENTATION-EVENT]</a></p>
+have focused on <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-9">high-level</a> sensors APIs. <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> <a data-link-type="biblio" href="#biblio-orientation-event">[ORIENTATION-EVENT]</a></p>
    <p>This was a reasonable approach for a number of reasons.
-Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-12">high-level</a> sensors:</p>
+Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-10">high-level</a> sensors:</p>
    <ul>
     <li data-md="">
      <p>convey developer intent clearly,</p>
@@ -2890,57 +2890,57 @@ Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-12">hi
    </ul>
    <p>However, an increasing number of use cases
 such as virtual and augmented reality
-require <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-11">low-level</a> access to sensors,
+require <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-9">low-level</a> access to sensors,
 most notably for performance reasons.</p>
-   <p>Providing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-12">low-level</a> access
+   <p>Providing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-10">low-level</a> access
 enables Web application developers to leverage domain-specific constraints
 and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>,
 extension specifications should focus primarily on
-exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-13">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-13">high-level</a> APIs when they are clear benefits in doing so.</p>
+exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level-11">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level-11">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="10.5" id="multiple-sensors"><span class="secno">10.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
    <p>TODO: provide guidance on when to:</p>
    <ul>
     <li data-md="">
      <p>allow multiple sensors of the same type to be instantiated,</p>
     <li data-md="">
-     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-29">Sensor</a></code>,</p>
+     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-27">Sensor</a></code>,</p>
     <li data-md="">
      <p>add constructor parameters to tweak sensors settings (e.g. setting required accuracy).</p>
    </ul>
    <h3 class="heading settled" data-level="10.6" id="definition-reqs"><span class="secno">10.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-33">sensor type</a> in extension specifications:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-31">sensor type</a> in extension specifications:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-30">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface-0">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces-0">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor-28">Sensor</a></code>.
   This interface must be constructible.
-  Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor">Constructor</a></code>] must take, as argument,
-  an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-2">SensorOptions</a></code>.
-  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-41">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only">read only</a> and
-  their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-3">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a> as arguments.</p>
+  Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as argument,
+  an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-0">SensorOptions</a></code>.
+  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute-2">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings-39">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
+  their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading-1">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute-3">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier-1">identifier</a> as arguments.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname-4">PermissionName</a></code>.</p>
    </ul>
    <p>An extension specification may specify the following definitions
-for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-34">sensor types</a>:</p>
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-32">sensor types</a>:</p>
    <ul>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-3">SensorOptions</a></code>.</p>
+     <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary-0">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries-0">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions-1">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-3">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-49">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-35">type</a>,
-  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-4">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-36">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-50">sensors</a> are common,
-  extension specifications may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-5">default sensor</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-1">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-47">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-33">type</a>,
+  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-2">default sensor</a> should be straightforward.
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-34">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-48">sensors</a> are common,
+  extension specifications may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor-3">default sensor</a>,
   especially when doing so would not make sense.</p>
     <li data-md="">
-     <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-3">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
+     <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters-1">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
    </ul>
    <h3 class="heading settled" data-level="10.7" id="permission-api"><span class="secno">10.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>Provide guidance on how to extend the Permission API <a data-link-type="biblio" href="#biblio-permissions">[PERMISSIONS]</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-37">sensor types</a>.</p>
+   <p>Provide guidance on how to extend the Permission API <a data-link-type="biblio" href="#biblio-permissions">[PERMISSIONS]</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-35">sensor types</a>.</p>
    <h3 class="heading settled" data-level="10.8" id="example-webidl"><span class="secno">10.8. </span><span class="content">Example WebIDL</span><a class="self-link" href="#example-webidl"></a></h3>
    <p>Here’s example WebIDL for a possible extension of this specification
-for proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-51">sensors</a>.</p>
+for proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-49">sensors</a>.</p>
 <pre class="example" id="example-899e9b74"><a class="self-link" href="#example-899e9b74"></a>[SecureContext, Constructor(optional ProximitySensorOptions proximitySensorOptions)]
 interface ProximitySensor : Sensor {
     readonly attribute unrestricted double distance;
@@ -3053,8 +3053,8 @@ for their editorial input.</p>
     <a class="self-link" href="#example-f839f6c8"></a> 
     <p>This is an example of an informative example.</p>
    </div>
-   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
-    Although all of the <a data-link-type="dfn" href="#concept-sensor">sensors</a> used a examples
+   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type-36">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
+    Although all of the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor-50">sensors</a> used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
     are planning to do so. </p>
@@ -3436,501 +3436,501 @@ for their editorial input.</p>
    <dd><a href="http://www.bipm.org/en/publications/si-brochure/">SI Brochure: The International System of Units (SI), 8th edition</a>. 2014. URL: <a href="http://www.bipm.org/en/publications/si-brochure/">http://www.bipm.org/en/publications/si-brochure/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <a class="nv" href="#sensor"><code>Sensor</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv" data-readonly="" data-type="boolean" href="#dom-sensor-activated"><code>activated</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a>? <a class="nv" data-readonly="" data-type="DOMHighResTimeStamp?" href="#dom-sensor-timestamp"><code>timestamp</code></a>;
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext-0-0">SecureContext</a>]
+<span class="kt">interface</span> <a class="nv" href="#sensor"><code>Sensor</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget-0">EventTarget</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean-0"><span class="kt">boolean</span></a> <a class="nv" data-readonly="" data-type="boolean" href="#dom-sensor-activated"><code>activated</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp-0">DOMHighResTimeStamp</a>? <a class="nv" data-readonly="" data-type="DOMHighResTimeStamp?" href="#dom-sensor-timestamp"><code>timestamp</code></a>;
   <span class="kt">void</span> <a class="nv" href="#dom-sensor-start"><code>start</code></a>();
   <span class="kt">void</span> <a class="nv" href="#dom-sensor-stop"><code>stop</code></a>();
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onreading"><code>onreading</code></a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onactivate"><code>onactivate</code></a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onerror"><code>onerror</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onreading"><code>onreading</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onactivate"><code>onactivate</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-1-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onerror"><code>onerror</code></a>;
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensoroptions"><code>SensorOptions</code></a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a>? <a class="nv" data-type="double? " href="#dom-sensoroptions-frequency"><code>frequency</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double-0"><span class="kt">double</span></a>? <a class="nv" data-type="double? " href="#dom-sensoroptions-frequency"><code>frequency</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit">SensorErrorEventInit</a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code></a>)]
-<span class="kt">interface</span> <a class="nv" href="#sensorerrorevent"><code>SensorErrorEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error"><span class="kt">Error</span></a> <a class="nv" data-readonly="" data-type="Error" href="#dom-sensorerrorevent-error"><code>error</code></a>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext-0-0">SecureContext</a>, <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit-0-0">SensorErrorEventInit</a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#sensorerrorevent"><code>SensorErrorEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event-0">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error" id="ref-for-idl-Error-0-0"><span class="kt">Error</span></a> <a class="nv" data-readonly="" data-type="Error" href="#dom-sensorerrorevent-error"><code>error</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error"><span class="kt">Error</span></a> <a class="nv" data-type="Error " href="#dom-sensorerroreventinit-error"><code>error</code></a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit-0">EventInit</a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Error" id="ref-for-idl-Error-0-0"><span class="kt">Error</span></a> <a class="nv" data-type="Error " href="#dom-sensorerroreventinit-error"><code>error</code></a>;
 };
 
 </pre>
   <aside class="dfn-panel" data-for="limit-max-freqency">
    <b><a href="#limit-max-freqency">#limit-max-freqency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-limit-max-freqency-1">5.2.3. Limit number of delivered readings</a>
+    <li><a href="#ref-for-limit-max-freqency">5.2.3. Limit number of delivered readings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="raw-sensor-readings">
    <b><a href="#raw-sensor-readings">#raw-sensor-readings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-raw-sensor-readings-1">6.1. Sensors</a> <a href="#ref-for-raw-sensor-readings-2">(2)</a> <a href="#ref-for-raw-sensor-readings-3">(3)</a>
+    <li><a href="#ref-for-raw-sensor-readings">6.1. Sensors</a> <a href="#ref-for-raw-sensor-readings-0">(2)</a> <a href="#ref-for-raw-sensor-readings-1">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="calibration">
    <b><a href="#calibration">#calibration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-calibration-1">6.1. Sensors</a>
-    <li><a href="#ref-for-calibration-2">6.2. Sensor Types</a>
+    <li><a href="#ref-for-calibration">6.1. Sensors</a>
+    <li><a href="#ref-for-calibration-0">6.2. Sensor Types</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-readings">
    <b><a href="#sensor-readings">#sensor-readings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-readings-1">5. Security and privacy considerations</a>
-    <li><a href="#ref-for-sensor-readings-2">5.1.1. Secure Context</a>
-    <li><a href="#ref-for-sensor-readings-3">5.1.2. Top-Level Browsing Context</a> <a href="#ref-for-sensor-readings-4">(2)</a>
-    <li><a href="#ref-for-sensor-readings-5">5.1.3. Losing Focus</a> <a href="#ref-for-sensor-readings-6">(2)</a>
-    <li><a href="#ref-for-sensor-readings-7">5.1.4. Visibility State</a> <a href="#ref-for-sensor-readings-8">(2)</a>
-    <li><a href="#ref-for-sensor-readings-9">5.1.5. Permissions API</a> <a href="#ref-for-sensor-readings-10">(2)</a>
-    <li><a href="#ref-for-sensor-readings-11">5.2.3. Limit number of delivered readings</a>
-    <li><a href="#ref-for-sensor-readings-12">5.2.4. Reducing accuracy</a> <a href="#ref-for-sensor-readings-13">(2)</a>
-    <li><a href="#ref-for-sensor-readings-14">5.2.5. Keeping the user informed about API use</a>
-    <li><a href="#ref-for-sensor-readings-15">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings-16">(2)</a> <a href="#ref-for-sensor-readings-17">(3)</a> <a href="#ref-for-sensor-readings-18">(4)</a> <a href="#ref-for-sensor-readings-19">(5)</a>
-    <li><a href="#ref-for-sensor-readings-20">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings-21">(2)</a> <a href="#ref-for-sensor-readings-22">(3)</a> <a href="#ref-for-sensor-readings-23">(4)</a> <a href="#ref-for-sensor-readings-24">(5)</a>
-    <li><a href="#ref-for-sensor-readings-25">6.4. Sampling Frequency</a>
-    <li><a href="#ref-for-sensor-readings-26">7.2. Sensor</a> <a href="#ref-for-sensor-readings-27">(2)</a> <a href="#ref-for-sensor-readings-28">(3)</a> <a href="#ref-for-sensor-readings-29">(4)</a>
-    <li><a href="#ref-for-sensor-readings-30">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor-readings-31">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings-32">(2)</a>
-    <li><a href="#ref-for-sensor-readings-33">8.1.7. Sensor.onreading</a>
-    <li><a href="#ref-for-sensor-readings-34">9.6. Set sensor settings</a> <a href="#ref-for-sensor-readings-35">(2)</a>
-    <li><a href="#ref-for-sensor-readings-36">9.7. Update latest reading</a>
-    <li><a href="#ref-for-sensor-readings-37">9.14. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-readings-38">10.2. Naming</a> <a href="#ref-for-sensor-readings-39">(2)</a>
-    <li><a href="#ref-for-sensor-readings-40">10.3. Unit</a>
-    <li><a href="#ref-for-sensor-readings-41">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor-readings">5. Security and privacy considerations</a>
+    <li><a href="#ref-for-sensor-readings-0">5.1.1. Secure Context</a>
+    <li><a href="#ref-for-sensor-readings-1">5.1.2. Top-Level Browsing Context</a> <a href="#ref-for-sensor-readings-2">(2)</a>
+    <li><a href="#ref-for-sensor-readings-3">5.1.3. Losing Focus</a> <a href="#ref-for-sensor-readings-4">(2)</a>
+    <li><a href="#ref-for-sensor-readings-5">5.1.4. Visibility State</a> <a href="#ref-for-sensor-readings-6">(2)</a>
+    <li><a href="#ref-for-sensor-readings-7">5.1.5. Permissions API</a> <a href="#ref-for-sensor-readings-8">(2)</a>
+    <li><a href="#ref-for-sensor-readings-9">5.2.3. Limit number of delivered readings</a>
+    <li><a href="#ref-for-sensor-readings-10">5.2.4. Reducing accuracy</a> <a href="#ref-for-sensor-readings-11">(2)</a>
+    <li><a href="#ref-for-sensor-readings-12">5.2.5. Keeping the user informed about API use</a>
+    <li><a href="#ref-for-sensor-readings-13">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings-14">(2)</a> <a href="#ref-for-sensor-readings-15">(3)</a> <a href="#ref-for-sensor-readings-16">(4)</a> <a href="#ref-for-sensor-readings-17">(5)</a>
+    <li><a href="#ref-for-sensor-readings-18">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings-19">(2)</a> <a href="#ref-for-sensor-readings-20">(3)</a> <a href="#ref-for-sensor-readings-21">(4)</a> <a href="#ref-for-sensor-readings-22">(5)</a>
+    <li><a href="#ref-for-sensor-readings-23">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-sensor-readings-24">7.2. Sensor</a> <a href="#ref-for-sensor-readings-25">(2)</a> <a href="#ref-for-sensor-readings-26">(3)</a> <a href="#ref-for-sensor-readings-27">(4)</a>
+    <li><a href="#ref-for-sensor-readings-28">8.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor-readings-29">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings-30">(2)</a>
+    <li><a href="#ref-for-sensor-readings-31">8.1.7. Sensor.onreading</a>
+    <li><a href="#ref-for-sensor-readings-32">9.6. Set sensor settings</a> <a href="#ref-for-sensor-readings-33">(2)</a>
+    <li><a href="#ref-for-sensor-readings-34">9.7. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings-35">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-readings-36">10.2. Naming</a> <a href="#ref-for-sensor-readings-37">(2)</a>
+    <li><a href="#ref-for-sensor-readings-38">10.3. Unit</a>
+    <li><a href="#ref-for-sensor-readings-39">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
    <b><a href="#low-level">#low-level</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-low-level-1">1. Introduction</a>
-    <li><a href="#ref-for-low-level-2">6.2. Sensor Types</a> <a href="#ref-for-low-level-3">(2)</a> <a href="#ref-for-low-level-4">(3)</a> <a href="#ref-for-low-level-5">(4)</a> <a href="#ref-for-low-level-6">(5)</a> <a href="#ref-for-low-level-7">(6)</a> <a href="#ref-for-low-level-8">(7)</a>
-    <li><a href="#ref-for-low-level-9">10. Extensibility</a>
-    <li><a href="#ref-for-low-level-10">10.2. Naming</a>
-    <li><a href="#ref-for-low-level-11">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-low-level-12">(2)</a> <a href="#ref-for-low-level-13">(3)</a>
+    <li><a href="#ref-for-low-level">1. Introduction</a>
+    <li><a href="#ref-for-low-level-0">6.2. Sensor Types</a> <a href="#ref-for-low-level-1">(2)</a> <a href="#ref-for-low-level-2">(3)</a> <a href="#ref-for-low-level-3">(4)</a> <a href="#ref-for-low-level-4">(5)</a> <a href="#ref-for-low-level-5">(6)</a> <a href="#ref-for-low-level-6">(7)</a>
+    <li><a href="#ref-for-low-level-7">10. Extensibility</a>
+    <li><a href="#ref-for-low-level-8">10.2. Naming</a>
+    <li><a href="#ref-for-low-level-9">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-low-level-10">(2)</a> <a href="#ref-for-low-level-11">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="high-level">
    <b><a href="#high-level">#high-level</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-high-level-1">1. Introduction</a>
-    <li><a href="#ref-for-high-level-2">6.2. Sensor Types</a> <a href="#ref-for-high-level-3">(2)</a> <a href="#ref-for-high-level-4">(3)</a> <a href="#ref-for-high-level-5">(4)</a> <a href="#ref-for-high-level-6">(5)</a> <a href="#ref-for-high-level-7">(6)</a> <a href="#ref-for-high-level-8">(7)</a>
-    <li><a href="#ref-for-high-level-9">10. Extensibility</a>
-    <li><a href="#ref-for-high-level-10">10.2. Naming</a>
-    <li><a href="#ref-for-high-level-11">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-high-level-12">(2)</a> <a href="#ref-for-high-level-13">(3)</a>
+    <li><a href="#ref-for-high-level">1. Introduction</a>
+    <li><a href="#ref-for-high-level-0">6.2. Sensor Types</a> <a href="#ref-for-high-level-1">(2)</a> <a href="#ref-for-high-level-2">(3)</a> <a href="#ref-for-high-level-3">(4)</a> <a href="#ref-for-high-level-4">(5)</a> <a href="#ref-for-high-level-5">(6)</a> <a href="#ref-for-high-level-6">(7)</a>
+    <li><a href="#ref-for-high-level-7">10. Extensibility</a>
+    <li><a href="#ref-for-high-level-8">10.2. Naming</a>
+    <li><a href="#ref-for-high-level-9">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-high-level-10">(2)</a> <a href="#ref-for-high-level-11">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-fusion">
    <b><a href="#sensor-fusion">#sensor-fusion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-fusion-1">6.1. Sensors</a> <a href="#ref-for-sensor-fusion-2">(2)</a>
-    <li><a href="#ref-for-sensor-fusion-3">6.2. Sensor Types</a> <a href="#ref-for-sensor-fusion-4">(2)</a> <a href="#ref-for-sensor-fusion-5">(3)</a> <a href="#ref-for-sensor-fusion-6">(4)</a> <a href="#ref-for-sensor-fusion-7">(5)</a>
+    <li><a href="#ref-for-sensor-fusion">6.1. Sensors</a> <a href="#ref-for-sensor-fusion-0">(2)</a>
+    <li><a href="#ref-for-sensor-fusion-1">6.2. Sensor Types</a> <a href="#ref-for-sensor-fusion-2">(2)</a> <a href="#ref-for-sensor-fusion-3">(3)</a> <a href="#ref-for-sensor-fusion-4">(4)</a> <a href="#ref-for-sensor-fusion-5">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="smart-sensors">
    <b><a href="#smart-sensors">#smart-sensors</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-smart-sensors-1">6.3. Reporting Modes</a>
+    <li><a href="#ref-for-smart-sensors">6.3. Reporting Modes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-hubs">
    <b><a href="#sensor-hubs">#sensor-hubs</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-hubs-1">6.3. Reporting Modes</a>
+    <li><a href="#ref-for-sensor-hubs">6.3. Reporting Modes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="reporting-modes">
    <b><a href="#reporting-modes">#reporting-modes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reporting-modes-1">5. Security and privacy considerations</a>
-    <li><a href="#ref-for-reporting-modes-2">6.3. Reporting Modes</a> <a href="#ref-for-reporting-modes-3">(2)</a> <a href="#ref-for-reporting-modes-4">(3)</a> <a href="#ref-for-reporting-modes-5">(4)</a> <a href="#ref-for-reporting-modes-6">(5)</a>
+    <li><a href="#ref-for-reporting-modes">5. Security and privacy considerations</a>
+    <li><a href="#ref-for-reporting-modes-0">6.3. Reporting Modes</a> <a href="#ref-for-reporting-modes-1">(2)</a> <a href="#ref-for-reporting-modes-2">(3)</a> <a href="#ref-for-reporting-modes-3">(4)</a> <a href="#ref-for-reporting-modes-4">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="frequency">
    <b><a href="#frequency">#frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-frequency-1">6.3. Reporting Modes</a> <a href="#ref-for-frequency-2">(2)</a>
-    <li><a href="#ref-for-frequency-3">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-frequency-4">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-frequency">6.3. Reporting Modes</a> <a href="#ref-for-frequency-0">(2)</a>
+    <li><a href="#ref-for-frequency-1">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-frequency-2">9.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic">
    <b><a href="#periodic">#periodic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-1">5. Security and privacy considerations</a>
-    <li><a href="#ref-for-periodic-2">6.3. Reporting Modes</a> <a href="#ref-for-periodic-3">(2)</a> <a href="#ref-for-periodic-4">(3)</a> <a href="#ref-for-periodic-5">(4)</a> <a href="#ref-for-periodic-6">(5)</a> <a href="#ref-for-periodic-7">(6)</a> <a href="#ref-for-periodic-8">(7)</a>
+    <li><a href="#ref-for-periodic">5. Security and privacy considerations</a>
+    <li><a href="#ref-for-periodic-0">6.3. Reporting Modes</a> <a href="#ref-for-periodic-1">(2)</a> <a href="#ref-for-periodic-2">(3)</a> <a href="#ref-for-periodic-3">(4)</a> <a href="#ref-for-periodic-4">(5)</a> <a href="#ref-for-periodic-5">(6)</a> <a href="#ref-for-periodic-6">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="implementation-specific">
    <b><a href="#implementation-specific">#implementation-specific</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-implementation-specific-1">6.3. Reporting Modes</a> <a href="#ref-for-implementation-specific-2">(2)</a> <a href="#ref-for-implementation-specific-3">(3)</a>
+    <li><a href="#ref-for-implementation-specific">6.3. Reporting Modes</a> <a href="#ref-for-implementation-specific-0">(2)</a> <a href="#ref-for-implementation-specific-1">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sampling-frequency">
    <b><a href="#sampling-frequency">#sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sampling-frequency-1">5.2.1. Limit maximum sampling frequency</a> <a href="#ref-for-sampling-frequency-2">(2)</a>
-    <li><a href="#ref-for-sampling-frequency-3">5.2.3. Limit number of delivered readings</a>
-    <li><a href="#ref-for-sampling-frequency-4">7.2. Sensor</a> <a href="#ref-for-sampling-frequency-5">(2)</a>
-    <li><a href="#ref-for-sampling-frequency-6">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-sampling-frequency">5.2.1. Limit maximum sampling frequency</a> <a href="#ref-for-sampling-frequency-0">(2)</a>
+    <li><a href="#ref-for-sampling-frequency-1">5.2.3. Limit number of delivered readings</a>
+    <li><a href="#ref-for-sampling-frequency-2">7.2. Sensor</a> <a href="#ref-for-sampling-frequency-3">(2)</a>
+    <li><a href="#ref-for-sampling-frequency-4">8.1.2. Sensor internal slots</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-type">
    <b><a href="#sensor-type">#sensor-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-type-1">3. Background</a> <a href="#ref-for-sensor-type-2">(2)</a> <a href="#ref-for-sensor-type-3">(3)</a> <a href="#ref-for-sensor-type-4">(4)</a> <a href="#ref-for-sensor-type-5">(5)</a> <a href="#ref-for-sensor-type-6">(6)</a>
-    <li><a href="#ref-for-sensor-type-7">5. Security and privacy considerations</a>
-    <li><a href="#ref-for-sensor-type-8">5.2. Mitigation strategies applied on a case by case basis</a>
-    <li><a href="#ref-for-sensor-type-9">5.2.1. Limit maximum sampling frequency</a>
-    <li><a href="#ref-for-sensor-type-10">6.2. Sensor Types</a> <a href="#ref-for-sensor-type-11">(2)</a> <a href="#ref-for-sensor-type-12">(3)</a> <a href="#ref-for-sensor-type-13">(4)</a> <a href="#ref-for-sensor-type-14">(5)</a> <a href="#ref-for-sensor-type-15">(6)</a> <a href="#ref-for-sensor-type-16">(7)</a> <a href="#ref-for-sensor-type-17">(8)</a>
-    <li><a href="#ref-for-sensor-type-18">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type-19">(2)</a> <a href="#ref-for-sensor-type-20">(3)</a>
-    <li><a href="#ref-for-sensor-type-21">7.1. Sensor Type</a> <a href="#ref-for-sensor-type-22">(2)</a> <a href="#ref-for-sensor-type-23">(3)</a> <a href="#ref-for-sensor-type-24">(4)</a> <a href="#ref-for-sensor-type-25">(5)</a> <a href="#ref-for-sensor-type-26">(6)</a>
-    <li><a href="#ref-for-sensor-type-27">7.2. Sensor</a> <a href="#ref-for-sensor-type-28">(2)</a>
-    <li><a href="#ref-for-sensor-type-29">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-sensor-type-30">9.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-type-31">10. Extensibility</a> <a href="#ref-for-sensor-type-32">(2)</a>
-    <li><a href="#ref-for-sensor-type-33">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type-34">(2)</a> <a href="#ref-for-sensor-type-35">(3)</a> <a href="#ref-for-sensor-type-36">(4)</a>
-    <li><a href="#ref-for-sensor-type-37">10.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-type">3. Background</a> <a href="#ref-for-sensor-type-0">(2)</a> <a href="#ref-for-sensor-type-1">(3)</a> <a href="#ref-for-sensor-type-2">(4)</a> <a href="#ref-for-sensor-type-3">(5)</a> <a href="#ref-for-sensor-type-4">(6)</a>
+    <li><a href="#ref-for-sensor-type-5">5. Security and privacy considerations</a>
+    <li><a href="#ref-for-sensor-type-6">5.2. Mitigation strategies applied on a case by case basis</a>
+    <li><a href="#ref-for-sensor-type-7">5.2.1. Limit maximum sampling frequency</a>
+    <li><a href="#ref-for-sensor-type-8">6.2. Sensor Types</a> <a href="#ref-for-sensor-type-9">(2)</a> <a href="#ref-for-sensor-type-10">(3)</a> <a href="#ref-for-sensor-type-11">(4)</a> <a href="#ref-for-sensor-type-12">(5)</a> <a href="#ref-for-sensor-type-13">(6)</a> <a href="#ref-for-sensor-type-14">(7)</a> <a href="#ref-for-sensor-type-15">(8)</a>
+    <li><a href="#ref-for-sensor-type-16">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type-17">(2)</a> <a href="#ref-for-sensor-type-18">(3)</a>
+    <li><a href="#ref-for-sensor-type-19">7.1. Sensor Type</a> <a href="#ref-for-sensor-type-20">(2)</a> <a href="#ref-for-sensor-type-21">(3)</a> <a href="#ref-for-sensor-type-22">(4)</a> <a href="#ref-for-sensor-type-23">(5)</a> <a href="#ref-for-sensor-type-24">(6)</a>
+    <li><a href="#ref-for-sensor-type-25">7.2. Sensor</a> <a href="#ref-for-sensor-type-26">(2)</a>
+    <li><a href="#ref-for-sensor-type-27">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-sensor-type-28">9.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-type-29">10. Extensibility</a> <a href="#ref-for-sensor-type-30">(2)</a>
+    <li><a href="#ref-for-sensor-type-31">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type-32">(2)</a> <a href="#ref-for-sensor-type-33">(3)</a> <a href="#ref-for-sensor-type-34">(4)</a>
+    <li><a href="#ref-for-sensor-type-35">10.7. Extending the Permission API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="associated-sensors">
    <b><a href="#associated-sensors">#associated-sensors</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-associated-sensors-1">7.1. Sensor Type</a>
+    <li><a href="#ref-for-associated-sensors">7.1. Sensor Type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="identifying-parameters">
    <b><a href="#identifying-parameters">#identifying-parameters</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-identifying-parameters-1">9.1. Construct sensor object</a> <a href="#ref-for-identifying-parameters-2">(2)</a>
-    <li><a href="#ref-for-identifying-parameters-3">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-identifying-parameters">9.1. Construct sensor object</a> <a href="#ref-for-identifying-parameters-0">(2)</a>
+    <li><a href="#ref-for-identifying-parameters-1">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="default-sensor">
    <b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-sensor-1">9.2. Connect to sensor</a> <a href="#ref-for-default-sensor-2">(2)</a>
-    <li><a href="#ref-for-default-sensor-3">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor-4">(2)</a> <a href="#ref-for-default-sensor-5">(3)</a>
+    <li><a href="#ref-for-default-sensor">9.2. Connect to sensor</a> <a href="#ref-for-default-sensor-0">(2)</a>
+    <li><a href="#ref-for-default-sensor-1">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor-2">(2)</a> <a href="#ref-for-default-sensor-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="concept-sensor">
    <b><a href="#concept-sensor">#concept-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-sensor-1">3. Background</a> <a href="#ref-for-concept-sensor-2">(2)</a> <a href="#ref-for-concept-sensor-3">(3)</a> <a href="#ref-for-concept-sensor-4">(4)</a> <a href="#ref-for-concept-sensor-5">(5)</a> <a href="#ref-for-concept-sensor-6">(6)</a> <a href="#ref-for-concept-sensor-7">(7)</a> <a href="#ref-for-concept-sensor-8">(8)</a>
-    <li><a href="#ref-for-concept-sensor-9">5. Security and privacy considerations</a> <a href="#ref-for-concept-sensor-10">(2)</a> <a href="#ref-for-concept-sensor-11">(3)</a>
-    <li><a href="#ref-for-concept-sensor-12">5.1.3. Losing Focus</a>
-    <li><a href="#ref-for-concept-sensor-13">6.1. Sensors</a> <a href="#ref-for-concept-sensor-14">(2)</a>
-    <li><a href="#ref-for-concept-sensor-15">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor-16">(2)</a> <a href="#ref-for-concept-sensor-17">(3)</a>
-    <li><a href="#ref-for-concept-sensor-18">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor-19">(2)</a> <a href="#ref-for-concept-sensor-20">(3)</a>
-    <li><a href="#ref-for-concept-sensor-21">6.4. Sampling Frequency</a>
-    <li><a href="#ref-for-concept-sensor-22">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-23">(2)</a>
-    <li><a href="#ref-for-concept-sensor-24">7.2. Sensor</a> <a href="#ref-for-concept-sensor-25">(2)</a> <a href="#ref-for-concept-sensor-26">(3)</a> <a href="#ref-for-concept-sensor-27">(4)</a> <a href="#ref-for-concept-sensor-28">(5)</a>
-    <li><a href="#ref-for-concept-sensor-29">8.1. The Sensor Interface</a> <a href="#ref-for-concept-sensor-30">(2)</a> <a href="#ref-for-concept-sensor-31">(3)</a>
-    <li><a href="#ref-for-concept-sensor-32">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-sensor-33">9.2. Connect to sensor</a> <a href="#ref-for-concept-sensor-34">(2)</a> <a href="#ref-for-concept-sensor-35">(3)</a> <a href="#ref-for-concept-sensor-36">(4)</a>
-    <li><a href="#ref-for-concept-sensor-37">9.3. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-38">9.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-39">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-sensor-40">9.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-sensor-41">9.7. Update latest reading</a>
-    <li><a href="#ref-for-concept-sensor-42">9.9. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-sensor-43">9.12. Notify activated state</a>
-    <li><a href="#ref-for-concept-sensor-44">9.14. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-sensor-45">9.15. Request sensor access</a>
-    <li><a href="#ref-for-concept-sensor-46">10.2. Naming</a> <a href="#ref-for-concept-sensor-47">(2)</a> <a href="#ref-for-concept-sensor-48">(3)</a>
-    <li><a href="#ref-for-concept-sensor-49">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor-50">(2)</a>
-    <li><a href="#ref-for-concept-sensor-51">10.8. Example WebIDL</a>
+    <li><a href="#ref-for-concept-sensor">3. Background</a> <a href="#ref-for-concept-sensor-0">(2)</a> <a href="#ref-for-concept-sensor-1">(3)</a> <a href="#ref-for-concept-sensor-2">(4)</a> <a href="#ref-for-concept-sensor-3">(5)</a> <a href="#ref-for-concept-sensor-4">(6)</a> <a href="#ref-for-concept-sensor-5">(7)</a> <a href="#ref-for-concept-sensor-6">(8)</a>
+    <li><a href="#ref-for-concept-sensor-7">5. Security and privacy considerations</a> <a href="#ref-for-concept-sensor-8">(2)</a> <a href="#ref-for-concept-sensor-9">(3)</a>
+    <li><a href="#ref-for-concept-sensor-10">5.1.3. Losing Focus</a>
+    <li><a href="#ref-for-concept-sensor-11">6.1. Sensors</a> <a href="#ref-for-concept-sensor-12">(2)</a>
+    <li><a href="#ref-for-concept-sensor-13">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor-14">(2)</a> <a href="#ref-for-concept-sensor-15">(3)</a>
+    <li><a href="#ref-for-concept-sensor-16">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor-17">(2)</a> <a href="#ref-for-concept-sensor-18">(3)</a>
+    <li><a href="#ref-for-concept-sensor-19">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-concept-sensor-20">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor-21">(2)</a>
+    <li><a href="#ref-for-concept-sensor-22">7.2. Sensor</a> <a href="#ref-for-concept-sensor-23">(2)</a> <a href="#ref-for-concept-sensor-24">(3)</a> <a href="#ref-for-concept-sensor-25">(4)</a> <a href="#ref-for-concept-sensor-26">(5)</a>
+    <li><a href="#ref-for-concept-sensor-27">8.1. The Sensor Interface</a> <a href="#ref-for-concept-sensor-28">(2)</a> <a href="#ref-for-concept-sensor-29">(3)</a>
+    <li><a href="#ref-for-concept-sensor-30">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-sensor-31">9.2. Connect to sensor</a> <a href="#ref-for-concept-sensor-32">(2)</a> <a href="#ref-for-concept-sensor-33">(3)</a> <a href="#ref-for-concept-sensor-34">(4)</a>
+    <li><a href="#ref-for-concept-sensor-35">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-36">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-37">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-sensor-38">9.6. Set sensor settings</a>
+    <li><a href="#ref-for-concept-sensor-39">9.7. Update latest reading</a>
+    <li><a href="#ref-for-concept-sensor-40">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-sensor-41">9.12. Notify activated state</a>
+    <li><a href="#ref-for-concept-sensor-42">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-sensor-43">9.15. Request sensor access</a>
+    <li><a href="#ref-for-concept-sensor-44">10.2. Naming</a> <a href="#ref-for-concept-sensor-45">(2)</a> <a href="#ref-for-concept-sensor-46">(3)</a>
+    <li><a href="#ref-for-concept-sensor-47">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor-48">(2)</a>
+    <li><a href="#ref-for-concept-sensor-49">10.8. Example WebIDL</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
    <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activated-sensor-objects-1">7.2. Sensor</a> <a href="#ref-for-activated-sensor-objects-2">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects-3">9.3. Activate a sensor object</a>
-    <li><a href="#ref-for-activated-sensor-objects-4">9.4. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects-5">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects-6">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-activated-sensor-objects-7">9.6. Set sensor settings</a>
+    <li><a href="#ref-for-activated-sensor-objects">7.2. Sensor</a> <a href="#ref-for-activated-sensor-objects-0">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects-1">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-activated-sensor-objects-2">9.4. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects-3">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects-4">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-activated-sensor-objects-5">9.6. Set sensor settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="latest-reading">
    <b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-latest-reading-1">7.2. Sensor</a> <a href="#ref-for-latest-reading-2">(2)</a> <a href="#ref-for-latest-reading-3">(3)</a> <a href="#ref-for-latest-reading-4">(4)</a> <a href="#ref-for-latest-reading-5">(5)</a> <a href="#ref-for-latest-reading-6">(6)</a> <a href="#ref-for-latest-reading-7">(7)</a>
-    <li><a href="#ref-for-latest-reading-8">9.6. Set sensor settings</a> <a href="#ref-for-latest-reading-9">(2)</a>
-    <li><a href="#ref-for-latest-reading-10">9.7. Update latest reading</a> <a href="#ref-for-latest-reading-11">(2)</a>
-    <li><a href="#ref-for-latest-reading-12">9.10. Report latest reading updated</a>
-    <li><a href="#ref-for-latest-reading-13">9.11. Notify new reading</a>
-    <li><a href="#ref-for-latest-reading-14">9.12. Notify activated state</a>
-    <li><a href="#ref-for-latest-reading-15">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-latest-reading">7.2. Sensor</a> <a href="#ref-for-latest-reading-0">(2)</a> <a href="#ref-for-latest-reading-1">(3)</a> <a href="#ref-for-latest-reading-2">(4)</a> <a href="#ref-for-latest-reading-3">(5)</a> <a href="#ref-for-latest-reading-4">(6)</a> <a href="#ref-for-latest-reading-5">(7)</a>
+    <li><a href="#ref-for-latest-reading-6">9.6. Set sensor settings</a> <a href="#ref-for-latest-reading-7">(2)</a>
+    <li><a href="#ref-for-latest-reading-8">9.7. Update latest reading</a> <a href="#ref-for-latest-reading-9">(2)</a>
+    <li><a href="#ref-for-latest-reading-10">9.10. Report latest reading updated</a>
+    <li><a href="#ref-for-latest-reading-11">9.11. Notify new reading</a>
+    <li><a href="#ref-for-latest-reading-12">9.12. Notify activated state</a>
+    <li><a href="#ref-for-latest-reading-13">9.14. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-sampling-frequency">
    <b><a href="#current-sampling-frequency">#current-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-sampling-frequency-1">7.2. Sensor</a>
-    <li><a href="#ref-for-current-sampling-frequency-2">9.6. Set sensor settings</a> <a href="#ref-for-current-sampling-frequency-3">(2)</a>
-    <li><a href="#ref-for-current-sampling-frequency-4">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-current-sampling-frequency">7.2. Sensor</a>
+    <li><a href="#ref-for-current-sampling-frequency-0">9.6. Set sensor settings</a> <a href="#ref-for-current-sampling-frequency-1">(2)</a>
+    <li><a href="#ref-for-current-sampling-frequency-2">9.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="optimal-sampling-frequency">
    <b><a href="#optimal-sampling-frequency">#optimal-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-optimal-sampling-frequency-1">7.2. Sensor</a>
-    <li><a href="#ref-for-optimal-sampling-frequency-2">9.6. Set sensor settings</a>
+    <li><a href="#ref-for-optimal-sampling-frequency">7.2. Sensor</a>
+    <li><a href="#ref-for-optimal-sampling-frequency-0">9.6. Set sensor settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor">
    <b><a href="#sensor">#sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-1">3. Background</a>
-    <li><a href="#ref-for-sensor-2">4. A note on Feature Detection of Hardware Features</a>
-    <li><a href="#ref-for-sensor-3">7.1. Sensor Type</a> <a href="#ref-for-sensor-4">(2)</a>
-    <li><a href="#ref-for-sensor-5">7.2. Sensor</a>
-    <li><a href="#ref-for-sensor-6">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor-7">8.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-sensor-8">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-9">(2)</a> <a href="#ref-for-sensor-10">(3)</a> <a href="#ref-for-sensor-11">(4)</a>
-    <li><a href="#ref-for-sensor-12">8.1.10. Event handlers</a>
-    <li><a href="#ref-for-sensor-13">9.1. Construct sensor object</a> <a href="#ref-for-sensor-14">(2)</a> <a href="#ref-for-sensor-15">(3)</a>
-    <li><a href="#ref-for-sensor-16">9.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-17">9.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor-18">9.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor-19">9.9. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor-20">9.10. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor-21">9.11. Notify new reading</a>
-    <li><a href="#ref-for-sensor-22">9.12. Notify activated state</a>
-    <li><a href="#ref-for-sensor-23">9.13. Notify error</a>
-    <li><a href="#ref-for-sensor-24">9.14. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-25">9.15. Request sensor access</a>
-    <li><a href="#ref-for-sensor-26">10.2. Naming</a> <a href="#ref-for-sensor-27">(2)</a> <a href="#ref-for-sensor-28">(3)</a>
-    <li><a href="#ref-for-sensor-29">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
-    <li><a href="#ref-for-sensor-30">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor">3. Background</a>
+    <li><a href="#ref-for-sensor-0">4. A note on Feature Detection of Hardware Features</a>
+    <li><a href="#ref-for-sensor-1">7.1. Sensor Type</a> <a href="#ref-for-sensor-2">(2)</a>
+    <li><a href="#ref-for-sensor-3">7.2. Sensor</a>
+    <li><a href="#ref-for-sensor-4">8.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor-5">8.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-sensor-6">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-7">(2)</a> <a href="#ref-for-sensor-8">(3)</a> <a href="#ref-for-sensor-9">(4)</a>
+    <li><a href="#ref-for-sensor-10">8.1.10. Event handlers</a>
+    <li><a href="#ref-for-sensor-11">9.1. Construct sensor object</a> <a href="#ref-for-sensor-12">(2)</a> <a href="#ref-for-sensor-13">(3)</a>
+    <li><a href="#ref-for-sensor-14">9.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-15">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor-16">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor-17">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor-18">9.10. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor-19">9.11. Notify new reading</a>
+    <li><a href="#ref-for-sensor-20">9.12. Notify activated state</a>
+    <li><a href="#ref-for-sensor-21">9.13. Notify error</a>
+    <li><a href="#ref-for-sensor-22">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-23">9.15. Request sensor access</a>
+    <li><a href="#ref-for-sensor-24">10.2. Naming</a> <a href="#ref-for-sensor-25">(2)</a> <a href="#ref-for-sensor-26">(3)</a>
+    <li><a href="#ref-for-sensor-27">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor-28">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
    <b><a href="#dom-sensor-activated">#dom-sensor-activated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-activated-1">8.1.3. Sensor.activated</a>
+    <li><a href="#ref-for-dom-sensor-activated">8.1.3. Sensor.activated</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-timestamp">
    <b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-timestamp-1">8.1.4. Sensor.timestamp</a>
-    <li><a href="#ref-for-dom-sensor-timestamp-2">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-timestamp">8.1.4. Sensor.timestamp</a>
+    <li><a href="#ref-for-dom-sensor-timestamp-0">9.1. Construct sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-start">
    <b><a href="#dom-sensor-start">#dom-sensor-start</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-start-1">8.1.5. Sensor.start()</a>
+    <li><a href="#ref-for-dom-sensor-start">8.1.5. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-stop">
    <b><a href="#dom-sensor-stop">#dom-sensor-stop</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-stop-1">8.1.6. Sensor.stop()</a>
+    <li><a href="#ref-for-dom-sensor-stop">8.1.6. Sensor.stop()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onreading">
    <b><a href="#dom-sensor-onreading">#dom-sensor-onreading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onreading-1">8.1.7. Sensor.onreading</a>
+    <li><a href="#ref-for-dom-sensor-onreading">8.1.7. Sensor.onreading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onactivate">
    <b><a href="#dom-sensor-onactivate">#dom-sensor-onactivate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onactivate-1">8.1.8. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensor-onactivate">8.1.8. Sensor.onactivate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onerror">
    <b><a href="#dom-sensor-onerror">#dom-sensor-onerror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onerror-1">8.1.9. Sensor.onerror</a>
+    <li><a href="#ref-for-dom-sensor-onerror">8.1.9. Sensor.onerror</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensoroptions">
    <b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-sensoroptions-1">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dictdef-sensoroptions-2">10.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions-3">(2)</a>
+    <li><a href="#ref-for-dictdef-sensoroptions">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dictdef-sensoroptions-0">10.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions-1">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensoroptions-frequency">
    <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensoroptions-frequency-1">9.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency-2">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency-3">(3)</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency">9.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency-0">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency-1">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-task-source">
    <b><a href="#sensor-task-source">#sensor-task-source</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-task-source-1">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor-task-source">9.4. Deactivate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-state-slot">
    <b><a href="#dom-sensor-state-slot">#dom-sensor-state-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-state-slot-1">8.1.3. Sensor.activated</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-2">8.1.5. Sensor.start()</a> <a href="#ref-for-dom-sensor-state-slot-3">(2)</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-4">8.1.6. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot-5">(2)</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-6">8.1.8. Sensor.onactivate</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-7">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-8">9.12. Notify activated state</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-9">9.13. Notify error</a>
-    <li><a href="#ref-for-dom-sensor-state-slot-10">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-dom-sensor-state-slot">8.1.3. Sensor.activated</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-0">8.1.5. Sensor.start()</a> <a href="#ref-for-dom-sensor-state-slot-1">(2)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-2">8.1.6. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot-3">(2)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-4">8.1.8. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-5">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-6">9.12. Notify activated state</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-7">9.13. Notify error</a>
+    <li><a href="#ref-for-dom-sensor-state-slot-8">9.14. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-desiredsamplingfrequency-slot">
    <b><a href="#dom-sensor-desiredsamplingfrequency-slot">#dom-sensor-desiredsamplingfrequency-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-1">7.2. Sensor</a> <a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-2">(2)</a>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-3">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-4">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot">7.2. Sensor</a> <a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-0">(2)</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-1">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-desiredsamplingfrequency-slot-2">9.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot">
    <b><a href="#dom-sensor-lasteventfiredat-slot">#dom-sensor-lasteventfiredat-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-1">9.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-2">9.10. Report latest reading updated</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-3">9.11. Notify new reading</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-0">9.10. Report latest reading updated</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot-1">9.11. Notify new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-pendingreadingnotification-slot">
    <b><a href="#dom-sensor-pendingreadingnotification-slot">#dom-sensor-pendingreadingnotification-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot-1">9.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot-2">9.10. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot-3">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot-4">(3)</a>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot-5">9.11. Notify new reading</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot-0">9.10. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot-1">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot-2">(3)</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot-3">9.11. Notify new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-identifyingparameters-slot">
    <b><a href="#dom-sensor-identifyingparameters-slot">#dom-sensor-identifyingparameters-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot-1">9.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot-2">9.2. Connect to sensor</a> <a href="#ref-for-dom-sensor-identifyingparameters-slot-3">(2)</a>
+    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot">9.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot-0">9.2. Connect to sensor</a> <a href="#ref-for-dom-sensor-identifyingparameters-slot-1">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensorerrorevent">
    <b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensorerrorevent-1">9.13. Notify error</a>
+    <li><a href="#ref-for-sensorerrorevent">9.13. Notify error</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorerrorevent-error">
    <b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorerrorevent-error-1">9.13. Notify error</a>
+    <li><a href="#ref-for-dom-sensorerrorevent-error">9.13. Notify error</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensorerroreventinit">
    <b><a href="#dictdef-sensorerroreventinit">#dictdef-sensorerroreventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-sensorerroreventinit-1">8.2. The SensorErrorEvent Interface</a>
-    <li><a href="#ref-for-dictdef-sensorerroreventinit-2">8.2.1. SensorErrorEvent.error</a>
+    <li><a href="#ref-for-dictdef-sensorerroreventinit">8.2. The SensorErrorEvent Interface</a>
+    <li><a href="#ref-for-dictdef-sensorerroreventinit-0">8.2.1. SensorErrorEvent.error</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="connect-to-sensor">
    <b><a href="#connect-to-sensor">#connect-to-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-connect-to-sensor-1">8.1.5. Sensor.start()</a>
+    <li><a href="#ref-for-connect-to-sensor">8.1.5. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activate-a-sensor-object">
    <b><a href="#activate-a-sensor-object">#activate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activate-a-sensor-object-1">8.1.5. Sensor.start()</a>
+    <li><a href="#ref-for-activate-a-sensor-object">8.1.5. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="deactivate-a-sensor-object">
    <b><a href="#deactivate-a-sensor-object">#deactivate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-deactivate-a-sensor-object-1">8.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-deactivate-a-sensor-object-2">8.1.6. Sensor.stop()</a>
-    <li><a href="#ref-for-deactivate-a-sensor-object-3">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object">8.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object-0">8.1.6. Sensor.stop()</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object-1">9.5. Revoke sensor permission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="revoke-sensor-permission">
    <b><a href="#revoke-sensor-permission">#revoke-sensor-permission</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-revoke-sensor-permission-1">7.1. Sensor Type</a>
+    <li><a href="#ref-for-revoke-sensor-permission">7.1. Sensor Type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="set-sensor-settings">
    <b><a href="#set-sensor-settings">#set-sensor-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-set-sensor-settings-1">9.3. Activate a sensor object</a>
-    <li><a href="#ref-for-set-sensor-settings-2">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-set-sensor-settings">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-set-sensor-settings-0">9.4. Deactivate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="update-latest-reading">
    <b><a href="#update-latest-reading">#update-latest-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-latest-reading-1">7.2. Sensor</a>
+    <li><a href="#ref-for-update-latest-reading">7.2. Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="security-check">
    <b><a href="#security-check">#security-check</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-security-check-1">5.1.3. Losing Focus</a>
-    <li><a href="#ref-for-security-check-2">5.1.4. Visibility State</a>
-    <li><a href="#ref-for-security-check-3">9.7. Update latest reading</a>
-    <li><a href="#ref-for-security-check-4">9.8. Security check</a>
+    <li><a href="#ref-for-security-check">5.1.3. Losing Focus</a>
+    <li><a href="#ref-for-security-check-0">5.1.4. Visibility State</a>
+    <li><a href="#ref-for-security-check-1">9.7. Update latest reading</a>
+    <li><a href="#ref-for-security-check-2">9.8. Security check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="find-the-reporting-frequency-of-a-sensor-object">
    <b><a href="#find-the-reporting-frequency-of-a-sensor-object">#find-the-reporting-frequency-of-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object-1">9.10. Report latest reading updated</a>
+    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object">9.10. Report latest reading updated</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="report-latest-reading-updated">
    <b><a href="#report-latest-reading-updated">#report-latest-reading-updated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-report-latest-reading-updated-1">9.7. Update latest reading</a>
+    <li><a href="#ref-for-report-latest-reading-updated">9.7. Update latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-new-reading">
    <b><a href="#notify-new-reading">#notify-new-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-new-reading-1">9.10. Report latest reading updated</a> <a href="#ref-for-notify-new-reading-2">(2)</a> <a href="#ref-for-notify-new-reading-3">(3)</a> <a href="#ref-for-notify-new-reading-4">(4)</a>
-    <li><a href="#ref-for-notify-new-reading-5">9.12. Notify activated state</a>
+    <li><a href="#ref-for-notify-new-reading">9.10. Report latest reading updated</a> <a href="#ref-for-notify-new-reading-0">(2)</a> <a href="#ref-for-notify-new-reading-1">(3)</a> <a href="#ref-for-notify-new-reading-2">(4)</a>
+    <li><a href="#ref-for-notify-new-reading-3">9.12. Notify activated state</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-activated-state">
    <b><a href="#notify-activated-state">#notify-activated-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-activated-state-1">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-notify-activated-state">9.3. Activate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-error">
    <b><a href="#notify-error">#notify-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-error-1">8.1.5. Sensor.start()</a> <a href="#ref-for-notify-error-2">(2)</a>
-    <li><a href="#ref-for-notify-error-3">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-notify-error">8.1.5. Sensor.start()</a> <a href="#ref-for-notify-error-0">(2)</a>
+    <li><a href="#ref-for-notify-error-1">9.5. Revoke sensor permission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="get-value-from-latest-reading">
    <b><a href="#get-value-from-latest-reading">#get-value-from-latest-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-get-value-from-latest-reading-1">7.2. Sensor</a>
-    <li><a href="#ref-for-get-value-from-latest-reading-2">8.1.4. Sensor.timestamp</a>
-    <li><a href="#ref-for-get-value-from-latest-reading-3">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-get-value-from-latest-reading">7.2. Sensor</a>
+    <li><a href="#ref-for-get-value-from-latest-reading-0">8.1.4. Sensor.timestamp</a>
+    <li><a href="#ref-for-get-value-from-latest-reading-1">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-sensor-access">
    <b><a href="#request-sensor-access">#request-sensor-access</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-sensor-access-1">8.1.5. Sensor.start()</a>
+    <li><a href="#ref-for-request-sensor-access">8.1.5. Sensor.start()</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
The spec does not use levels.

(It seems most others specs in DAS WG do have a "Level:" entry, tho. @dontcallmedom?)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/sensors/level-none.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/7f19df1...1ddf631.html)