### PR TITLE
A better name and description for the Sensor.requestedReportingFrequency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -768,12 +768,12 @@ A [=platform sensor=] has an associated [=requested sampling frequency=] which i
 
 For a non[=set/is empty|empty=] [=ordered set|set=] of [=activated sensor objects=] the
 [=requested sampling frequency=] is equal to <dfn>optimal sampling frequency</dfn>, which is estimated
-by the user agent taking into account {{[[requestedReportingFrequency]]|requested reporting frequencies}}
+by the user agent taking into account {{[[frequency]]|provided frequencies}}
 of [=activated sensor objects|activated=] {{Sensor|Sensors}} and [=sampling frequency=] bounds
 defined by the underlying platform.
 
 Note: For example, the user agent may estimate [=optimal sampling frequency=] as a Least Common
-Denominator (LCD) for a set of {{[[requestedReportingFrequency]]|requested reporting frequencies}} capped
+Denominator (LCD) for a set of {{[[frequency]]|provided frequencies}} capped
 by [=sampling frequency=] bounds defined by the underlying platform.
 
 <h2 id="api">API</h2>
@@ -923,7 +923,7 @@ with the internal slots described in the following table:
     <tbody>
         <tr>
             <td><dfn attribute for=Sensor>\[[state]]</dfn></td>
-            <td>The current state of {{Sensor}} object which is one of
+            <td>The current state of the {{Sensor}} object which is one of
                 "idle",
                 "activating", or
                 "activated".
@@ -931,12 +931,18 @@ with the internal slots described in the following table:
             </td>
         </tr>
         <tr>
-            <td><dfn attribute for=Sensor>\[[requestedReportingFrequency]]</dfn></td>
-            <td>The requested [=reporting frequency=]. It is initially unset.</td>
+            <td><dfn attribute for=Sensor>\[[frequency]]</dfn></td>
+            <td>A double representing frequency in Hz that is used to calculate
+                the [=requested sampling frequency=] for the associated [=platform sensor=]
+                and to define the upper bound of the [=reporting frequency=] for this
+                {{Sensor}} object.
+
+                This slot holds the provided {{SensorOptions}}.{{frequency!!dict-member}} value.
+                It is initially unset.</td>
         </tr>
         <tr>
             <td><dfn attribute for=Sensor>\[[lastEventFiredAt]]</dfn></td>
-            <td>the high resolution timestamp of the latest [=sensor reading=]
+            <td>The high resolution timestamp of the latest [=sensor reading=]
                 that was sent to observers of the {{Sensor}} object,
                 expressed in milliseconds that passed since the [=time origin=].
                 It is initially null.
@@ -1122,7 +1128,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
         1.  [=throw=] a {{SecurityError}}.
     1.  Let |sensor_instance| be a new {{Sensor}} object,
     1.  If |options|.{{frequency!!dict-member}} is [=present=], then
-        1.  Set |sensor_instance|.{{[[requestedReportingFrequency]]}} to |options|.{{frequency!!dict-member}}.
+        1.  Set |sensor_instance|.{{[[frequency]]}} to |options|.{{frequency!!dict-member}}.
 
         Note: there is not guarantee that the requested |options|.{{frequency!!dict-member}}
         can be respected. The actual [=sampling frequency=] can be calculated using
@@ -1264,7 +1270,7 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     :: [=reporting frequency=] in Hz.
 
     1.  Let |frequency| be null.
