### PR TITLE
Update geolocation.js polyfill

### DIFF
--- a/examples/realtime-positioning/proposal.js
+++ b/examples/realtime-positioning/proposal.js
@@ -1,6 +1,6 @@
 var sensor = new GeolocationSensor({ accuracy: "low" });
 sensor.start();
-sensor.onreading = function(event) {
+sensor.onreading = function() {
     var coords = [sensor.latitude, sensor.longitude];
     updateMap(null, coords, sensor.accuracy);
 };

--- a/examples/realtime-positioning/proposal.js
+++ b/examples/realtime-positioning/proposal.js
@@ -1,13 +1,9 @@
 var sensor = new GeolocationSensor({ accuracy: "low" });
 sensor.start();
-sensor.onchange = function(event) {
-    var coords = [event.reading.latitude, event.reading.longitude];
-    updateMap(null, coords, event.reading.accuracy);
+sensor.onreading = function(event) {
+    var coords = [event.latitude, event.longitude];
+    updateMap(null, coords, event.accuracy);
 };
 sensor.onerror = function(error) {
     updateMap(error);
 };
-sensor.onstatechange = function(e) {
-    console.log("STATE:", this.state)
-};
-

--- a/examples/realtime-positioning/proposal.js
+++ b/examples/realtime-positioning/proposal.js
@@ -1,8 +1,8 @@
 var sensor = new GeolocationSensor({ accuracy: "low" });
 sensor.start();
 sensor.onreading = function(event) {
-    var coords = [event.latitude, event.longitude];
-    updateMap(null, coords, event.accuracy);
+    var coords = [sensor.latitude, sensor.longitude];
+    updateMap(null, coords, sensor.accuracy);
 };
 sensor.onerror = function(error) {
     updateMap(error);

--- a/polyfills/geolocation.js
+++ b/polyfills/geolocation.js
@@ -308,7 +308,7 @@
             updateState(sensor, "activated");
         }
         queueATask(function() {
-            var event = new SensorReadingEvent("change", {
+            var event = new SensorReadingEvent("reading", {
                 reading: reading
             });
             sensor.dispatchEvent(event);

--- a/polyfills/geolocation.js
+++ b/polyfills/geolocation.js
@@ -331,10 +331,6 @@
     
     function updateState(sensor, state) {
         setSlot(sensor, "state", state);
-        queueATask(function() {
-            var event = new Event("statechange");
-            sensor.dispatchEvent(event);
-        });
     }
 
     var GeolocationSensor = (function () {

--- a/polyfills/geolocation.js
+++ b/polyfills/geolocation.js
@@ -170,7 +170,7 @@
             });
         }
         
-        function ondata(position) {
+        function onreading(position) {
             var reading = currentReading = toReading(position);
             if (_state == "activating") {
                 _state = "active";
@@ -209,7 +209,7 @@
             if (_watchId) {
                 navigator.geolocation.clearWatch(_watchId);
             }
-            _watchId = navigator.geolocation.watchPosition(ondata, onerror, {
+            _watchId = navigator.geolocation.watchPosition(onreading, onerror, {
                 enableHighAccuracy: options.accuracy == "high",
                 maximumAge: 0, 
                 timeout: Infinity

--- a/polyfills/geolocation.js
+++ b/polyfills/geolocation.js
@@ -297,6 +297,13 @@
     
     function updateReading(sensor, reading) {
         setSlot(sensor, "reading", reading);
+        setSlot(sensor, "latitude", reading.latitude);
+        setSlot(sensor, "longitude", reading.longitude);
+        setSlot(sensor, "altitude", reading.altitude);
+        setSlot(sensor, "accuracy", reading.accuracy);
+        setSlot(sensor, "altitudeAccuracy", reading.altitudeAccuracy);
+        setSlot(sensor, "heading", reading.heading);
+        setSlot(sensor, "speed", reading.speed);
         if (sensor._state == "activating") {
             updateState(sensor, "active");
         }
@@ -334,6 +341,13 @@
         
         function GeolocationSensor(options) {
             setSlot(this, "options", options || {});
+            setSlot(this, "latitude", "null");
+            setSlot(this, "longitude", "null");
+            setSlot(this, "altitude", "null");
+            setSlot(this, "accuracy", "null");
+            setSlot(this, "altitudeAccuracy", "null");
+            setSlot(this, "heading", "null");
+            setSlot(this, "speed", "null");
             setSlot(this, "state", "idle");
             setSlot(this, "reading", "null");
             Sensor.call(this);
@@ -342,6 +356,41 @@
             reading: {
                 get: function() {
                     return getSlot(this, "reading");
+                }
+            },
+            latitude: {
+                get: function() {
+                    return getSlot(this, "reading").latitude;
+                }
+            },
+            longitude: {
+                get: function() {
+                    return getSlot(this, "reading").longitude;
+                }
+            },
+            altitude: {
+                get: function() {
+                    return getSlot(this, "reading").altitude;
+                }
+            },
+            accuracy: {
+                get: function() {
+                    return getSlot(this, "reading").accuracy;
+                }
+            },
+            altitudeAccuracy: {
+                get: function() {
+                    return getSlot(this, "reading").altitudeAccuracy;
+                }
+            },
+            heading: {
+                get: function() {
+                    return getSlot(this, "reading").heading;
+                }
+            },
+            speed: {
+                get: function() {
+                    return getSlot(this, "reading").speed;
                 }
             }
         });

--- a/polyfills/geolocation.js
+++ b/polyfills/geolocation.js
@@ -44,7 +44,7 @@
         var SUPPORTED_REPORTING_MODES = ["auto"];
         var currentReportingMode = "auto";
         var associatedSensors = new Set();
-        var _state = "idle"; // one of idle, activating, active, primed,
+        var _state = "idle"; // one of idle, activating, activated
         var currentReading = null;
         var cachedReading = null;
         var _watchId = null;
@@ -128,7 +128,7 @@
                         if (canEmitCachedReading(sensor)) {
                             updateReading(sensor, currentReading);
                         }
-                    } else if (currentState == "active") {
+                    } else if (currentState == "activated") {
                         if (optChanged) {
                             activate(opt);
                         }
@@ -173,7 +173,7 @@
         function onreading(position) {
             var reading = currentReading = toReading(position);
             if (_state == "activating") {
-                _state = "active";
+                _state = "activated";
             }
             Array.from(associatedSensors).forEach(function(sensor) {
                 updateReading(sensor, reading)
@@ -305,7 +305,7 @@
         setSlot(sensor, "heading", reading.heading);
         setSlot(sensor, "speed", reading.speed);
         if (sensor._state == "activating") {
-            updateState(sensor, "active");
+            updateState(sensor, "activated");
         }
         queueATask(function() {
             var event = new SensorReadingEvent("change", {
@@ -397,7 +397,7 @@
         GeolocationSensor.prototype.constructor = GeolocationSensor;
     
         GeolocationSensor.prototype.start = function() {
-            if (this._state == "activating" || this._state == "active") {
+            if (this._state == "activating" || this._state == "activated") {
                 throw new DOMException("Sensor already started.", "InvalidStateError");
             }
             updateState(this, "activating");


### PR DESCRIPTION
This is an attempt to update the geolocation.js polyfill started by @tobie to better match the latest Generic Sensor API.

It seems at least https://w3c.github.io/sensors/examples/realtime-positioning/ example works after my patches. I haven't attempted to run the test suite.

Related, here's an early draft of the Geolocation Sensor spec:

https://anssiko.github.io/geolocation-sensor/

PTAL @rwaldron