### PR TITLE
Redefine [=sensor=] concept

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -182,20 +182,20 @@ The Generic Sensor API is designed to make the most common use cases straightfor
 while still enabling more complex use cases.
 
 Most devices deployed today do not carry more than one
-[=sensor=] of each [=sensor type|sensor types=].
+[=device sensor|sensor=] of each [=sensor type|sensor types=].
 This shouldn't come as a surprise since use cases for more than
-a [=sensor=] of a given [=sensor types|type=] are rare
+a [=device sensor|sensor=] of a given [=sensor types|type=] are rare
 and generally limited to specific [=sensor types=],
 such as proximity sensors.
 
 The API therefore makes it easy to interact with
-the device's default (and often unique) [=sensor=]
+the device's default (and often unique) [=device sensor|sensor=]
 for each [=sensor types|type=]
 simply by instantiating the corresponding {{Sensor}} subclass.
 
-Indeed, without specific information identifying a particular [=sensor=]
+Indeed, without specific information identifying a particular [=device sensor|sensor=]
 of a given [=sensor type|type=],
-the default [=sensor=] is chosen.
+the default [=device sensor|sensor=] is chosen.
 
 <div class="example">
     Listening to geolocation changes:
@@ -217,11 +217,11 @@ the default [=sensor=] is chosen.
 
 Note: extension to this specification may choose not to define a default sensor
 when doing so wouldn't make sense.
-For example, it might be difficult to agree on an obvious default [=sensor=] for
-proximity [=sensors=].
+For example, it might be difficult to agree on an obvious default [=device sensor|sensor=] for
+proximity [=device sensor|sensors=].
 
 In cases where
-multiple [=sensors=] of the same [=sensor type|type=]
+multiple [=device sensor|sensors=] of the same [=sensor type|type=]
 may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.
@@ -314,13 +314,13 @@ and defensive programming which includes:
 
 [=sensor readings|Sensor readings=] are sensitive data and could become a subject of
 various attacks from malicious Web pages. Before discussing the mitigation strategies we