-    1.  Let |f| be |sensor_instance|.{{[[requestedReportingFrequency]]}}.
+    1.  Let |f| be |sensor_instance|.{{[[frequency]]}}.
         1. if |f| is set,
             1. set |frequency| to |f| capped by the upper and lower [=sampling frequency=]
                bounds for the associated [=platform sensor=].

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version afd377055fd60b78052b08cc89f300fd74918048" name="generator">
+  <meta content="Bikeshed version 882591573ecc5f03f5f46a2281b235e4b6a3e5df" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
 <style>
     emu-val {
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-27">27 September 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-29">29 September 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2089,10 +2089,10 @@ and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attri
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑤">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry③">entries</a> is initially set to null.</p>
    <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
    <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
-by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-requestedreportingfrequency-slot" id="ref-for-dom-sensor-requestedreportingfrequency-slot">requested reporting frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
+by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
 defined by the underlying platform.</p>
    <p class="note" role="note"><span>Note:</span> For example, the user agent may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency">optimal sampling frequency</a> as a Least Common
-Denominator (LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-requestedreportingfrequency-slot" id="ref-for-dom-sensor-requestedreportingfrequency-slot①">requested reporting frequencies</a></code> capped
+Denominator (LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot①">provided frequencies</a></code> capped
 by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑧">sampling frequency</a> bounds defined by the underlying platform.</p>
    <h2 class="heading settled" data-level="7" id="api"><span class="secno">7. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="the-sensor-interface"><span class="secno">7.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
@@ -2209,6 +2209,7 @@ invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-de
    <h4 class="heading settled" data-level="7.1.2" id="sensor-internal-slots"><span class="secno">7.1.2. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
    <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
+   <p></p>
    <table class="vert data" id="sensor-slots">
     <thead>
      <tr>
@@ -2217,17 +2218,21 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object which is one of
+      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
                 It is initially "idle". 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-requestedreportingfrequency-slot"><code>[[requestedReportingFrequency]]</code></dfn>
-      <td>The requested <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a>. It is initially unset.
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
+      <td>
+       A double representing frequency in Hz that is used to calculate
+                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object. 
+       <p>This slot holds the provided <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> value.
+                It is initially unset.</p>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>the high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object,
+      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
@@ -2237,7 +2242,7 @@ with the internal slots described in the following table:</p>
                 It is initially false.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-identifyingparameters-slot"><code>[[identifyingParameters]]</code></dfn>
-      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object. 
+      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object. 
    </table>
    <h4 class="heading settled" data-level="7.1.3" id="sensor-activated"><span class="secno">7.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
@@ -2337,7 +2342,7 @@ to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-s
 an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type" id="ref-for-dfn-exception-type">exception</a> cannot be handled synchronously.</p>
    <h4 class="heading settled" data-level="7.1.11" id="event-handlers"><span class="secno">7.1.11. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers①">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type①">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> interface:</p>
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> interface:</p>
    <table class="def">
     <thead>
      <tr>
@@ -2373,10 +2378,10 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code> object.</p>
+      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2392,14 +2397,14 @@ that must be supported as attributes by the objects implementing the <code class
         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw①">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror①">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object,</p>
      <li data-md="">
-      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
+      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-requestedreportingfrequency-slot" id="ref-for-dom-sensor-requestedreportingfrequency-slot②">[[requestedReportingFrequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code>.</p>
+        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
      <li data-md="">
       <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters">identifying parameters</a> in <var>options</var> are set, then:</p>
       <ol>
@@ -2417,26 +2422,26 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot①">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot②">[[identifyingParameters]]</a></code> allows
-  a unique <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a> to be identified, then:</p>
+  a unique <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a> to be identified, then:</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>,</p>
+        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a>,</p>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a> on the device, then</p>
+      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> on the device, then</p>
       <ol>
        <li data-md="">
         <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
@@ -2452,14 +2457,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated sensor objects</a>.</p>
      <li data-md="">
@@ -2473,7 +2478,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2483,7 +2488,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task①">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue">task queue</a> associated
   with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>sensor_instance</var>,</p>
       <ol>
@@ -2503,7 +2508,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2528,7 +2533,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2538,7 +2543,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑥">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty②">is empty</a>,</p>
       <ol>
        <li data-md="">
-        <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> to null.</p>
+        <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> to null.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑥">latest reading</a>.</p>
         <ol>
@@ -2551,7 +2556,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>Return.</p>
       </ol>
      <li data-md="">
-      <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency①">optimal sampling frequency</a>.</p>
+      <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑦">requested sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency①">optimal sampling frequency</a>.</p>
     </ol>
    </div>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.7" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">8.7. </span><span class="content">Update latest reading</span></h3>
@@ -2559,7 +2564,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
      <dd data-md="">
       <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor reading</a>.</p>
     </dl>
@@ -2597,7 +2602,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2606,13 +2611,13 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p>Let <var>frequency</var> be null.</p>
      <li data-md="">
-      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-requestedreportingfrequency-slot" id="ref-for-dom-sensor-requestedreportingfrequency-slot③">[[requestedReportingFrequency]]</a></code>.</p>
+      <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot③">[[frequency]]</a></code>.</p>
       <ol>
        <li data-md="">
         <p>if <var>f</var> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
+          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a>.</p>
         </ol>
        <li data-md="">
         <p>Otherwise,</p>
@@ -2630,7 +2635,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2693,7 +2698,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2712,7 +2717,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2723,7 +2728,7 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire①">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①②">latest reading</a>["timestamp"] is not null,</p>
       <ol>
@@ -2737,7 +2742,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception">exception</a>.</p>
      <dt data-md="">output
@@ -2756,7 +2761,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
@@ -2768,7 +2773,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
-        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a>.</p>
+        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a>.</p>
        <li data-md="">
         <p>Return <var>readings</var>[<var>key</var>].</p>
       </ol>
@@ -2781,14 +2786,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>Let <var>permission_name</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionName</a></code> associated with <var>sensor</var>.</p>
      <li data-md="">
@@ -2818,16 +2823,16 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> subclass that
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> subclass that
 hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④②">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
@@ -2880,7 +2885,7 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">
     <li data-md="">
      <p>allow multiple sensors of the same type to be instantiated,</p>
     <li data-md="">
-     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code>,</p>
+     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code>,</p>
     <li data-md="">
      <p>add constructor parameters to tweak sensors settings (e.g. setting required accuracy).</p>
    </ul>
@@ -2889,10 +2894,10 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">
 each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑤">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as argument,
-  an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code>.
+  an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
   Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑤">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
     <li data-md="">
@@ -2902,9 +2907,9 @@ each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">
 for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a>:</p>
    <ul>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.</p>
+     <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions③">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">type</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑧">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑤">default sensor</a> should be straightforward.
   For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>,
   especially when doing so would not make sense.</p>
@@ -2912,8 +2917,8 @@ for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③�
      <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters②">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑨">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
    <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">sensor readings</a> from
@@ -3225,6 +3230,7 @@ for their editorial input.</p>
    <li><a href="#extension-specification">extension specification</a><span>, in §9</span>
    <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §8.7</span>
    <li><a href="#dom-sensoroptions-frequency">frequency</a><span>, in §7.1</span>
+   <li><a href="#dom-sensor-frequency-slot">[[frequency]]</a><span>, in §7.1.2</span>
    <li><a href="#generic-sensor-permission-revocation-algorithm">generic sensor permission revocation algorithm</a><span>, in §6.1</span>
    <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.12</span>
    <li><a href="#dom-sensor-hasreading">hasReading</a><span>, in §7.1</span>
@@ -3252,7 +3258,6 @@ for their editorial input.</p>
    <li><a href="#reduce-accuracy">Reduce accuracy</a><span>, in §4.3.3</span>
    <li><a href="#reporting-frequency">reporting frequency</a><span>, in §5.5</span>
    <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §8.8</span>
-   <li><a href="#dom-sensor-requestedreportingfrequency-slot">[[requestedReportingFrequency]]</a><span>, in §7.1.2</span>
    <li><a href="#requested-sampling-frequency">requested sampling frequency</a><span>, in §5.5</span>
    <li><a href="#request-sensor-access">Request sensor access</a><span>, in §8.13</span>
    <li><a href="#revoke-sensor-permission">Revoke sensor permission</a><span>, in §8.4</span>
@@ -3537,19 +3542,19 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor⑨">6.1. Sensor Type</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a>
     <li><a href="#ref-for-concept-platform-sensor①①">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①②">(2)</a> <a href="#ref-for-concept-platform-sensor①③">(3)</a> <a href="#ref-for-concept-platform-sensor①④">(4)</a> <a href="#ref-for-concept-platform-sensor①⑤">(5)</a> <a href="#ref-for-concept-platform-sensor①⑥">(6)</a>
     <li><a href="#ref-for-concept-platform-sensor①⑦">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑧">(2)</a> <a href="#ref-for-concept-platform-sensor①⑨">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⓪">7.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-platform-sensor②①">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②②">(2)</a> <a href="#ref-for-concept-platform-sensor②③">(3)</a> <a href="#ref-for-concept-platform-sensor②④">(4)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑤">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑥">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑦">8.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑧">8.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑨">8.7. Update latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③⓪">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor③①">8.11. Notify activated state</a>
-    <li><a href="#ref-for-concept-platform-sensor③②">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③③">8.14. Request sensor access</a>
-    <li><a href="#ref-for-concept-platform-sensor③④">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑤">(2)</a> <a href="#ref-for-concept-platform-sensor③⑥">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor③⑦">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-concept-platform-sensor②⓪">7.1.2. Sensor internal slots</a> <a href="#ref-for-concept-platform-sensor②①">(2)</a>
+    <li><a href="#ref-for-concept-platform-sensor②②">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②③">(2)</a> <a href="#ref-for-concept-platform-sensor②④">(3)</a> <a href="#ref-for-concept-platform-sensor②⑤">(4)</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑥">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑦">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑧">8.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑨">8.6. Set sensor settings</a>
+    <li><a href="#ref-for-concept-platform-sensor③⓪">8.7. Update latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③①">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor③②">8.11. Notify activated state</a>
+    <li><a href="#ref-for-concept-platform-sensor③③">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③④">8.14. Request sensor access</a>
+    <li><a href="#ref-for-concept-platform-sensor③⑤">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑥">(2)</a> <a href="#ref-for-concept-platform-sensor③⑦">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor③⑧">9.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
@@ -3614,7 +3619,8 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-requested-sampling-frequency">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-requested-sampling-frequency①">(2)</a> <a href="#ref-for-requested-sampling-frequency②">(3)</a>
     <li><a href="#ref-for-requested-sampling-frequency③">6.2. Sensor</a> <a href="#ref-for-requested-sampling-frequency④">(2)</a>
-    <li><a href="#ref-for-requested-sampling-frequency⑤">8.6. Set sensor settings</a> <a href="#ref-for-requested-sampling-frequency⑥">(2)</a>
+    <li><a href="#ref-for-requested-sampling-frequency⑤">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-requested-sampling-frequency⑥">8.6. Set sensor settings</a> <a href="#ref-for-requested-sampling-frequency⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="reporting-frequency">
@@ -3710,23 +3716,23 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor⑥">6.2. Sensor</a>
     <li><a href="#ref-for-sensor⑦">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-sensor⑧">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-sensor⑨">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor①⓪">(2)</a> <a href="#ref-for-sensor①①">(3)</a> <a href="#ref-for-sensor①②">(4)</a>
-    <li><a href="#ref-for-sensor①③">7.1.11. Event handlers</a>
-    <li><a href="#ref-for-sensor①④">8.1. Construct sensor object</a> <a href="#ref-for-sensor①⑤">(2)</a> <a href="#ref-for-sensor①⑥">(3)</a>
-    <li><a href="#ref-for-sensor①⑦">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor①⑧">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor①⑨">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②⓪">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②①">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②②">8.10. Notify new reading</a>
-    <li><a href="#ref-for-sensor②③">8.11. Notify activated state</a>
-    <li><a href="#ref-for-sensor②④">8.12. Notify error</a>
-    <li><a href="#ref-for-sensor②⑤">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor②⑥">8.14. Request sensor access</a>
-    <li><a href="#ref-for-sensor②⑦">9.2. Naming</a> <a href="#ref-for-sensor②⑧">(2)</a> <a href="#ref-for-sensor②⑨">(3)</a>
-    <li><a href="#ref-for-sensor③⓪">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
-    <li><a href="#ref-for-sensor③①">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor③②">9.7. Extending the Permission API</a> <a href="#ref-for-sensor③③">(2)</a>
+    <li><a href="#ref-for-sensor⑨">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor①⓪">(2)</a> <a href="#ref-for-sensor①①">(3)</a> <a href="#ref-for-sensor①②">(4)</a> <a href="#ref-for-sensor①③">(5)</a>
+    <li><a href="#ref-for-sensor①④">7.1.11. Event handlers</a>
+    <li><a href="#ref-for-sensor①⑤">8.1. Construct sensor object</a> <a href="#ref-for-sensor①⑥">(2)</a> <a href="#ref-for-sensor①⑦">(3)</a>
+    <li><a href="#ref-for-sensor①⑧">8.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor①⑨">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor②⓪">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor②①">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②②">8.9. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②③">8.10. Notify new reading</a>
+    <li><a href="#ref-for-sensor②④">8.11. Notify activated state</a>
+    <li><a href="#ref-for-sensor②⑤">8.12. Notify error</a>
+    <li><a href="#ref-for-sensor②⑥">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor②⑦">8.14. Request sensor access</a>
+    <li><a href="#ref-for-sensor②⑧">9.2. Naming</a> <a href="#ref-for-sensor②⑨">(2)</a> <a href="#ref-for-sensor③⓪">(3)</a>
+    <li><a href="#ref-for-sensor③①">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor③②">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor③③">9.7. Extending the Permission API</a> <a href="#ref-for-sensor③④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
@@ -3782,14 +3788,16 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="dictdef-sensoroptions">
    <b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-sensoroptions">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dictdef-sensoroptions①">9.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions②">(2)</a>
+    <li><a href="#ref-for-dictdef-sensoroptions">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-dictdef-sensoroptions①">8.1. Construct sensor object</a>
+    <li><a href="#ref-for-dictdef-sensoroptions②">9.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensoroptions-frequency">
    <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensoroptions-frequency">8.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency①">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency②">(3)</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency①">8.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency②">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-task-source">
@@ -3811,12 +3819,12 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-sensor-state-slot⑨">8.13. Get value from latest reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-requestedreportingfrequency-slot">
-   <b><a href="#dom-sensor-requestedreportingfrequency-slot">#dom-sensor-requestedreportingfrequency-slot</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-sensor-frequency-slot">
+   <b><a href="#dom-sensor-frequency-slot">#dom-sensor-frequency-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-requestedreportingfrequency-slot">6.2. Sensor</a> <a href="#ref-for-dom-sensor-requestedreportingfrequency-slot①">(2)</a>
-    <li><a href="#ref-for-dom-sensor-requestedreportingfrequency-slot②">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-requestedreportingfrequency-slot③">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-frequency-slot">6.2. Sensor</a> <a href="#ref-for-dom-sensor-frequency-slot①">(2)</a>
+    <li><a href="#ref-for-dom-sensor-frequency-slot②">8.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-frequency-slot③">8.8. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot">


### PR DESCRIPTION
The name of the Sensor.requestedReportingFrequency internal slot gave
a wrong impression that it was used only to define a reporting
frequency.

Actually, this slot stores the frequency option and its value is used
for these two things:
- (indirectly) set the requested sampling frequency for the associated
  platform sensor.
- set the reporting frequency for the given Sensor object (in practice
  it sets the upper limit because reporting frequency is always capped to
  sampling frequency).

Now the slot is renamed to `frequency` (so that it reflects the sensor
option name) to avoid this confusion.

Fixes #294


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/fix-294.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/61cfd6e...pozdnyakov:0b3b862.html)