### PR TITLE
Remove nullable member type from SensorOptions.frequency and fix warning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -800,7 +800,7 @@ interface Sensor : EventTarget {
 };
 
 dictionary SensorOptions {
-  double? frequency;
+  double frequency;
 };
 </pre>
 
@@ -1245,7 +1245,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     : output
     :: None
 
-    1.  [=map/For each=] |key| → |value| of [=latest reading=].
+    1.  [=map/For each=] |key| → <var ignore>value</var> of [=latest reading=].
         1.  [=map/Set=] [=latest reading=][|key|] to the corresponding
             value of |reading|.
     1.  let |activated_sensors| be |sensor|'s associated [=ordered set|set=] of [=activated sensor objects=].

--- a/index.html
+++ b/index.html
@@ -2101,7 +2101,7 @@ by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequ
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensoroptions"><code>SensorOptions</code></dfn> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>.</p>
@@ -3439,7 +3439,7 @@ for their editorial input.</p>
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensoroptions"><code>SensorOptions</code></a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a>? <a class="nv" data-type="double? " href="#dom-sensoroptions-frequency"><code>frequency</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a> <a class="nv" data-type="double " href="#dom-sensoroptions-frequency"><code>frequency</code></a>;
 };
 
 [<a class="nv" href="#dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit②">SensorErrorEventInit</a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code></a>),


### PR DESCRIPTION
This PR fixes warning for one of the algorithms and removes ambiguous nullable dictionary member.

Reason to make `SensorOptions.frequency` non-nullable:
- `SensorOptions` is already optional in constructor
- Easier to check if `SensorOptions.frequency` is present, like in [construct sensor object](https://w3c.github.io/sensors/#construct-sensor-object).
- No need to add `null` to a possible set of frequency values, therefore, complicating algorithms.

Right now, passing `{ frequency: null }` would lead to setting `sensor_instance.desiredSamplingFrequency` to `null`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/sensors/remove_nullable_dict_member.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/86e2254...alexshalamov:2e24ee6.html)