-briefly enumerate the main types of the [=sensor=]'s privacy and security threats.
+briefly enumerate the main types of the [=device sensor|sensor=]'s privacy and security threats.
 The [[MOBILESENSORS]] categorizes main threats into [[#location-tracking|location tracking]],
 [[#eavesdropping|eavesdropping]], [[#keystroke-monitoring|keystroke monitoring]],
 [[#device-fingerprinting|device fingerprinting]], and [[#user-identifying|user identification]].
 This categorization is a good fit for this specification.
 
-The risk of successful attack can increase when [=sensors=] are used with each other,
+The risk of successful attack can increase when [=device sensor|sensors=] are used with each other,
 in combination with other functionality, or when used over time,
 specifically with the risk of correlation of data
 and user identification through fingerprinting.
@@ -353,12 +353,12 @@ it may be possible for that code to correlate the user across those two contexts
 creating unanticipated tracking mechanisms.
 
 User agents should consider providing the user
-an indication of when the [=sensor=] is used
+an indication of when the [=device sensor|sensor=] is used
 and allowing the user to disable it.
 Additionally, user agents may consider
 allowing the user to verify past and current sensor use patterns.
 
-Web application developers that use [=sensors=] should
+Web application developers that use [=device sensor|sensors=] should
 perform a privacy impact assessment of their application
 taking all aspects of their application into consideration.
 
@@ -445,7 +445,7 @@ the [=top-level browsing contexts=] suddenly becomes in a position
 to carry out a skimming attack against the [=browsing context=] that has [=gains focus|gained focus=].
 
 To mitigate this threat,
-[=sensor reading|readings=] of [=sensors=] running in a [=top-level browsing contexts=]
+[=sensor reading|readings=] of [=device sensor|sensors=] running in a [=top-level browsing contexts=]
 are not delivered in such cases.
 A [=security check=] is run before [=sensor readings=] are delivered to ensure that.
 
@@ -552,12 +552,15 @@ which would have issues of its own.
 
 <h3 id="concepts-sensors">Sensors</h3>
 
-A [=sensor=] measures different physical quantities
+The term <dfn id="concept-device-sensor">device sensor</dfn> refers to a device's underlying
+physical sensor instance.
+
+The [=device sensors=] measure different physical quantities
 and provide corresponding <dfn>raw sensor readings</dfn>
 which are a source of information about the user and their environment.
 
 Each [=raw sensor reading|reading=] is composed of the <dfn lt="reading value">values</dfn>
-of the different physical quantities measured by the [=sensor=]
+of the different physical quantities measured by the [=device sensor|sensor=]
 at time <var ignore>t<sub>n</sub></var>.
 
 Known, <em>predictable</em> discrepancies between [=raw sensor readings=]
@@ -569,6 +572,22 @@ through a process called [=sensor fusion=].
 
 [=calibration|Calibrated=] [=raw sensor readings=] are referred to as <dfn>sensor readings</dfn>,
 whether or not they have undergone [=sensor fusion=].
+
+The term <dfn id="concept-platform-sensor">platform sensor</dfn> refers to platform interfaces,
+with which the user agent ineracts to obtain [=sensor readings=] for a single [=sensor type=]
+originated from one or several [=device sensors=].
+
+[=Platform sensor=] can be defined by the underlying platform (e.g. in a native sensors framework)
+or by the user agent, if it has a direct access to [=device sensor=].
+
+In simple case a [=platform sensor=] corresponds to a single [=device sensor=],
+but if the provided [=sensor readings=] are product of [=sensor fusion=] performed
+in software, the [=platform sensor=] corresponds to a set of [=device sensors=]
+involved in the [=sensor fusion=] process.
+
+Note: [=platform sensors=] created through [=sensor fusion=] are sometimes
+called virtual or synthetic sensors. However, the specification doesn't
+make any practical distinction between them.
 
 <h3 id="concepts-sensor-types">Sensor Types</h3>
 
@@ -642,14 +661,6 @@ by using the raw output of a gyroscope
 and waiting for quick rotational movements of the head
 to compensate for drift.
 
-Note: [=sensors=] created through [=sensor fusion=] are sometimes
-called virtual or synthetic sensors.
-However, the specification doesn't make any practical differences between them,
-preferring instead to differentiate [=sensors=] as to whether they describe
-the kind of [=sensor readings|readings=] produced--these are [=high-level=] sensors--
-or how the sensor is implemented ([=low-level=] sensors).
-
-
 <h3 id="concepts-reporting-modes">Reporting Modes</h3>
 
 Issue: **This feature is at risk.**
@@ -686,7 +697,7 @@ when no requirements are made as to what [=frequency=] they should operate at.
 Note: [=reporting mode=] is distinct from,
 but related to,
 [=sensor readings=] acquisition.
-If [=sensors=] are polled at regular interval,
+If [=device sensors=] are polled at regular interval,
 as is generally the case,
 [=reporting mode=] can be either [=periodic=] or [=implementation specific=].
 However, when the underlying implementation itself only provides [=sensor readings=]
@@ -710,7 +721,7 @@ and thus "on change" sensors would be useful.
 
 ## Sampling Frequency ## {#concepts-sampling-frequency}
 
-For the purpose of this specification, <dfn>sampling frequency</dfn> for a [=sensor=] is defined
+For the purpose of this specification, <dfn>sampling frequency</dfn> for a [=platform sensor=] is defined
 as a frequency at which the UA obtains [=sensor readings=] from the underlying platform.
 
 <h2 id="model">Model</h2>
@@ -724,9 +735,9 @@ whose [=inherited interfaces=] contains {{Sensor}}.
 
 A [=sensor type=] has a [=ordered set|set=] of <dfn export>associated sensors</dfn>.
 
-If a [=sensor type=] has more than one [=sensor=],
+If a [=sensor type=] has more than one [=platform sensor=],
 it must have a set of associated <dfn export>identifying parameters</dfn>
-to select the right [=sensor=] to associate to each new {{Sensor}} objects.
+to select the right [=platform sensor=] to associate to each new {{Sensor}} objects.
 
 A [=sensor type=] may have a <dfn export>default sensor</dfn>.
 
@@ -749,19 +760,19 @@ A [=sensor type=] has a [=permission revocation algorithm=].
 
 <h3 id="model-sensor">Sensor</h3>
 
-A <dfn id=concept-sensor>sensor</dfn> has an associated [=ordered set|set=]
+A [=platform sensor=] has an associated [=ordered set|set=]
 of <dfn>activated sensor objects</dfn>.
 This set is initially [=set/is empty|empty=].
 
-The current [=browsing context=]'s [=sensor=] has an associated <dfn>latest reading</dfn>
+The current [=browsing context=]'s [=platfrom sensor=] has an associated <dfn>latest reading</dfn>
 [=ordered map|map=] which holds the latest available [=sensor readings=].
 
 Note: User agents can share [=sensor readings=] [=ordered map|map=] between different
 [=browsing context|contexts=] only if the [=origins=] of these contexts' [=active documents=]
 are [=same origin-domain=].
 
-Any time the user agent obtains a new [=sensor reading=] for a [=sensor=] from the underlying
-platform, it invokes [=update latest reading=] with the [=sensor=] and the [=sensor reading=]
+Any time the user agent obtains a new [=sensor reading=] for a [=platfrom sensor=] from the underlying
+platform, it invokes [=update latest reading=] with the [=platfrom sensor=] and the [=sensor reading=]
 as arguments.
 
 The [=latest reading=] [=ordered map|map=]
@@ -774,7 +785,7 @@ expressed in milliseconds that passed since the [=time origin=].
 unless the [=latest reading=] [=ordered map|map=] caches a previous [=sensor readings|reading=].
 
 The other [=map/entries=] of the [=latest reading=] [=ordered map|map=]
-hold the values of the different quantities measured by the [=sensor=].
+hold the values of the different quantities measured by the [=platform sensor=].
 The [=map/keys=] of these [=map/entries=] must match
 the [=attribute=] [=identifier=] defined by
 the [=sensor type=]'s associated interface.
@@ -791,9 +802,9 @@ caches a previous [=sensor readings|reading=].
 
 Note: there are additional privacy concerns when using cached [=sensor readings|readings=]
 which predate either [=navigating=] to resources in the current [=origin=],
-or being granted permission to access the [=sensor=]. -->
+or being granted permission to access the [=platform sensor=]. -->
 
-A [=sensor=] has an associated <dfn>current sampling frequency</dfn> which is initially null.
+A [=platform sensor=] has an associated <dfn>current sampling frequency</dfn> which is initially null.
 
 For a non[=set/is empty|empty=] [=ordered set|set=] of [=activated sensor objects=] the
 [=current sampling frequency=] is equal to <dfn>optimal sampling frequency</dfn>, which is estimated
@@ -827,15 +838,15 @@ dictionary SensorOptions {
 };
 </pre>
 
-A {{Sensor}} object has an associated [=sensor=].
+A {{Sensor}} object has an associated [=platform sensor=].
 
 The [=task source=] for the [=tasks=] mentioned in this specification is the <dfn>sensor task source</dfn>.
 
 <div class="example">
     In the following example, we construct accelerometer sensor and add
-    [=event listener|event listeners=] to get [=event|events=] for [=sensor=] activation, error
+    [=event listener|event listeners=] to get [=event|events=] for [=platform sensor=] activation, error
     conditions and notifications about newly available [=sensor readings=]. The example measures
-    and logs maximum total acceleration of a device hosting the [=sensor=].
+    and logs maximum total acceleration of a device hosting the [=platform sensor=].
 
     The [=event handler event types=] for the corresponding
     [[#the-sensor-interface| Sensor Interface]]'s [=event handler=] attributes are defined in
@@ -980,7 +991,7 @@ with the internal slots described in the following table:
             <td><dfn attribute for=Sensor>\[[identifyingParameters]]</dfn></td>
             <td>
                 A [=sensor type=]-specific group of [=dictionary members=]
-                used to select the correct [=sensor=]
+                used to select the correct [=platform sensor=]
                 to associate to this {{Sensor}} object.
             </td>
         </tr>
@@ -1158,17 +1169,17 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     : input
     :: |sensor_instance|, a {{Sensor}} object.
     : output
-    :: True if sensor instance was associated with a [=sensor=],
+    :: True if sensor instance was associated with a [=platform sensor=],
        false otherwise.
 
     1.  If |sensor_instance|.{{[[identifyingParameters]]}} is set and
         |sensor_instance|.{{[[identifyingParameters]]}} allows
-        a unique [=sensor=] to be identified, then:
-        1.  let |sensor| be that [=sensor=],
+        a unique [=platform sensor=] to be identified, then:
+        1.  let |sensor| be that [=platform sensor=],
         1.  associate |sensor_instance| with |sensor|.
         1.  Return true.
     1.  If the [=sensor type=] of |sensor_instance| has an associated [=default sensor=]
-        and there is a corresponding [=sensor=] on the device, then
+        and there is a corresponding [=platform sensor=] on the device, then
         1.  associate |sensor_instance| with [=default sensor=].
         1.  Return true.    
     1.  Return false.
@@ -1184,7 +1195,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     : output
     :: None
 
-    1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
+    1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
     1.  [=set/Append=] |sensor_instance| to |sensor|'s set of [=activated sensor objects=].
     1.  Invoke [=set sensor settings=] with |sensor| as argument.
     1.  Queue a task to run [=notify activated state=] with |sensor_instance|
@@ -1203,7 +1214,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 
     1.  Remove all [=tasks=] associated with |sensor_instance| from the [=task queue=] associated
         with [=sensor task source=].
-    1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
+    1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
     1.  If |sensor|'s set of [=activated sensor objects=] [=set/contains=] |sensor_instance|,
         1.  [=set/Remove=] |sensor_instance| from |sensor|'s set of [=activated sensor objects=].
         1.  Invoke [=set sensor settings=] with |sensor| as argument.
@@ -1216,7 +1227,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 <div algorithm="revoke sensor permission">
 
     : input
-    :: |sensor|, a [=sensor=].
+    :: |sensor|, a [=platform sensor=].
     : output
     :: None
 
@@ -1234,7 +1245,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 <div algorithm="set sensor settings">
 
     : input
-    :: |sensor|, a [=sensor=].
+    :: |sensor|, a [=platform sensor=].
     : output
     :: None
 
@@ -1253,7 +1264,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
 <div algorithm="update latest reading">
 
     : input
-    :: |sensor|, a [=sensor=].
+    :: |sensor|, a [=platform sensor=].
     :: |reading|, a [=sensor reading=].
 
     Issue: The timestamp needs to be specified more precisely,
@@ -1326,7 +1337,7 @@ in order to reduce resource consumption, notably battery usage.
     1.  Let |f| be |sensor_instance|.{{[[desiredSamplingFrequency]]}}.
         1. if |f| is set,
             1. set |frequency| to |f| capped by the upper and lower [=current sampling frequency=]
-               bounds for the associated [=sensor=].
+               bounds for the associated [=platform sensor=].
         1.  Otherwise,
             1. user agent can assign |frequency| to an appropriate value.
     1. return |frequency|.
@@ -1389,7 +1400,7 @@ in order to reduce resource consumption, notably battery usage.
 
     1.  Set |sensor_instance|.{{[[state]]}} to "activated".
     1.  [=Fire an event=] named "activate" at |sensor_instance|.
-    1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
+    1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
     1.  If |sensor|’s [=latest reading=]["timestamp"] is not null,
         1.  Queue a task to run [=notify new reading=] with |sensor_instance|
             as an argument.
@@ -1423,7 +1434,7 @@ in order to reduce resource consumption, notably battery usage.
     :: A [=sensor reading=] value or null.
 
     1.  If |sensor_instance|.{{[[state]]}} is "activated",
-        1.  Let |readings| be the [=latest reading=] of |sensor_instance|'s related [=sensor=].
+        1.  Let |readings| be the [=latest reading=] of |sensor_instance|'s related [=platform sensor=].
         1.  Return |readings|[|key|].
     1.  Otherwise, return null.
 </div>
@@ -1438,7 +1449,7 @@ in order to reduce resource consumption, notably battery usage.
     : output
     :: A [=permission state=].
 
-    1.  Let |sensor| be the [=sensor=] associated with |sensor_instance|.
+    1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
     1.  Let |permission_name| be the {{PermissionName}} associated with |sensor|.
     1.  Let |state| be the result of [=request permission to use|requesting permission to use=] |permission_name|.
     1.  Return |state|.
@@ -1476,13 +1487,13 @@ Extension specifications are expected to:
 <h3 id="naming">Naming</h3>
 
 {{Sensor}} interfaces for [=low-level=] sensors should be
-named after their associated [=sensor=].
+named after their associated [=platform sensor=].
 So for example, the interface associated with a gyroscope
 should be simply named `Gyroscope`.
 {{Sensor}} interfaces for [=high-level=] sensors should be
-named by combining the physical quantity the [=sensor=] measures
+named by combining the physical quantity the [=platform sensor=] measures
 with the "Sensor" suffix.
-For example, a [=sensor=] measuring
+For example, a [=platform sensor=] measuring
 the distance at which an object is from it
 may see its associated interface called `ProximitySensor`.
 
@@ -1569,10 +1580,10 @@ An extension specification may specify the following definitions
 for each [=sensor types=]:
 
 -   A [=dictionary=] whose [=inherited dictionaries=] contains {{SensorOptions}}.
--   A [=default sensor=]. Generally, devices are equipped with a single [=sensor=]
+-   A [=default sensor=]. Generally, devices are equipped with a single [=platform sensor=]
     of each [=sensor types|type=],
     so defining a [=default sensor=] should be straightforward.
-    For [=sensor types=] where multiple [=sensors=] are common,
+    For [=sensor types=] where multiple [=device senosrs|sensors=] are common,
     extension specifications may choose not to define a [=default sensor=],
     especially when doing so would not make sense.
 -   A set of [=identifying parameters=]. TODO: replace that by an abstract operation.
@@ -1608,7 +1619,7 @@ for accelerometer sensor is given below.
 <h3 id="example-webidl">Example WebIDL</h3>
 
 Here's example WebIDL for a possible extension of this specification
-for proximity [=sensors=].
+for proximity [=device sesnors|sensors=].
 
 <pre class=example>
     [Constructor(optional ProximitySensorOptions proximitySensorOptions),
@@ -1745,7 +1756,7 @@ for their editorial input.
     <p>Because this document doesn't itself define APIs for specific [=sensor types=]--
     that is the role of extensions to this specification--
     all examples are inevitably (wishful) fabrications.
-    Although all of the [=sensors=] used a examples
+    Although all of the [=device sensor|sensors=] used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
     are planning to do so.

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,6 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version df778ba2d9793f77f64705dbba65d0c50f68e0d9" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
-  <meta content="8ccec25d6639955304e2355ac7a008db4cf63411" name="document-revision">
 <style>
     emu-val {
       font-weight: bold;
@@ -1697,15 +1696,15 @@ either to another section of the spec
 or to an external explainer document.</p>
    <p>The Generic Sensor API is designed to make the most common use cases straightforward
 while still enabling more complex use cases.</p>
-   <p>Most devices deployed today do not carry more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type">sensor types</a>.
+   <p>Most devices deployed today do not carry more than one <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type">sensor types</a>.
 This shouldn’t come as a surprise since use cases for more than
-a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①">type</a> are rare
+a <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①">type</a> are rare
 and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②">sensor types</a>,
 such as proximity sensors.</p>
    <p>The API therefore makes it easy to interact with
-the device’s default (and often unique) <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor">Sensor</a></code> subclass.</p>
-   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④">type</a>,
-the default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④">sensor</a> is chosen.</p>
+the device’s default (and often unique) <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor">Sensor</a></code> subclass.</p>
+   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④">type</a>,
+the default <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor④">sensor</a> is chosen.</p>
    <div class="example" id="example-2b740ace">
     <a class="self-link" href="#example-2b740ace"></a> Listening to geolocation changes: 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">({</span> accuracy<span class="o">:</span> <span class="s2">"high"</span> <span class="p">});</span>
@@ -1723,16 +1722,16 @@ sensor<span class="p">.</span>start<span class="p">();</span>
    </div>
    <p class="note" role="note"><span>Note:</span> extension to this specification may choose not to define a default sensor
 when doing so wouldn’t make sense.
-For example, it might be difficult to agree on an obvious default <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑤">sensor</a> for
-proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑥">sensors</a>.</p>
+For example, it might be difficult to agree on an obvious default <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑤">sensor</a> for
+proximity <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑥">sensors</a>.</p>
    <p>In cases where
-multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑦">sensors</a> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑤">type</a> may coexist on the same device,
+multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑦">sensors</a> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑤">type</a> may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.</p>
    <div class="example" id="example-fdd94e11">
     <a class="self-link" href="#example-fdd94e11"></a> For example checking the pressure of the left rear tire: 
 <pre class="highlight"><span class="kd">var</span> sensor <span class="o">=</span> <span class="k">new</span> DirectTirePressureSensor<span class="p">({</span> position<span class="o">:</span> <span class="s2">"rear"</span><span class="p">,</span> side<span class="o">:</span> <span class="s2">"left"</span> <span class="p">});</span>
-sensor<span class="p">.</span>onreading <span class="o">=</span> _ <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>pressure<span class="p">);</span>
+sensor<span class="p">.</span>onreading <span class="o">=</span> _ <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>pressure<span class="p">);</span>
 sensor<span class="p">.</span>start<span class="p">();</span>
 </pre>
    </div>
@@ -1796,8 +1795,8 @@ and defensive programming which includes:</p>
 <pre class="highlight"><span class="k">try</span> <span class="p">{</span> <span class="c1">// No need to feature detect thanks to try..catch block.</span>
 <span class="c1"></span>    <span class="kd">var</span> sensor <span class="o">=</span> <span class="k">new</span> GeolocationSensor<span class="p">();</span>
     sensor<span class="p">.</span>start<span class="p">();</span>
-    sensor<span class="p">.</span>onerror <span class="o">=</span> error <span class="o">=></span> gracefullyDegrade<span class="p">(</span>error<span class="p">);</span>
-    sensor<span class="p">.</span>onreading <span class="o">=</span> _ <span class="o">=></span> updatePosition<span class="p">(</span>sensor<span class="p">.</span>latitude<span class="p">,</span> sensor<span class="p">.</span>longitude<span class="p">);</span>
+    sensor<span class="p">.</span>onerror <span class="o">=</span> error <span class="p">=></span> gracefullyDegrade<span class="p">(</span>error<span class="p">);</span>
+    sensor<span class="p">.</span>onreading <span class="o">=</span> _ <span class="p">=></span> updatePosition<span class="p">(</span>sensor<span class="p">.</span>latitude<span class="p">,</span> sensor<span class="p">.</span>longitude<span class="p">);</span>
 <span class="p">}</span> <span class="k">catch</span><span class="p">(</span>error<span class="p">)</span> <span class="p">{</span>
     gracefullyDegrade<span class="p">(</span>error<span class="p">);</span>
 <span class="p">}</span>
@@ -1806,10 +1805,10 @@ and defensive programming which includes:</p>
    <h2 class="heading settled" data-level="5" id="security-and-privacy"><span class="secno">5. </span><span class="content">Security and privacy considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
    <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings">Sensor readings</a> are sensitive data and could become a subject of
 various attacks from malicious Web pages. Before discussing the mitigation strategies we
-briefly enumerate the main types of the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑧">sensor</a>'s privacy and security threats.
+briefly enumerate the main types of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑧">sensor</a>'s privacy and security threats.
 The <a data-link-type="biblio" href="#biblio-mobilesensors">[MOBILESENSORS]</a> categorizes main threats into <a href="#location-tracking">location tracking</a>, <a href="#eavesdropping">eavesdropping</a>, <a href="#keystroke-monitoring">keystroke monitoring</a>, <a href="#device-fingerprinting">device fingerprinting</a>, and <a href="#user-identifying">user identification</a>.
 This categorization is a good fit for this specification.</p>
-   <p>The risk of successful attack can increase when <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑨">sensors</a> are used with each other,
+   <p>The risk of successful attack can increase when <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑨">sensors</a> are used with each other,
 in combination with other functionality, or when used over time,
 specifically with the risk of correlation of data
 and user identification through fingerprinting.
@@ -1834,11 +1833,11 @@ used simultaneously in different window contexts on the same device
 it may be possible for that code to correlate the user across those two contexts,
 creating unanticipated tracking mechanisms.</p>
    <p>User agents should consider providing the user
-an indication of when the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⓪">sensor</a> is used
+an indication of when the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⓪">sensor</a> is used
 and allowing the user to disable it.
 Additionally, user agents may consider
 allowing the user to verify past and current sensor use patterns.</p>
-   <p>Web application developers that use <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①①">sensors</a> should
+   <p>Web application developers that use <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①①">sensors</a> should
 perform a privacy impact assessment of their application
 taking all aspects of their application into consideration.</p>
    <p>Ability to detect a full working set of sensors on a device can form an
@@ -1890,7 +1889,7 @@ or when a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/b
 using a third party payment service from within an iframe)
 the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context②">top-level browsing contexts</a> suddenly becomes in a position
 to carry out a skimming attack against the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a> that has <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#gains-focus" id="ref-for-gains-focus①">gained focus</a>.</p>
-   <p>To mitigate this threat, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑨">readings</a> of <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①②">sensors</a> running in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context③">top-level browsing contexts</a> are not delivered in such cases.
+   <p>To mitigate this threat, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑨">readings</a> of <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①②">sensors</a> running in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context③">top-level browsing contexts</a> are not delivered in such cases.
 A <a data-link-type="dfn" href="#security-check" id="ref-for-security-check">security check</a> is run before <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings①⓪">sensor readings</a> are delivered to ensure that.</p>
    <h4 class="heading settled" data-level="5.2.4" id="visibility-state"><span class="secno">5.2.4. </span><span class="content">Visibility State</span><a class="self-link" href="#visibility-state"></a></h4>
    <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings①①">Sensor readings</a> are only available
@@ -1956,23 +1955,35 @@ about current and past use of the API.</p>
    <p class="note" role="note"><span>Note:</span> this does not imply keeping a log of the actual <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings①⑧">sensor readings</a> which would have issues of its own.</p>
    <h2 class="heading settled" data-level="6" id="concepts"><span class="secno">6. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="concepts-sensors"><span class="secno">6.1. </span><span class="content">Sensors</span><a class="self-link" href="#concepts-sensors"></a></h3>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①③">sensor</a> measures different physical quantities
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-device-sensor">device sensor</dfn> refers to a device’s underlying
+physical sensor instance.</p>
+   <p>The <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①③">device sensors</a> measure different physical quantities
 and provide corresponding <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="raw-sensor-readings">raw sensor readings</dfn> which are a source of information about the user and their environment.</p>
-   <p>Each <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings">reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the different physical quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①④">sensor</a> at time <var>t<sub>n</sub></var>.</p>
+   <p>Each <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings">reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the different physical quantities measured by the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①④">sensor</a> at time <var>t<sub>n</sub></var>.</p>
    <p>Known, <em>predictable</em> discrepancies between <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings①">raw sensor readings</a> and the corresponding physical quantities being measured
 are corrected through <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="calibration">calibration</dfn>.</p>
    <p>Known but <em>unpredictable</em> discrepancies need to be addressed dynamically
 through a process called <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion">sensor fusion</a>.</p>
    <p><a data-link-type="dfn" href="#calibration" id="ref-for-calibration">Calibrated</a> <a data-link-type="dfn" href="#raw-sensor-readings" id="ref-for-raw-sensor-readings②">raw sensor readings</a> are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-readings">sensor readings</dfn>,
 whether or not they have undergone <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①">sensor fusion</a>.</p>
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-platform-sensor">platform sensor</dfn> refers to platform interfaces,
+with which the user agent ineracts to obtain <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings①⑨">sensor readings</a> for a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑨">sensor type</a> originated from one or several <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑤">device sensors</a>.</p>
+   <p><a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor">Platform sensor</a> can be defined by the underlying platform (e.g. in a native sensors framework)
+or by the user agent, if it has a direct access to <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑥">device sensor</a>.</p>
+   <p>In simple case a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①">platform sensor</a> corresponds to a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑦">device sensor</a>,
+but if the provided <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⓪">sensor readings</a> are product of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion②">sensor fusion</a> performed
+in software, the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②">platform sensor</a> corresponds to a set of <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑧">device sensors</a> involved in the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion③">sensor fusion</a> process.</p>
+   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③">platform sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion④">sensor fusion</a> are sometimes
+called virtual or synthetic sensors. However, the specification doesn’t
+make any practical distinction between them.</p>
    <h3 class="heading settled" data-level="6.2" id="concepts-sensor-types"><span class="secno">6.2. </span><span class="content">Sensor Types</span><a class="self-link" href="#concepts-sensor-types"></a></h3>
-   <p>Different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑨">sensor types</a> measure different physical quantities
+   <p>Different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⓪">sensor types</a> measure different physical quantities
 such as temperature, air pressure, heart-rate, or luminosity.</p>
-   <p>For the purpose of this specification we distinguish between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⓪">sensor types</a>.</p>
-   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①①">Sensor types</a> which are characterized by their implementation
+   <p>For the purpose of this specification we distinguish between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①①">sensor types</a>.</p>
+   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①②">Sensor types</a> which are characterized by their implementation
 are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="low-level">low-level</dfn> sensors.
-For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level②">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①②">sensor type</a>.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⑤">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings①⑨">readings</a>,
+For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level②">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①③">sensor type</a>.</p>
+   <p><a data-link-type="dfn">Sensors</a> named after their <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②①">readings</a>,
 regardless of the implementation,
 are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-level">high-level</dfn> sensors.
 For instance, geolocation sensors provide information about the user’s location,
@@ -1981,33 +1992,33 @@ is purposefully left opaque
 (it could come from a GPS chip, network cell triangulation,
 wifi networks, etc. or any combination of the above)
 and depends on various, implementation-specific heuristics. <a data-link-type="dfn" href="#high-level" id="ref-for-high-level②">High-level</a> sensors are generally the fruits of
-applying algorithms to <a data-link-type="dfn" href="#low-level" id="ref-for-low-level③">low-level</a> sensors—<wbr>for example, a pedometer can be built using only the output of a gyroscope—<wbr>or of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion②">sensor fusion</a>.</p>
-   <p>That said, the distinction between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level③">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level④">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①③">sensor types</a> is somewhat arbitrary and the line between the two is often blurred.
+applying algorithms to <a data-link-type="dfn" href="#low-level" id="ref-for-low-level③">low-level</a> sensors—<wbr>for example, a pedometer can be built using only the output of a gyroscope—<wbr>or of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑤">sensor fusion</a>.</p>
+   <p>That said, the distinction between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level③">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level④">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①④">sensor types</a> is somewhat arbitrary and the line between the two is often blurred.
 For instance, a barometer, which measures air pressure,
 would be considered <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑤">low-level</a> for most common purposes,
-even though it is the product of the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion③">sensor fusion</a> of
+even though it is the product of the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑥">sensor fusion</a> of
 resistive piezo-electric pressure and temperature sensors.
 Exposing the sensors that compose it would serve no practical purpose;
 who cares about the temperature of a piezo-electric sensor?
 A pressure-altimeter would probably fall in the same category,
-while a nondescript altimeter—<wbr>which could get its data from either a barometer or a GPS signal—<wbr>would clearly be categorized as a <a data-link-type="dfn" href="#high-level" id="ref-for-high-level④">high-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①④">sensor type</a>.</p>
+while a nondescript altimeter—<wbr>which could get its data from either a barometer or a GPS signal—<wbr>would clearly be categorized as a <a data-link-type="dfn" href="#high-level" id="ref-for-high-level④">high-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑤">sensor type</a>.</p>
    <p>Because the distinction is somewhat blurry,
 extensions to this specification (see <a href="#extensibility">§10 Extensibility</a>)
 are encouraged to provide domain-specific definitions of <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑤">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑥">low-level</a> sensors
-for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑤">sensor types</a> they are targeting.</p>
-   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⓪">Sensor readings</a> from different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">sensor types</a> can be combined together
+for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">sensor types</a> they are targeting.</p>
+   <p><a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②②">Sensor readings</a> from different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑦">sensor types</a> can be combined together
 through a process called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-fusion">sensor fusion</dfn>.
 This process provides <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑥">higher-level</a> or
 more accurate data (often at the cost of increased latency).
-For example, the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②①">readings</a> of a three-axis magnetometer
-needs to be combined with the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②②">readings</a> of an accelerometer
+For example, the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②③">readings</a> of a three-axis magnetometer
+needs to be combined with the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②④">readings</a> of an accelerometer
 to provide a correct bearing.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="smart-sensors">Smart sensors</dfn> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-hubs">sensor hubs</dfn> have built-in compute resources which allow them
-to carry out <a data-link-type="dfn" href="#calibration" id="ref-for-calibration①">calibration</a> and <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion④">sensor fusion</a> at the hardware level,
+to carry out <a data-link-type="dfn" href="#calibration" id="ref-for-calibration①">calibration</a> and <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑦">sensor fusion</a> at the hardware level,
 freeing up CPU resources
 and lowering battery consumption
 in the process.</p>
-   <p>But <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑤">sensor fusion</a> can also be carried out in software.
+   <p>But <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑧">sensor fusion</a> can also be carried out in software.
 This is particularly useful when performance requirements can only be met
 by relying on application-specific data.
 For example, head tracking for virtual or augmented reality applications
@@ -2017,37 +2028,32 @@ That low-latency is best provided
 by using the raw output of a gyroscope
 and waiting for quick rotational movements of the head
 to compensate for drift.</p>
-   <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⑥">sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑥">sensor fusion</a> are sometimes
-called virtual or synthetic sensors.
-However, the specification doesn’t make any practical differences between them,
-preferring instead to differentiate <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⑦">sensors</a> as to whether they describe
-the kind of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②③">readings</a> produced--these are <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high-level</a> sensors—<wbr>or how the sensor is implemented (<a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low-level</a> sensors).</p>
    <h3 class="heading settled" data-level="6.3" id="concepts-reporting-modes"><span class="secno">6.3. </span><span class="content">Reporting Modes</span><a class="self-link" href="#concepts-reporting-modes"></a></h3>
    <p class="issue" id="issue-f240c7ff"><a class="self-link" href="#issue-f240c7ff"></a> <strong>This feature is at risk.</strong> It is not clear whether there is value
-in splitting up <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑦">sensor types</a> between
+in splitting up <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑧">sensor types</a> between
 those that fire events at regular intervals
 and those which don’t.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⑧">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
-When <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②④">sensor readings</a> are reported at regular intervals,
+   <p><a data-link-type="dfn">Sensors</a> have different <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-modes">reporting modes</dfn>.
+When <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑤">sensor readings</a> are reported at regular intervals,
 at an adjustable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="frequency">frequency</dfn> measured in hertz (Hz),
 the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes①">reporting mode</a> is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="periodic">periodic</dfn>.
-On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑧">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic①">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic②">periodic reporting mode</a> is triggered
+On <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑨">sensor types</a> with support for <a data-link-type="dfn" href="#periodic" id="ref-for-periodic①">periodic reporting mode</a>, <a data-link-type="dfn" href="#periodic" id="ref-for-periodic②">periodic reporting mode</a> is triggered
 by requesting a specific <a data-link-type="dfn" href="#frequency" id="ref-for-frequency">frequency</a>.</p>
-   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑨">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic③">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
-When the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes②">reporting mode</a> is <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific">implementation specific</a>, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑤">sensor readings</a> may be provided at regular intervals, irregularly,
-or only when a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑥">reading</a> change is observed.
+   <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">Sensor types</a> which do not support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic③">periodic reporting mode</a> are said to operate in an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implementation-specific">implementation specific</dfn> way.
+When the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes②">reporting mode</a> is <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific">implementation specific</a>, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑥">sensor readings</a> may be provided at regular intervals, irregularly,
+or only when a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑦">reading</a> change is observed.
 This allows user agents more latitude to
 carry out power- or CPU-saving strategies,
 and support multiple hardware configurations. <a data-link-type="dfn" href="#periodic" id="ref-for-periodic④">Periodic reporting mode</a>, on the other hand,
 allows a much more fine-grained approach
 and is essential for use cases with, for example,
 low latency requirements.</p>
-   <p><a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor①⑨">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic⑤">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific①">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency①">frequency</a> they should operate at.</p>
+   <p><a data-link-type="dfn">Sensors</a> which support <a data-link-type="dfn" href="#periodic" id="ref-for-periodic⑤">periodic reporting mode</a> <dfn data-dfn-type="dfn" data-noexport="" id="fallback">fallback<a class="self-link" href="#fallback"></a></dfn> to <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific①">implementation specific reporting mode</a> when no requirements are made as to what <a data-link-type="dfn" href="#frequency" id="ref-for-frequency①">frequency</a> they should operate at.</p>
    <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes③">reporting mode</a> is distinct from,
-but related to, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑦">sensor readings</a> acquisition.
-If <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⓪">sensors</a> are polled at regular interval,
+but related to, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑧">sensor readings</a> acquisition.
+If <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">device sensors</a> are polled at regular interval,
 as is generally the case, <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes④">reporting mode</a> can be either <a data-link-type="dfn" href="#periodic" id="ref-for-periodic⑥">periodic</a> or <a data-link-type="dfn" href="#implementation-specific" id="ref-for-implementation-specific②">implementation specific</a>.
-However, when the underlying implementation itself only provides <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑧">sensor readings</a> when it measures change,
+However, when the underlying implementation itself only provides <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑨">sensor readings</a> when it measures change,
 perhaps because is is relying on <a data-link-type="dfn" href="#smart-sensors" id="ref-for-smart-sensors">smart sensors</a> or a <a data-link-type="dfn" href="#sensor-hubs" id="ref-for-sensor-hubs">sensor hubs</a>,
 the <a data-link-type="dfn" href="#reporting-modes" id="ref-for-reporting-modes⑤">reporting mode</a> cannot be <a data-link-type="dfn" href="#periodic" id="ref-for-periodic⑦">periodic</a>,
 as that would require data inference.</p>
@@ -2062,19 +2068,19 @@ how increased sensor sampling frequency decreases latency.</p>
 how it affects threshold,
 and thus "on change" sensors would be useful.</p>
    <h3 class="heading settled" data-level="6.4" id="concepts-sampling-frequency"><span class="secno">6.4. </span><span class="content">Sampling Frequency</span><a class="self-link" href="#concepts-sampling-frequency"></a></h3>
-   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②①">sensor</a> is defined
-as a frequency at which the UA obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑨">sensor readings</a> from the underlying platform.</p>
+   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor④">platform sensor</a> is defined
+as a frequency at which the UA obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⓪">sensor readings</a> from the underlying platform.</p>
    <h2 class="heading settled" data-level="7" id="model"><span class="secno">7. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p class="issue" id="issue-d36d1a2e"><a class="self-link" href="#issue-d36d1a2e"></a> A diagram would really help here.</p>
    <h3 class="heading settled" data-level="7.1" id="model-sensor-type"><span class="secno">7.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②">Sensor</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
-   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②②">sensor</a>,
-it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②③">sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③">Sensor</a></code> objects.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code>.</p>
-   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">PermissionName</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
+   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑤">platform sensor</a>,
+it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑥">platform sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③">Sensor</a></code> objects.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> may have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code>.</p>
+   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">PermissionName</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
    <div class="algorithm" data-algorithm="permission revocation algorithm">
     <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname②">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
     <ol>
@@ -2091,26 +2097,26 @@ it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" da
     </ol>
    </div>
    <h3 class="heading settled" data-level="7.2" id="model-sensor"><span class="secno">7.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-sensor">sensor</dfn> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
+   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑦">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
 This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
-   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②④">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⓪">sensor readings</a>.</p>
-   <p class="note" role="note"><span>Note:</span> User agents can share <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③①">sensor readings</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2①">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a>.</p>
-   <p>Any time the user agent obtains a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③②">sensor reading</a> for a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⑤">sensor</a> from the underlying
-platform, it invokes <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> with the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⑥">sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③③">sensor reading</a> as arguments.</p>
+   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn">platfrom sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③①">sensor readings</a>.</p>
+   <p class="note" role="note"><span>Note:</span> User agents can share <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③②">sensor readings</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2①">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a>.</p>
+   <p>Any time the user agent obtains a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③③">sensor reading</a> for a <a data-link-type="dfn">platfrom sensor</a> from the underlying
+platform, it invokes <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> with the <a data-link-type="dfn">platfrom sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③④">sensor reading</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is "timestamp" and
 whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> is a high resolution timestamp of the time
 at which the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①">latest reading</a> was obtained
 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin">time origin</a>. <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading②">latest reading</a>["timestamp"] is initially set to null,
-unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading③">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③④">reading</a>.</p>
-   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading④">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⑦">sensor</a>.
+unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading③">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">reading</a>.</p>
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading④">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑧">platform sensor</a>.
 The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry②">entries</a> must match
 the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier">identifier</a> defined by
-the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a>'s associated interface.
+the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a>'s associated interface.
 The return value of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute①">attribute</a> getter is
-easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a>'s associated interface
+easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a>'s associated interface
 and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute②">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier①">identifier</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑤">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry③">entries</a> is initially set to null.</p>
-   <p>A <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⑧">sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
+   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-sampling-frequency">current sampling frequency</dfn> which is initially null.</p>
    <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> the <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency">current sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
 by the UA taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-desiredsamplingfrequency-slot" id="ref-for-dom-sensor-desiredsamplingfrequency-slot">desired sampling frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency③">sampling frequency</a> bounds defined
 by the underlying platform.</p>
@@ -2133,18 +2139,18 @@ by the underlying platform.</p>
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor②⑨">sensor</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a>.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
-   <div class="example" id="example-b77a6b87">
-    <a class="self-link" href="#example-b77a6b87"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⓪">sensor</a> activation, error
-    conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor readings</a>. The example measures
-    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③①">sensor</a>. 
+   <div class="example" id="example-6910c0fd">
+    <a class="self-link" href="#example-6910c0fd"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①①">platform sensor</a> activation, error
+    conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑥">sensor readings</a>. The example measures
+    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①②">platform sensor</a>. 
     <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
 <pre class="highlight"><span class="kd">let</span> acl <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">30</span><span class="p">});</span>
 <span class="kd">let</span> max_magnitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
-acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'activate'</span><span class="p">,</span> <span class="p">()</span> <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Ready to measure.'</span><span class="p">));</span>
-acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'error'</span><span class="p">,</span> error <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Error: '</span> <span class="o">+</span> error<span class="p">.</span>name<span class="p">));</span>
-acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'reading'</span><span class="p">,</span> <span class="p">()</span> <span class="o">=></span> <span class="p">{</span>
+acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'activate'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Ready to measure.'</span><span class="p">));</span>
+acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'error'</span><span class="p">,</span> error <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Error: '</span> <span class="o">+</span> error<span class="p">.</span>name<span class="p">));</span>
+acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'reading'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> <span class="p">{</span>
     <span class="kd">let</span> magnitude <span class="o">=</span> Math<span class="p">.</span>hypot<span class="p">(</span>acl<span class="p">.</span>x<span class="p">,</span> acl<span class="p">.</span>y<span class="p">,</span> acl<span class="p">.</span>z<span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span>magnitude <span class="o">></span> max_magnitude<span class="p">)</span> <span class="p">{</span>
         max_magnitude <span class="o">=</span> magnitude<span class="p">;</span>
@@ -2248,17 +2254,17 @@ with the internal slots described in the following table:</p>
       <td>The requested <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑤">sampling frequency</a>. It is initially unset.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑥">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> object,
+      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑦">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-pendingreadingnotification-slot"><code>[[pendingReadingNotification]]</code></dfn>
       <td>A boolean which indicates whether the observers need to be
-                notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑦">sensor reading</a> was reported.
+                notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">sensor reading</a> was reported.
                 It is initially false.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-identifyingparameters-slot"><code>[[identifyingParameters]]</code></dfn>
-      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member①">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③②">sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object. 
+      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member①">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object. 
    </table>
    <h4 class="heading settled" data-level="8.1.3" id="sensor-activated"><span class="secno">8.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
@@ -2338,7 +2344,7 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
    </div>
    <h4 class="heading settled" data-level="8.1.7" id="sensor-onreading"><span class="secno">8.1.7. </span><span class="content">Sensor.onreading</span><a class="self-link" href="#sensor-onreading"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading">onreading</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler③">EventHandler</a></code> which is called
-to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">reading</a> is available.</p>
+to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">reading</a> is available.</p>
    <h4 class="heading settled" data-level="8.1.8" id="sensor-onactivate"><span class="secno">8.1.8. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler④">EventHandler</a></code> which is called when <emu-val>this</emu-val>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑤">[[state]]</a></code> transitions from "activating" to "activated".</p>
    <h4 class="heading settled" data-level="8.1.9" id="sensor-onerror"><span class="secno">8.1.9. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
@@ -2429,23 +2435,23 @@ that must be supported as attributes by the objects implementing the <code class
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③③">sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①④">platform sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot①">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot②">[[identifyingParameters]]</a></code> allows
-  a unique <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③④">sensor</a> to be identified, then:</p>
+  a unique <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑤">platform sensor</a> to be identified, then:</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⑤">sensor</a>,</p>
+        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a>,</p>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⑥">sensor</a> on the device, then</p>
+      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a> on the device, then</p>
       <ol>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor①">default sensor</a>.</p>
@@ -2468,7 +2474,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⑦">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated sensor objects</a>.</p>
      <li data-md="">
@@ -2492,7 +2498,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task①">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue">task queue</a> associated
   with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⑧">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>sensor_instance</var>,</p>
       <ol>
@@ -2512,7 +2518,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor③⑨">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2537,7 +2543,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⓪">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2555,7 +2561,7 @@ that must be supported as attributes by the objects implementing the <code class
           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑦">latest reading</a>[<var>key</var>] to null.</p>
         </ol>
        <li data-md="">
-        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">readings</a>.</p>
+        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④①">readings</a>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
@@ -2568,9 +2574,9 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④①">sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a>.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④①">sensor reading</a>.</p>
+      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④②">sensor reading</a>.</p>
     </dl>
     <p class="issue" id="issue-d62b5d37"><a class="self-link" href="#issue-d62b5d37"></a> The timestamp needs to be specified more precisely,
     see <a href="https://github.com/w3c/sensors/issues/155">issue #155</a>.</p>
@@ -2679,7 +2685,7 @@ in order to reduce resource consumption, notably battery usage.</p>
         <p>if <var>f</var> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency③">current sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④②">sensor</a>.</p>
+          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#current-sampling-frequency" id="ref-for-current-sampling-frequency③">current sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>.</p>
         </ol>
        <li data-md="">
         <p>Otherwise,</p>
@@ -2790,7 +2796,7 @@ in order to reduce resource consumption, notably battery usage.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire①">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④③">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①②">latest reading</a>["timestamp"] is not null,</p>
       <ol>
@@ -2828,14 +2834,14 @@ in order to reduce resource consumption, notably battery usage.</p>
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④②">sensor reading</a> value or null.</p>
+      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">sensor reading</a> value or null.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
-        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④④">sensor</a>.</p>
+        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a>.</p>
        <li data-md="">
         <p>Return <var>readings</var>[<var>key</var>].</p>
       </ol>
@@ -2855,7 +2861,7 @@ in order to reduce resource consumption, notably battery usage.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⑤">sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>Let <var>permission_name</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionName</a></code> associated with <var>sensor</var>.</p>
      <li data-md="">
@@ -2868,9 +2874,9 @@ in order to reduce resource consumption, notably battery usage.</p>
    <p><em>This section is non-normative.</em></p>
    <p>Its purpose is to describe
 how this specification can be extended to specify APIs for
-different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor types</a>.</p>
-   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a>,
-exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low</a> level
+different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor types</a>.</p>
+   <p>Extension specifications are encouraged to focus on a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a>,
+exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
    <h3 class="heading settled" data-level="10.1" id="extension-security-and-privacy"><span class="secno">10.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
    <p>Extension specifications are expected to:</p>
@@ -2887,25 +2893,25 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="10.2" id="naming"><span class="secno">10.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑨">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⑥">sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑨">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⑦">sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⑧">sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
    <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">sensor readings</a> values
+hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④④">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
-the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④④">sensor reading</a>'s value in
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑤">sensor reading</a>'s value in
 a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp</code> attribute).
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="10.3" id="unit"><span class="secno">10.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑤">sensor readings</a>.</p>
+   <p>Extension specification must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">sensor readings</a>.</p>
    <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
@@ -2917,9 +2923,9 @@ Non-SI units accepted for use with the SI,
 as described in the SI Brochure <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <h3 class="heading settled" data-level="10.4" id="high-vs-low-level"><span class="secno">10.4. </span><span class="content">Exposing High-Level vs. Low-Level Sensors</span><a class="self-link" href="#high-vs-low-level"></a></h3>
    <p>So far, specifications exposing sensors to the Web platform
-have focused on <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①⓪">high-level</a> sensors APIs. <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> <a data-link-type="biblio" href="#biblio-orientation-event">[ORIENTATION-EVENT]</a></p>
+have focused on <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑨">high-level</a> sensors APIs. <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> <a data-link-type="biblio" href="#biblio-orientation-event">[ORIENTATION-EVENT]</a></p>
    <p>This was a reasonable approach for a number of reasons.
-Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> sensors:</p>
+Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①⓪">high-level</a> sensors:</p>
    <ul>
     <li data-md="">
      <p>convey developer intent clearly,</p>
@@ -2936,14 +2942,14 @@ Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①"
    </ul>
    <p>However, an increasing number of use cases
 such as virtual and augmented reality
-require <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①⓪">low-level</a> access to sensors,
+require <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑨">low-level</a> access to sensors,
 most notably for performance reasons.</p>
-   <p>Providing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> access
+   <p>Providing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①⓪">low-level</a> access
 enables Web application developers to leverage domain-specific constraints
 and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>,
 extension specifications should focus primarily on
-exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①②">high-level</a> APIs when they are clear benefits in doing so.</p>
+exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="10.5" id="multiple-sensors"><span class="secno">10.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
    <p>TODO: provide guidance on when to:</p>
    <ul>
@@ -2956,38 +2962,38 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">
    </ul>
    <h3 class="heading settled" data-level="10.6" id="definition-reqs"><span class="secno">10.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a> in extension specifications:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> in extension specifications:</p>
    <ul>
     <li data-md="">
      <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code>.
-  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
+  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
     <li data-md="">
      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code>.</p>
    </ul>
    <p>An extension specification may specify the following definitions
-for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor types</a>:</p>
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor types</a>:</p>
    <ul>
     <li data-md="">
      <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor④⑨">sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">type</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑤⓪">sensors</a> are common,
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor types</a> where multiple <a data-link-type="dfn">sensors</a> are common,
   extension specifications may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>,
   especially when doing so would not make sense.</p>
     <li data-md="">
      <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters②">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
    </ul>
    <h3 class="heading settled" data-level="10.7" id="permission-api"><span class="secno">10.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor①">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
-for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑦">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑧">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor①">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
+for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑨">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
-   <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑧">sensor readings</a> from
+   <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor readings</a> from
 fused data, some of the original information might be inferred. For example, it is easy to
 deduce user’s orientation in space if absolute or geomagnetic orientation sensors are used,
 therefore, these sensors must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use②">request permission to use</a> magnetometer as it provides information about orientation of device in relation to Earth’s
@@ -3003,7 +3009,7 @@ for accelerometer sensor is given below.</p>
 </pre>
    <h3 class="heading settled" data-level="10.8" id="example-webidl"><span class="secno">10.8. </span><span class="content">Example WebIDL</span><a class="self-link" href="#example-webidl"></a></h3>
    <p>Here’s example WebIDL for a possible extension of this specification
-for proximity <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑤①">sensors</a>.</p>
+for proximity <a data-link-type="dfn">sensors</a>.</p>
 <pre class="example" id="example-be4b13c4"><a class="self-link" href="#example-be4b13c4"></a>[Constructor(optional ProximitySensorOptions proximitySensorOptions),
  SecureContext, Exposed=Window]
 interface ProximitySensor : Sensor {
@@ -3117,8 +3123,8 @@ for their editorial input.</p>
     <a class="self-link" href="#example-f839f6c8"></a> 
     <p>This is an example of an informative example.</p>
    </div>
-   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
-    Although all of the <a data-link-type="dfn" href="#concept-sensor" id="ref-for-concept-sensor⑤②">sensors</a> used a examples
+   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
+    Although all of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⓪">sensors</a> used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
     are planning to do so. </p>
@@ -3286,6 +3292,7 @@ for their editorial input.</p>
    <li><a href="#deactivate-a-sensor-object">Deactivate a sensor object</a><span>, in §9.3</span>
    <li><a href="#default-sensor">default sensor</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-desiredsamplingfrequency-slot">[[desiredSamplingFrequency]]</a><span>, in §8.1.2</span>
+   <li><a href="#concept-device-sensor">device sensor</a><span>, in §6.1</span>
    <li><a href="#equivalent">equivalent</a><span>, in §Unnumbered section</span>
    <li>
     error
@@ -3321,6 +3328,7 @@ for their editorial input.</p>
    <li><a href="#optimal-sampling-frequency">optimal sampling frequency</a><span>, in §7.2</span>
    <li><a href="#dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a><span>, in §8.1.2</span>
    <li><a href="#periodic">periodic</a><span>, in §6.3</span>
+   <li><a href="#concept-platform-sensor">platform sensor</a><span>, in §6.1</span>
    <li><a href="#raw-sensor-readings">raw sensor readings</a><span>, in §6.1</span>
    <li><a href="#reading-value">reading value</a><span>, in §6.1</span>
    <li><a href="#reduce-accuracy">Reduce accuracy</a><span>, in §5.3.3</span>
@@ -3331,7 +3339,6 @@ for their editorial input.</p>
    <li><a href="#sampling-frequency">sampling frequency</a><span>, in §6.4</span>
    <li><a href="#security-check">Security check</a><span>, in §9.7</span>
    <li><a href="#sensor">Sensor</a><span>, in §8.1</span>
-   <li><a href="#concept-sensor">sensor</a><span>, in §7.2</span>
    <li><a href="#sensorerrorevent">SensorErrorEvent</a><span>, in §8.2</span>
    <li><a href="#dictdef-sensorerroreventinit">SensorErrorEventInit</a><span>, in §8.2</span>
    <li><a href="#dom-sensorerrorevent-sensorerrorevent">SensorErrorEvent(type, errorEventInitDict)</a><span>, in §8.2</span>
@@ -3542,6 +3549,16 @@ for their editorial input.</p>
     <li><a href="#ref-for-limit-max-frequency">5.3.3. Limit number of delivered readings</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="concept-device-sensor">
+   <b><a href="#concept-device-sensor">#concept-device-sensor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-device-sensor">3. Background</a> <a href="#ref-for-concept-device-sensor①">(2)</a> <a href="#ref-for-concept-device-sensor②">(3)</a> <a href="#ref-for-concept-device-sensor③">(4)</a> <a href="#ref-for-concept-device-sensor④">(5)</a> <a href="#ref-for-concept-device-sensor⑤">(6)</a> <a href="#ref-for-concept-device-sensor⑥">(7)</a> <a href="#ref-for-concept-device-sensor⑦">(8)</a>
+    <li><a href="#ref-for-concept-device-sensor⑧">5. Security and privacy considerations</a> <a href="#ref-for-concept-device-sensor⑨">(2)</a> <a href="#ref-for-concept-device-sensor①⓪">(3)</a> <a href="#ref-for-concept-device-sensor①①">(4)</a>
+    <li><a href="#ref-for-concept-device-sensor①②">5.2.3. Losing Focus</a>
+    <li><a href="#ref-for-concept-device-sensor①③">6.1. Sensors</a> <a href="#ref-for-concept-device-sensor①④">(2)</a> <a href="#ref-for-concept-device-sensor①⑤">(3)</a> <a href="#ref-for-concept-device-sensor①⑥">(4)</a> <a href="#ref-for-concept-device-sensor①⑦">(5)</a> <a href="#ref-for-concept-device-sensor①⑧">(6)</a>
+    <li><a href="#ref-for-concept-device-sensor①⑨">6.3. Reporting Modes</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="raw-sensor-readings">
    <b><a href="#raw-sensor-readings">#raw-sensor-readings</a></b><b>Referenced in:</b>
    <ul>
@@ -3571,49 +3588,73 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings①⑤">5.3.3. Limit number of delivered readings</a>
     <li><a href="#ref-for-sensor-readings①⑥">5.3.4. Reduce accuracy</a> <a href="#ref-for-sensor-readings①⑦">(2)</a>
     <li><a href="#ref-for-sensor-readings①⑧">5.3.5. Keep the user informed about API use</a>
-    <li><a href="#ref-for-sensor-readings①⑨">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings②⓪">(2)</a> <a href="#ref-for-sensor-readings②①">(3)</a> <a href="#ref-for-sensor-readings②②">(4)</a> <a href="#ref-for-sensor-readings②③">(5)</a>
-    <li><a href="#ref-for-sensor-readings②④">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings②⑤">(2)</a> <a href="#ref-for-sensor-readings②⑥">(3)</a> <a href="#ref-for-sensor-readings②⑦">(4)</a> <a href="#ref-for-sensor-readings②⑧">(5)</a>
-    <li><a href="#ref-for-sensor-readings②⑨">6.4. Sampling Frequency</a>
-    <li><a href="#ref-for-sensor-readings③⓪">7.2. Sensor</a> <a href="#ref-for-sensor-readings③①">(2)</a> <a href="#ref-for-sensor-readings③②">(3)</a> <a href="#ref-for-sensor-readings③③">(4)</a> <a href="#ref-for-sensor-readings③④">(5)</a>
-    <li><a href="#ref-for-sensor-readings③⑤">8.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor-readings③⑥">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings③⑦">(2)</a>
-    <li><a href="#ref-for-sensor-readings③⑧">8.1.7. Sensor.onreading</a>
-    <li><a href="#ref-for-sensor-readings③⑨">9.6. Set sensor settings</a> <a href="#ref-for-sensor-readings④⓪">(2)</a>
-    <li><a href="#ref-for-sensor-readings④①">9.7. Update latest reading</a>
-    <li><a href="#ref-for-sensor-readings④②">9.14. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-readings④③">10.2. Naming</a> <a href="#ref-for-sensor-readings④④">(2)</a>
-    <li><a href="#ref-for-sensor-readings④⑤">10.3. Unit</a>
-    <li><a href="#ref-for-sensor-readings④⑥">10.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor-readings④⑦">10.7. Extending the Permission API</a> <a href="#ref-for-sensor-readings④⑧">(2)</a>
+    <li><a href="#ref-for-sensor-readings①⑨">6.1. Sensors</a> <a href="#ref-for-sensor-readings②⓪">(2)</a>
+    <li><a href="#ref-for-sensor-readings②①">6.2. Sensor Types</a> <a href="#ref-for-sensor-readings②②">(2)</a> <a href="#ref-for-sensor-readings②③">(3)</a> <a href="#ref-for-sensor-readings②④">(4)</a>
+    <li><a href="#ref-for-sensor-readings②⑤">6.3. Reporting Modes</a> <a href="#ref-for-sensor-readings②⑥">(2)</a> <a href="#ref-for-sensor-readings②⑦">(3)</a> <a href="#ref-for-sensor-readings②⑧">(4)</a> <a href="#ref-for-sensor-readings②⑨">(5)</a>
+    <li><a href="#ref-for-sensor-readings③⓪">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-sensor-readings③①">7.2. Sensor</a> <a href="#ref-for-sensor-readings③②">(2)</a> <a href="#ref-for-sensor-readings③③">(3)</a> <a href="#ref-for-sensor-readings③④">(4)</a> <a href="#ref-for-sensor-readings③⑤">(5)</a>
+    <li><a href="#ref-for-sensor-readings③⑥">8.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor-readings③⑦">8.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings③⑧">(2)</a>
+    <li><a href="#ref-for-sensor-readings③⑨">8.1.7. Sensor.onreading</a>
+    <li><a href="#ref-for-sensor-readings④⓪">9.6. Set sensor settings</a> <a href="#ref-for-sensor-readings④①">(2)</a>
+    <li><a href="#ref-for-sensor-readings④②">9.7. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings④③">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-readings④④">10.2. Naming</a> <a href="#ref-for-sensor-readings④⑤">(2)</a>
+    <li><a href="#ref-for-sensor-readings④⑥">10.3. Unit</a>
+    <li><a href="#ref-for-sensor-readings④⑦">10.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor-readings④⑧">10.7. Extending the Permission API</a> <a href="#ref-for-sensor-readings④⑨">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="concept-platform-sensor">
+   <b><a href="#concept-platform-sensor">#concept-platform-sensor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-platform-sensor">6.1. Sensors</a> <a href="#ref-for-concept-platform-sensor①">(2)</a> <a href="#ref-for-concept-platform-sensor②">(3)</a> <a href="#ref-for-concept-platform-sensor③">(4)</a>
+    <li><a href="#ref-for-concept-platform-sensor④">6.4. Sampling Frequency</a>
+    <li><a href="#ref-for-concept-platform-sensor⑤">7.1. Sensor Type</a> <a href="#ref-for-concept-platform-sensor⑥">(2)</a>
+    <li><a href="#ref-for-concept-platform-sensor⑦">7.2. Sensor</a> <a href="#ref-for-concept-platform-sensor⑧">(2)</a> <a href="#ref-for-concept-platform-sensor⑨">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor①⓪">8.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①①">(2)</a> <a href="#ref-for-concept-platform-sensor①②">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor①③">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-platform-sensor①④">9.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor①⑤">(2)</a> <a href="#ref-for-concept-platform-sensor①⑥">(3)</a> <a href="#ref-for-concept-platform-sensor①⑦">(4)</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑧">9.3. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑨">9.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⓪">9.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-platform-sensor②①">9.6. Set sensor settings</a>
+    <li><a href="#ref-for-concept-platform-sensor②②">9.7. Update latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor②③">9.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②④">9.12. Notify activated state</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑤">9.14. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑥">9.15. Request sensor access</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑦">10.2. Naming</a> <a href="#ref-for-concept-platform-sensor②⑧">(2)</a> <a href="#ref-for-concept-platform-sensor②⑨">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor③⓪">10.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
    <b><a href="#low-level">#low-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-level">1. Introduction</a>
-    <li><a href="#ref-for-low-level①">6.2. Sensor Types</a> <a href="#ref-for-low-level②">(2)</a> <a href="#ref-for-low-level③">(3)</a> <a href="#ref-for-low-level④">(4)</a> <a href="#ref-for-low-level⑤">(5)</a> <a href="#ref-for-low-level⑥">(6)</a> <a href="#ref-for-low-level⑦">(7)</a>
-    <li><a href="#ref-for-low-level⑧">10. Extensibility</a>
-    <li><a href="#ref-for-low-level⑨">10.2. Naming</a>
-    <li><a href="#ref-for-low-level①⓪">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-low-level①①">(2)</a> <a href="#ref-for-low-level①②">(3)</a>
-    <li><a href="#ref-for-low-level①③">10.7. Extending the Permission API</a> <a href="#ref-for-low-level①④">(2)</a>
+    <li><a href="#ref-for-low-level①">6.2. Sensor Types</a> <a href="#ref-for-low-level②">(2)</a> <a href="#ref-for-low-level③">(3)</a> <a href="#ref-for-low-level④">(4)</a> <a href="#ref-for-low-level⑤">(5)</a> <a href="#ref-for-low-level⑥">(6)</a>
+    <li><a href="#ref-for-low-level⑦">10. Extensibility</a>
+    <li><a href="#ref-for-low-level⑧">10.2. Naming</a>
+    <li><a href="#ref-for-low-level⑨">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-low-level①⓪">(2)</a> <a href="#ref-for-low-level①①">(3)</a>
+    <li><a href="#ref-for-low-level①②">10.7. Extending the Permission API</a> <a href="#ref-for-low-level①③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="high-level">
    <b><a href="#high-level">#high-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-level">1. Introduction</a>
-    <li><a href="#ref-for-high-level①">6.2. Sensor Types</a> <a href="#ref-for-high-level②">(2)</a> <a href="#ref-for-high-level③">(3)</a> <a href="#ref-for-high-level④">(4)</a> <a href="#ref-for-high-level⑤">(5)</a> <a href="#ref-for-high-level⑥">(6)</a> <a href="#ref-for-high-level⑦">(7)</a>
-    <li><a href="#ref-for-high-level⑧">10. Extensibility</a>
-    <li><a href="#ref-for-high-level⑨">10.2. Naming</a>
-    <li><a href="#ref-for-high-level①⓪">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-high-level①①">(2)</a> <a href="#ref-for-high-level①②">(3)</a>
+    <li><a href="#ref-for-high-level①">6.2. Sensor Types</a> <a href="#ref-for-high-level②">(2)</a> <a href="#ref-for-high-level③">(3)</a> <a href="#ref-for-high-level④">(4)</a> <a href="#ref-for-high-level⑤">(5)</a> <a href="#ref-for-high-level⑥">(6)</a>
+    <li><a href="#ref-for-high-level⑦">10. Extensibility</a>
+    <li><a href="#ref-for-high-level⑧">10.2. Naming</a>
+    <li><a href="#ref-for-high-level⑨">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-high-level①⓪">(2)</a> <a href="#ref-for-high-level①①">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-fusion">
    <b><a href="#sensor-fusion">#sensor-fusion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-fusion">6.1. Sensors</a> <a href="#ref-for-sensor-fusion①">(2)</a>
-    <li><a href="#ref-for-sensor-fusion②">6.2. Sensor Types</a> <a href="#ref-for-sensor-fusion③">(2)</a> <a href="#ref-for-sensor-fusion④">(3)</a> <a href="#ref-for-sensor-fusion⑤">(4)</a> <a href="#ref-for-sensor-fusion⑥">(5)</a>
-    <li><a href="#ref-for-sensor-fusion⑦">10.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-fusion">6.1. Sensors</a> <a href="#ref-for-sensor-fusion①">(2)</a> <a href="#ref-for-sensor-fusion②">(3)</a> <a href="#ref-for-sensor-fusion③">(4)</a> <a href="#ref-for-sensor-fusion④">(5)</a>
+    <li><a href="#ref-for-sensor-fusion⑤">6.2. Sensor Types</a> <a href="#ref-for-sensor-fusion⑥">(2)</a> <a href="#ref-for-sensor-fusion⑦">(3)</a> <a href="#ref-for-sensor-fusion⑧">(4)</a>
+    <li><a href="#ref-for-sensor-fusion⑨">10.7. Extending the Permission API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="smart-sensors">
@@ -3673,15 +3714,16 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-type⑥">5. Security and privacy considerations</a>
     <li><a href="#ref-for-sensor-type⑦">5.3. Mitigation strategies applied on a case by case basis</a>
     <li><a href="#ref-for-sensor-type⑧">5.3.1. Limit maximum sampling frequency</a>
-    <li><a href="#ref-for-sensor-type⑨">6.2. Sensor Types</a> <a href="#ref-for-sensor-type①⓪">(2)</a> <a href="#ref-for-sensor-type①①">(3)</a> <a href="#ref-for-sensor-type①②">(4)</a> <a href="#ref-for-sensor-type①③">(5)</a> <a href="#ref-for-sensor-type①④">(6)</a> <a href="#ref-for-sensor-type①⑤">(7)</a> <a href="#ref-for-sensor-type①⑥">(8)</a>
-    <li><a href="#ref-for-sensor-type①⑦">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type①⑧">(2)</a> <a href="#ref-for-sensor-type①⑨">(3)</a>
-    <li><a href="#ref-for-sensor-type②⓪">7.1. Sensor Type</a> <a href="#ref-for-sensor-type②①">(2)</a> <a href="#ref-for-sensor-type②②">(3)</a> <a href="#ref-for-sensor-type②③">(4)</a> <a href="#ref-for-sensor-type②④">(5)</a> <a href="#ref-for-sensor-type②⑤">(6)</a>
-    <li><a href="#ref-for-sensor-type②⑥">7.2. Sensor</a> <a href="#ref-for-sensor-type②⑦">(2)</a>
-    <li><a href="#ref-for-sensor-type②⑧">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-sensor-type②⑨">9.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-type③⓪">10. Extensibility</a> <a href="#ref-for-sensor-type③①">(2)</a>
-    <li><a href="#ref-for-sensor-type③②">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type③③">(2)</a> <a href="#ref-for-sensor-type③④">(3)</a> <a href="#ref-for-sensor-type③⑤">(4)</a>
-    <li><a href="#ref-for-sensor-type③⑥">10.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-type⑨">6.1. Sensors</a>
+    <li><a href="#ref-for-sensor-type①⓪">6.2. Sensor Types</a> <a href="#ref-for-sensor-type①①">(2)</a> <a href="#ref-for-sensor-type①②">(3)</a> <a href="#ref-for-sensor-type①③">(4)</a> <a href="#ref-for-sensor-type①④">(5)</a> <a href="#ref-for-sensor-type①⑤">(6)</a> <a href="#ref-for-sensor-type①⑥">(7)</a> <a href="#ref-for-sensor-type①⑦">(8)</a>
+    <li><a href="#ref-for-sensor-type①⑧">6.3. Reporting Modes</a> <a href="#ref-for-sensor-type①⑨">(2)</a> <a href="#ref-for-sensor-type②⓪">(3)</a>
+    <li><a href="#ref-for-sensor-type②①">7.1. Sensor Type</a> <a href="#ref-for-sensor-type②②">(2)</a> <a href="#ref-for-sensor-type②③">(3)</a> <a href="#ref-for-sensor-type②④">(4)</a> <a href="#ref-for-sensor-type②⑤">(5)</a> <a href="#ref-for-sensor-type②⑥">(6)</a>
+    <li><a href="#ref-for-sensor-type②⑦">7.2. Sensor</a> <a href="#ref-for-sensor-type②⑧">(2)</a>
+    <li><a href="#ref-for-sensor-type②⑨">8.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-sensor-type③⓪">9.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-type③①">10. Extensibility</a> <a href="#ref-for-sensor-type③②">(2)</a>
+    <li><a href="#ref-for-sensor-type③③">10.6. Definition Requirements</a> <a href="#ref-for-sensor-type③④">(2)</a> <a href="#ref-for-sensor-type③⑤">(3)</a> <a href="#ref-for-sensor-type③⑥">(4)</a>
+    <li><a href="#ref-for-sensor-type③⑦">10.7. Extending the Permission API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="associated-sensors">
@@ -3702,35 +3744,6 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-default-sensor">9.2. Connect to sensor</a> <a href="#ref-for-default-sensor①">(2)</a>
     <li><a href="#ref-for-default-sensor②">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor③">(2)</a> <a href="#ref-for-default-sensor④">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="concept-sensor">
-   <b><a href="#concept-sensor">#concept-sensor</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-sensor">3. Background</a> <a href="#ref-for-concept-sensor①">(2)</a> <a href="#ref-for-concept-sensor②">(3)</a> <a href="#ref-for-concept-sensor③">(4)</a> <a href="#ref-for-concept-sensor④">(5)</a> <a href="#ref-for-concept-sensor⑤">(6)</a> <a href="#ref-for-concept-sensor⑥">(7)</a> <a href="#ref-for-concept-sensor⑦">(8)</a>
-    <li><a href="#ref-for-concept-sensor⑧">5. Security and privacy considerations</a> <a href="#ref-for-concept-sensor⑨">(2)</a> <a href="#ref-for-concept-sensor①⓪">(3)</a> <a href="#ref-for-concept-sensor①①">(4)</a>
-    <li><a href="#ref-for-concept-sensor①②">5.2.3. Losing Focus</a>
-    <li><a href="#ref-for-concept-sensor①③">6.1. Sensors</a> <a href="#ref-for-concept-sensor①④">(2)</a>
-    <li><a href="#ref-for-concept-sensor①⑤">6.2. Sensor Types</a> <a href="#ref-for-concept-sensor①⑥">(2)</a> <a href="#ref-for-concept-sensor①⑦">(3)</a>
-    <li><a href="#ref-for-concept-sensor①⑧">6.3. Reporting Modes</a> <a href="#ref-for-concept-sensor①⑨">(2)</a> <a href="#ref-for-concept-sensor②⓪">(3)</a>
-    <li><a href="#ref-for-concept-sensor②①">6.4. Sampling Frequency</a>
-    <li><a href="#ref-for-concept-sensor②②">7.1. Sensor Type</a> <a href="#ref-for-concept-sensor②③">(2)</a>
-    <li><a href="#ref-for-concept-sensor②④">7.2. Sensor</a> <a href="#ref-for-concept-sensor②⑤">(2)</a> <a href="#ref-for-concept-sensor②⑥">(3)</a> <a href="#ref-for-concept-sensor②⑦">(4)</a> <a href="#ref-for-concept-sensor②⑧">(5)</a>
-    <li><a href="#ref-for-concept-sensor②⑨">8.1. The Sensor Interface</a> <a href="#ref-for-concept-sensor③⓪">(2)</a> <a href="#ref-for-concept-sensor③①">(3)</a>
-    <li><a href="#ref-for-concept-sensor③②">8.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-sensor③③">9.2. Connect to sensor</a> <a href="#ref-for-concept-sensor③④">(2)</a> <a href="#ref-for-concept-sensor③⑤">(3)</a> <a href="#ref-for-concept-sensor③⑥">(4)</a>
-    <li><a href="#ref-for-concept-sensor③⑦">9.3. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-sensor③⑧">9.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-sensor③⑨">9.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-sensor④⓪">9.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-sensor④①">9.7. Update latest reading</a>
-    <li><a href="#ref-for-concept-sensor④②">9.9. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-sensor④③">9.12. Notify activated state</a>
-    <li><a href="#ref-for-concept-sensor④④">9.14. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-sensor④⑤">9.15. Request sensor access</a>
-    <li><a href="#ref-for-concept-sensor④⑥">10.2. Naming</a> <a href="#ref-for-concept-sensor④⑦">(2)</a> <a href="#ref-for-concept-sensor④⑧">(3)</a>
-    <li><a href="#ref-for-concept-sensor④⑨">10.6. Definition Requirements</a> <a href="#ref-for-concept-sensor⑤⓪">(2)</a>
-    <li><a href="#ref-for-concept-sensor⑤①">10.8. Example WebIDL</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activated-sensor-objects">


### PR DESCRIPTION
This patch splits [=sensor=] concept into two concepts:
1. device sensor - refers to a physical sensor instance on a device
2. platform sensor - refers to a piece of platform API representing a device sensor

Fixes #162


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/sensor_concepts.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/adbdb43...pozdnyakov:514dba9.html)