### PR TITLE
Rework the 'Connect to Sensor' abstract operation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -599,8 +599,13 @@ for each [=sensor types|type=]
 simply by instantiating the corresponding {{Sensor}} subclass.
 
 Indeed, without specific information identifying a particular [=device sensor|sensor=]
-of a given [=sensor type|type=],
-the <dfn export>default sensor</dfn> is chosen.
+of a given [=sensor type|type=], the <dfn export>default sensor</dfn> is chosen by the
+user agent.
+
+If the underlying platform provides an interface to find the [=default sensor=],
+the user agent must choose the sensor offered by the platform, otherwise the user agent
+itself defines which of the [=device sensor|sensors=] present on the device is
+the [=default sensor=]. 
 
 <div class="example">
     Listening to the default accelerometer changes:
@@ -703,10 +708,6 @@ A <dfn>sensor type</dfn> has an associated [=interface=]
 whose [=inherited interfaces=] contains {{Sensor}}.
 
 A [=sensor type=] has a [=ordered set|set=] of <dfn export>associated sensors</dfn>.
-
-If a [=sensor type=] has more than one [=platform sensor=],
-it must have a set of associated <dfn export>identifying parameters</dfn>
-to select the right [=platform sensor=] to associate to each new {{Sensor}} objects.
 
 A [=sensor type=] may have a [=default sensor=].
 
@@ -964,14 +965,6 @@ with the internal slots described in the following table:
                 notified after a new [=sensor reading=] was reported.
                 It is initially false.</td>
         </tr>
-        <tr>
-            <td><dfn attribute for=Sensor>\[[identifyingParameters]]</dfn></td>
-            <td>
-                A [=sensor type=]-specific group of [=dictionary members=]
-                used to select the correct [=platform sensor=]
-                to associate to this {{Sensor}} object.
-            </td>
-        </tr>
     </tbody>
 </table>
 
@@ -1016,7 +1009,8 @@ and "timestamp" as arguments.
         or "activated", then return.
     1.  Set |sensor_instance|.{{[[state]]}} to "activating".
     1.  Run these sub-steps [=in parallel=]:
-        1.  let |connected| be the result of invoking [=connect to sensor=].
+        1.  let |connected| be the result of invoking [=connect to sensor=] with |sensor_instance|
+            as argument.
         1.  If |connected| is false, then
             1.  Let |e| be the result of [=created|creating=] a
                 "{{NotReadableError!!exception}}" {{DOMException}}.
@@ -1143,8 +1137,6 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
         Note: there is not guarantee that the requested |options|.{{frequency!!dict-member}}
         can be respected. The actual [=sampling frequency=] can be calculated using
         {{Sensor}} {{Sensor/timestamp!!attribute}} attributes.
-    1.  If [=identifying parameters=] in |options| are set, then:
-        1.  Set |sensor_instance|.{{[[identifyingParameters]]}} to [=identifying parameters=].
     1.  Set |sensor_instance|.{{[[state]]}} to "idle".
     1.  Return |sensor_instance|.
 </div>
@@ -1160,16 +1152,18 @@ Gets the {{Error}} object passed to {{SensorErrorEventInit}}.
     :: True if sensor instance was associated with a [=platform sensor=],
        false otherwise.
 
-    1.  If |sensor_instance|.{{[[identifyingParameters]]}} is set and
-        |sensor_instance|.{{[[identifyingParameters]]}} allows
-        a unique [=platform sensor=] to be identified, then:
-        1.  let |sensor| be that [=platform sensor=],
-        1.  associate |sensor_instance| with |sensor|.
+    1.  Let |type| be the [=sensor type=] of |sensor_instance|.
+    1.  If the device has a single [=device sensor=] which can provide [=sensor readings|readings=]
+        for |type|, then
+        1.  Associate |sensor_instance| with a [=platform sensor=] corresponding
+            to this [=device sensor=].
         1.  Return true.
-    1.  If the [=sensor type=] of |sensor_instance| has an associated [=default sensor=]
-        and there is a corresponding [=platform sensor=] on the device, then
-        1.  associate |sensor_instance| with [=default sensor=].
-        1.  Return true.
+    1.  If the device has multiple [=device sensors=] which can provide [=sensor readings|readings=]
+        for |type|, then
+        1.  If |type| has an associated [=default sensor=], then
+            1.  Associate |sensor_instance| with a [=platform sensor=] corresponding
+                to [=default sensor=].
+            1.  Return true.
     1.  Return false.
 </div>
 
@@ -1528,7 +1522,6 @@ for each [=sensor types=]:
     For [=sensor types=] where multiple [=device sensor|sensors=] are common,
     [=extension specifications=] may choose not to define a [=default sensor=],
     especially when doing so would not make sense.
--   A set of [=identifying parameters=]. TODO: replace that by an abstract operation.
 
 <h3 id="permission-api">Extending the Permission API</h3>
 

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 5834a15f311a639c0b59ff2edbf3a060391d15ff" name="generator">
+  <meta content="Bikeshed version 349d758672bdfc395c895cca900784a2944ab548" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
 <style>
     emu-val {
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-03">3 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-04">4 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1976,8 +1976,12 @@ and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id
 such as multiple accelerometers in 2-in-1 laptops.</p>
    <p>The API therefore makes it easy to interact with
 the device’s default (and often unique) <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①②">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①④">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①">Sensor</a></code> subclass.</p>
-   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①③">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑤">type</a>,
-the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn> is chosen.</p>
+   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①③">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑤">type</a>, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn> is chosen by the
+user agent.</p>
+   <p>If the underlying platform provides an interface to find the <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a>,
+the user agent must choose the sensor offered by the platform, otherwise the user agent
+itself defines which of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①④">sensors</a> present on the device is
+the <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor①">default sensor</a>.</p>
    <div class="example" id="example-bd37b819">
     <a class="self-link" href="#example-bd37b819"></a> Listening to the default accelerometer changes: 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span> frequency<span class="o">:</span> <span class="mi">30</span> <span class="p">});</span>
@@ -1986,11 +1990,11 @@ sensor<span class="p">.</span>onreading <span class="o">=</span> <span class="p"
 sensor<span class="p">.</span>start<span class="p">();</span>
 </pre>
    </div>
-   <p class="note" role="note"><span>Note:</span> extension to this specification may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a> when doing so wouldn’t make sense.
-For example, it does not make sense to explicitly define a default <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①④">sensor</a> for geolocation <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">sensor type</a> as the
+   <p class="note" role="note"><span>Note:</span> extension to this specification may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a> when doing so wouldn’t make sense.
+For example, it does not make sense to explicitly define a default <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑤">sensor</a> for geolocation <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">sensor type</a> as the
 implementation of its interface can use multiple backends.</p>
    <p>In cases where
-multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑤">device sensors</a> corresponding to the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑦">type</a> may coexist on the same device,
+multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑥">device sensors</a> corresponding to the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑦">type</a> may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.</p>
    <div class="example" id="example-fdd94e11">
@@ -2004,10 +2008,10 @@ sensor<span class="p">.</span>start<span class="p">();</span>
    <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor④">platform sensor</a> reports <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②③">readings</a> to the user agent considering
 the <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold">reading change threshold</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reading-change-threshold">reading change threshold</dfn> refers to a value which indicates whether or
-not the changes in the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑥">device sensor</a>'s measurements were significant enough to
+not the changes in the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑦">device sensor</a>'s measurements were significant enough to
 update the corresponding <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②④">sensor readings</a>.</p>
    <p>The <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold①">threshold</a> value depends on the surrounding software and hardware
-environment constraints, e.g., software power consumption optimizations or the underlying <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑦">device sensor</a>'s accuracy.</p>
+environment constraints, e.g., software power consumption optimizations or the underlying <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑧">device sensor</a>'s accuracy.</p>
    <h3 class="heading settled" data-level="5.5" id="concepts-sampling-and-reporting-frequencies"><span class="secno">5.5. </span><span class="content">Sampling Frequency and Reporting Frequency</span><a class="self-link" href="#concepts-sampling-and-reporting-frequencies"></a></h3>
    <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑤">platform sensor</a> is
 defined as a frequency at which the user agent obtains <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑤">sensor readings</a> from the underlying
@@ -2022,7 +2026,7 @@ can support it.</p>
      <p>the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency②">requested sampling frequency</a> exceeds upper or lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑤">sampling frequency</a> bounds
  supported by the underlying platform.</p>
     <li data-md="">
-     <p>the <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold②">threshold</a> value is significant so that some of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑧">device sensor</a>'s measurements are skipped and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑦">sensor readings</a> are not updated.</p>
+     <p>the <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold②">threshold</a> value is significant so that some of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">device sensor</a>'s measurements are skipped and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑦">sensor readings</a> are not updated.</p>
    </ul>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-frequency">reporting frequency</dfn> for a concrete <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②">Sensor</a></code> object is defined as a frequency at which <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading">onreading</a></code> notification is called.</p>
    <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③">Sensor</a></code> object cannot access new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑧">readings</a> at a higher rate than the
@@ -2045,12 +2049,10 @@ never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-
    <h3 class="heading settled" data-level="6.1" id="model-sensor-type"><span class="secno">6.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④">Sensor</a></code>.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑨">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
-   <p>If a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">sensor type</a> has more than one <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a>,
-it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="identifying-parameters">identifying parameters</dfn> to select the right <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a> to associate to each new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensor</a></code> objects.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a> may have a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor①">default sensor</a>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code>.</p>
-   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">PermissionName</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">sensor type</a> may have a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a> has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code>.</p>
+   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">PermissionName</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
    <div class="algorithm" data-algorithm="permission revocation algorithm">
     <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname②">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
     <ol>
@@ -2067,28 +2069,28 @@ it must have a set of associated <dfn class="dfn-paneled" data-dfn-type="dfn" da
     </ol>
    </div>
    <h3 class="heading settled" data-level="6.2" id="model-sensor"><span class="secno">6.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①①">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
+   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
 This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
-   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①②">platform sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑨">sensor readings</a>.</p>
+   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings②⑨">sensor readings</a>.</p>
    <p class="note" role="note"><span>Note:</span> User agents can share <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⓪">sensor readings</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2②">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document⑥">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain①">same origin-domain</a>.</p>
-   <p>Any time a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③①">sensor reading</a> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a> is obtained and if the user agent <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings①">can expose sensor readings</a>, <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> is invoked with the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①④">platform sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③②">sensor reading</a> as arguments.</p>
+   <p>Any time a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③①">sensor reading</a> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①①">platform sensor</a> is obtained and if the user agent <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings①">can expose sensor readings</a>, <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> is invoked with the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①②">platform sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③②">sensor reading</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is
 "timestamp" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> is a high resolution timestamp that estimates the <a data-link-type="dfn" href="#reading-timestamp" id="ref-for-reading-timestamp②">reading timestamp</a> expressed in milliseconds since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin">time origin</a>.</p>
    <p class="note" role="note"><span>Note:</span> The accuracy of the <a data-link-type="dfn" href="#reading-timestamp" id="ref-for-reading-timestamp③">reading timestamp</a> estimate depends on the underlying
 platform interfaces that expose it.</p>
    <p><a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①">latest reading</a>["timestamp"] is initially set to null,
 unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading②">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③③">reading</a>.</p>
-   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading③">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑤">platform sensor</a>.
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading③">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a>.
 The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry②">entries</a> must match
 the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier">identifier</a> defined by
-the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a>'s associated interface.
+the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a>'s associated interface.
 The return value of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute①">attribute</a> getter is
-easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a>'s associated interface
+easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a>'s associated interface
 and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute②">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier①">identifier</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading④">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry③">entries</a> is initially set to null.</p>
-   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
+   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①④">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
    <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
-by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
+by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
 defined by the underlying platform.</p>
    <p class="note" role="note"><span>Note:</span> For example, the user agent may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency">optimal sampling frequency</a> as a Least Common
 Denominator (LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot①">provided frequencies</a></code> capped
@@ -2111,12 +2113,12 @@ by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequ
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double? " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑦">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑤">platform sensor</a>.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
    <div class="example" id="example-6910c0fd">
-    <a class="self-link" href="#example-6910c0fd"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> activation, error
+    <a class="self-link" href="#example-6910c0fd"></a> In the following example, we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a> activation, error
     conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③④">sensor readings</a>. The example measures
-    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a>. 
+    and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>. 
     <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
 <pre class="highlight"><span class="kd">let</span> acl <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">30</span><span class="p">});</span>
 <span class="kd">let</span> max_magnitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
@@ -2203,10 +2205,10 @@ acl<span class="p">.</span>start<span class="p">();</span>
      </g>
     </g>
    </svg>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑧">Sensor</a></code> object is eligible for garbage collection, the user agent must
+   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑦">Sensor</a></code> object is eligible for garbage collection, the user agent must
 invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor object</a> with this object as argument.</p>
    <h4 class="heading settled" data-level="7.1.2" id="sensor-internal-slots"><span class="secno">7.1.2. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
-   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> are created
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑧">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
    <p></p>
    <table class="vert data" id="sensor-slots">
@@ -2217,7 +2219,7 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object which is one of
+      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
@@ -2226,12 +2228,12 @@ with the internal slots described in the following table:</p>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
       <td>
        A double representing frequency in Hz that is used to calculate
-                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object. 
+                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object. 
        <p>This slot holds the provided <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> value.
                 It is initially unset.</p>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object,
+      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
@@ -2239,9 +2241,6 @@ with the internal slots described in the following table:</p>
       <td>A boolean which indicates whether the observers need to be
                 notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑥">sensor reading</a> was reported.
                 It is initially false.
-     <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-identifyingparameters-slot"><code>[[identifyingParameters]]</code></dfn>
-      <td> A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a>-specific group of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary-member" id="ref-for-dfn-dictionary-member">dictionary members</a> used to select the correct <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> to associate to this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object. 
    </table>
    <h4 class="heading settled" data-level="7.1.3" id="sensor-activated"><span class="secno">7.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
@@ -2284,7 +2283,7 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>let <var>connected</var> be the result of invoking <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor">connect to sensor</a>.</p>
+        <p>let <var>connected</var> be the result of invoking <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor">connect to sensor</a> with <var>sensor_instance</var> as argument.</p>
        <li data-md="">
         <p>If <var>connected</var> is false, then</p>
         <ol>
@@ -2341,7 +2340,7 @@ to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-s
 an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type" id="ref-for-dfn-exception-type">exception</a> cannot be handled synchronously.</p>
    <h4 class="heading settled" data-level="7.1.11" id="event-handlers"><span class="secno">7.1.11. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers①">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type①">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> interface:</p>
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> interface:</p>
    <table class="def">
     <thead>
      <tr>
@@ -2380,7 +2379,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2396,20 +2395,14 @@ that must be supported as attributes by the objects implementing the <code class
         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw①">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror①">SecurityError</a></code>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> object,</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
-     <li data-md="">
-      <p>If <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters">identifying parameters</a> in <var>options</var> are set, then:</p>
-      <ol>
-       <li data-md="">
-        <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot">[[identifyingParameters]]</a></code> to <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters①">identifying parameters</a>.</p>
-      </ol>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
      <li data-md="">
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑥">[[state]]</a></code> to "idle".</p>
      <li data-md="">
@@ -2421,31 +2414,36 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot①">[[identifyingParameters]]</a></code> is set and <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-identifyingparameters-slot" id="ref-for-dom-sensor-identifyingparameters-slot②">[[identifyingParameters]]</a></code> allows
-  a unique <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a> to be identified, then:</p>
+      <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a> of <var>sensor_instance</var>.</p>
+     <li data-md="">
+      <p>If the device has a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⓪">device sensor</a> which can provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">readings</a> for <var>type</var>, then</p>
       <ol>
        <li data-md="">
-        <p>let <var>sensor</var> be that <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a>,</p>
-       <li data-md="">
-        <p>associate <var>sensor_instance</var> with <var>sensor</var>.</p>
+        <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a> corresponding
+  to this <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②①">device sensor</a>.</p>
        <li data-md="">
         <p>Return true.</p>
       </ol>
      <li data-md="">
-      <p>If the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> of <var>sensor_instance</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a> and there is a corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> on the device, then</p>
+      <p>If the device has multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②②">device sensors</a> which can provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">readings</a> for <var>type</var>, then</p>
       <ol>
        <li data-md="">
-        <p>associate <var>sensor_instance</var> with <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
-       <li data-md="">
-        <p>Return true.</p>
+        <p>If <var>type</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>, then</p>
+        <ol>
+         <li data-md="">
+          <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> corresponding
+  to <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑤">default sensor</a>.</p>
+         <li data-md="">
+          <p>Return true.</p>
+        </ol>
       </ol>
      <li data-md="">
       <p>Return false.</p>
@@ -2456,14 +2454,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated sensor objects</a>.</p>
      <li data-md="">
@@ -2477,7 +2475,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2487,7 +2485,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task①">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue">task queue</a> associated
   with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>sensor_instance</var>,</p>
       <ol>
@@ -2507,7 +2505,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2532,7 +2530,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2550,7 +2548,7 @@ that must be supported as attributes by the objects implementing the <code class
           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑥">latest reading</a>[<var>key</var>] to null.</p>
         </ol>
        <li data-md="">
-        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">readings</a>.</p>
+        <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④①">readings</a>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
@@ -2563,9 +2561,9 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a>.</p>
      <dd data-md="">
-      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor reading</a>.</p>
+      <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④②">sensor reading</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2597,7 +2595,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2612,7 +2610,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>if <var>f</var> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a>.</p>
+          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a>.</p>
         </ol>
        <li data-md="">
         <p>Otherwise,</p>
@@ -2630,7 +2628,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2693,7 +2691,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2712,7 +2710,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2723,7 +2721,7 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire①">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①①">latest reading</a>["timestamp"] is not null,</p>
       <ol>
@@ -2737,7 +2735,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception">exception</a>.</p>
      <dt data-md="">output
@@ -2756,19 +2754,19 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④①">sensor reading</a> value or null.</p>
+      <p>A <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">sensor reading</a> value or null.</p>
     </dl>
     <ol>
      <li data-md="">
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
-        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①②">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a>.</p>
+        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①②">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
        <li data-md="">
         <p>Return <var>readings</var>[<var>key</var>].</p>
       </ol>
@@ -2781,14 +2779,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>Let <var>permission_name</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionName</a></code> associated with <var>sensor</var>.</p>
      <li data-md="">
@@ -2799,9 +2797,9 @@ that must be supported as attributes by the objects implementing the <code class
    </div>
    <h2 class="heading settled" data-level="9" id="extensibility"><span class="secno">9. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor types</a>.</p>
+   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor types</a>.</p>
    <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport="" id="extension-specification">extension specifications</dfn> are encouraged to focus on a
-single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
+single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
    <p>For an up-to-date list of <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification②">extension specifications</a>, please refer to <a data-link-type="biblio" href="#biblio-generic-sensor-usecases">[GENERIC-SENSOR-USECASES]</a> and <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> documents.</p>
    <h3 class="heading settled" data-level="9.1" id="extension-security-and-privacy"><span class="secno">9.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
@@ -2819,25 +2817,25 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> subclass that
-hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④②">sensor readings</a> values
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> subclass that
+hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④④">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
-the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">sensor reading</a>'s value in
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑤">sensor reading</a>'s value in
 a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp</code> attribute).
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="9.3" id="unit"><span class="secno">9.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification④">Extension specifications</a> must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④④">sensor readings</a>.</p>
+   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification④">Extension specifications</a> must specify the unit of <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">sensor readings</a>.</p>
    <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
@@ -2881,43 +2879,41 @@ exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">
     <li data-md="">
      <p>allow multiple sensors of the same type to be instantiated,</p>
     <li data-md="">
-     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code>,</p>
+     <p>create different interfaces that inherit from <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code>,</p>
     <li data-md="">
      <p>add constructor parameters to tweak sensors settings (e.g. setting required accuracy).</p>
    </ul>
    <h3 class="heading settled" data-level="9.6" id="definition-reqs"><span class="secno">9.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑥">extension specifications</a>:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑥">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
-  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑤">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
+  Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <emu-val>this</emu-val> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
     <li data-md="">
      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code>.</p>
    </ul>
    <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specification</a> may specify the following definitions
-for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a>:</p>
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor types</a>:</p>
    <ul>
     <li data-md="">
      <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions③">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑧">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">type</a>,
-  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑤">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">type</a>,
+  so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑦">default sensor</a> should be straightforward.
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②③">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
   especially when doing so would not make sense.</p>
-    <li data-md="">
-     <p>A set of <a data-link-type="dfn" href="#identifying-parameters" id="ref-for-identifying-parameters②">identifying parameters</a>. TODO: replace that by an abstract operation.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑧">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">PermissionName</a></code>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑨">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
-   <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">sensor readings</a> from
+   <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor readings</a> from
 fused data, some of the original information might be inferred. For example, it is easy to
 deduce user’s orientation in space if absolute or geomagnetic orientation sensors are used,
 therefore, these sensors must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use②">request permission to use</a> magnetometer as it provides information about orientation of device in relation to Earth’s
@@ -2933,7 +2929,7 @@ for accelerometer sensor is given below.</p>
 </pre>
    <h3 class="heading settled" data-level="9.8" id="example-webidl"><span class="secno">9.8. </span><span class="content">Example WebIDL</span><a class="self-link" href="#example-webidl"></a></h3>
    <p>Here’s example WebIDL for a possible extension of this specification
-for proximity <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⓪">sensors</a>.</p>
+for proximity <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②④">sensors</a>.</p>
 <pre class="example" id="example-29041274"><a class="self-link" href="#example-29041274"></a>[Constructor(optional ProximitySensorOptions proximitySensorOptions),
  SecureContext, Exposed=Window]
 interface ProximitySensor : Sensor {
@@ -3047,8 +3043,8 @@ for their editorial input.</p>
     <a class="self-link" href="#example-f839f6c8"></a> 
     <p>This is an example of an informative example.</p>
    </div>
-   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
-    Although all of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②①">sensors</a> used a examples
+   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
+    Although all of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑤">sensors</a> used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
     are planning to do so. </p>
@@ -3231,8 +3227,6 @@ for their editorial input.</p>
    <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.12</span>
    <li><a href="#dom-sensor-hasreading">hasReading</a><span>, in §7.1</span>
    <li><a href="#high-level">high-level</a><span>, in §5.2</span>
-   <li><a href="#identifying-parameters">identifying parameters</a><span>, in §6.1</span>
-   <li><a href="#dom-sensor-identifyingparameters-slot">[[identifyingParameters]]</a><span>, in §7.1.2</span>
    <li><a href="#dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a><span>, in §7.1.2</span>
    <li><a href="#latest-reading">latest reading</a><span>, in §6.2</span>
    <li><a href="#limit-max-frequency">Limit maximum sampling frequency</a><span>, in §4.3</span>
@@ -3375,7 +3369,6 @@ for their editorial input.</p>
      <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-dictionary-member">dictionary members</a>
      <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception">exception</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception-type">exception types</a>
@@ -3480,11 +3473,12 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-concept-device-sensor">4. Security and privacy considerations</a> <a href="#ref-for-concept-device-sensor①">(2)</a> <a href="#ref-for-concept-device-sensor②">(3)</a> <a href="#ref-for-concept-device-sensor③">(4)</a>
     <li><a href="#ref-for-concept-device-sensor④">5.1. Sensors</a> <a href="#ref-for-concept-device-sensor⑤">(2)</a> <a href="#ref-for-concept-device-sensor⑥">(3)</a> <a href="#ref-for-concept-device-sensor⑦">(4)</a> <a href="#ref-for-concept-device-sensor⑧">(5)</a> <a href="#ref-for-concept-device-sensor⑨">(6)</a>
-    <li><a href="#ref-for-concept-device-sensor①⓪">5.3. Default sensor</a> <a href="#ref-for-concept-device-sensor①①">(2)</a> <a href="#ref-for-concept-device-sensor①②">(3)</a> <a href="#ref-for-concept-device-sensor①③">(4)</a> <a href="#ref-for-concept-device-sensor①④">(5)</a> <a href="#ref-for-concept-device-sensor①⑤">(6)</a>
-    <li><a href="#ref-for-concept-device-sensor①⑥">5.4. Reading change threshold</a> <a href="#ref-for-concept-device-sensor①⑦">(2)</a>
-    <li><a href="#ref-for-concept-device-sensor①⑧">5.5. Sampling Frequency and Reporting Frequency</a>
-    <li><a href="#ref-for-concept-device-sensor①⑨">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-concept-device-sensor②⓪">9.8. Example WebIDL</a>
+    <li><a href="#ref-for-concept-device-sensor①⓪">5.3. Default sensor</a> <a href="#ref-for-concept-device-sensor①①">(2)</a> <a href="#ref-for-concept-device-sensor①②">(3)</a> <a href="#ref-for-concept-device-sensor①③">(4)</a> <a href="#ref-for-concept-device-sensor①④">(5)</a> <a href="#ref-for-concept-device-sensor①⑤">(6)</a> <a href="#ref-for-concept-device-sensor①⑥">(7)</a>
+    <li><a href="#ref-for-concept-device-sensor①⑦">5.4. Reading change threshold</a> <a href="#ref-for-concept-device-sensor①⑧">(2)</a>
+    <li><a href="#ref-for-concept-device-sensor①⑨">5.5. Sampling Frequency and Reporting Frequency</a>
+    <li><a href="#ref-for-concept-device-sensor②⓪">8.2. Connect to sensor</a> <a href="#ref-for-concept-device-sensor②①">(2)</a> <a href="#ref-for-concept-device-sensor②②">(3)</a>
+    <li><a href="#ref-for-concept-device-sensor②③">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-concept-device-sensor②④">9.8. Example WebIDL</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="raw-sensor-readings">
@@ -3531,13 +3525,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings③④">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-sensor-readings③⑤">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings③⑥">(2)</a>
     <li><a href="#ref-for-sensor-readings③⑦">7.1.8. Sensor.onreading</a>
-    <li><a href="#ref-for-sensor-readings③⑧">8.6. Set sensor settings</a> <a href="#ref-for-sensor-readings③⑨">(2)</a>
-    <li><a href="#ref-for-sensor-readings④⓪">8.7. Update latest reading</a>
-    <li><a href="#ref-for-sensor-readings④①">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor-readings④②">9.2. Naming</a> <a href="#ref-for-sensor-readings④③">(2)</a>
-    <li><a href="#ref-for-sensor-readings④④">9.3. Unit</a>
-    <li><a href="#ref-for-sensor-readings④⑤">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor-readings④⑥">9.7. Extending the Permission API</a> <a href="#ref-for-sensor-readings④⑦">(2)</a>
+    <li><a href="#ref-for-sensor-readings③⑧">8.2. Connect to sensor</a> <a href="#ref-for-sensor-readings③⑨">(2)</a>
+    <li><a href="#ref-for-sensor-readings④⓪">8.6. Set sensor settings</a> <a href="#ref-for-sensor-readings④①">(2)</a>
+    <li><a href="#ref-for-sensor-readings④②">8.7. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings④③">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-readings④④">9.2. Naming</a> <a href="#ref-for-sensor-readings④⑤">(2)</a>
+    <li><a href="#ref-for-sensor-readings④⑥">9.3. Unit</a>
+    <li><a href="#ref-for-sensor-readings④⑦">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor-readings④⑧">9.7. Extending the Permission API</a> <a href="#ref-for-sensor-readings④⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="concept-platform-sensor">
@@ -3547,22 +3542,21 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor④">5.4. Reading change threshold</a>
     <li><a href="#ref-for-concept-platform-sensor⑤">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-concept-platform-sensor⑥">5.6. Conditions to expose sensor readings</a> <a href="#ref-for-concept-platform-sensor⑦">(2)</a> <a href="#ref-for-concept-platform-sensor⑧">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor⑨">6.1. Sensor Type</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a>
-    <li><a href="#ref-for-concept-platform-sensor①①">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①②">(2)</a> <a href="#ref-for-concept-platform-sensor①③">(3)</a> <a href="#ref-for-concept-platform-sensor①④">(4)</a> <a href="#ref-for-concept-platform-sensor①⑤">(5)</a> <a href="#ref-for-concept-platform-sensor①⑥">(6)</a>
-    <li><a href="#ref-for-concept-platform-sensor①⑦">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑧">(2)</a> <a href="#ref-for-concept-platform-sensor①⑨">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⓪">7.1.2. Sensor internal slots</a> <a href="#ref-for-concept-platform-sensor②①">(2)</a>
-    <li><a href="#ref-for-concept-platform-sensor②②">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②③">(2)</a> <a href="#ref-for-concept-platform-sensor②④">(3)</a> <a href="#ref-for-concept-platform-sensor②⑤">(4)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑥">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑦">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑧">8.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑨">8.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-platform-sensor③⓪">8.7. Update latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③①">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor③②">8.11. Notify activated state</a>
-    <li><a href="#ref-for-concept-platform-sensor③③">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③④">8.14. Request sensor access</a>
-    <li><a href="#ref-for-concept-platform-sensor③⑤">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑥">(2)</a> <a href="#ref-for-concept-platform-sensor③⑦">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor③⑧">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-concept-platform-sensor⑨">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a> <a href="#ref-for-concept-platform-sensor①①">(3)</a> <a href="#ref-for-concept-platform-sensor①②">(4)</a> <a href="#ref-for-concept-platform-sensor①③">(5)</a> <a href="#ref-for-concept-platform-sensor①④">(6)</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑤">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑥">(2)</a> <a href="#ref-for-concept-platform-sensor①⑦">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑧">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑨">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②⓪">(2)</a> <a href="#ref-for-concept-platform-sensor②①">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor②②">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②③">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②④">8.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑤">8.6. Set sensor settings</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑥">8.7. Update latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑦">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑧">8.11. Notify activated state</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑨">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③⓪">8.14. Request sensor access</a>
+    <li><a href="#ref-for-concept-platform-sensor③①">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③②">(2)</a> <a href="#ref-for-concept-platform-sensor③③">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor③④">9.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
@@ -3597,10 +3591,10 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="default-sensor">
    <b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-sensor">5.3. Default sensor</a>
-    <li><a href="#ref-for-default-sensor①">6.1. Sensor Type</a>
-    <li><a href="#ref-for-default-sensor②">8.2. Connect to sensor</a> <a href="#ref-for-default-sensor③">(2)</a>
-    <li><a href="#ref-for-default-sensor④">9.6. Definition Requirements</a> <a href="#ref-for-default-sensor⑤">(2)</a> <a href="#ref-for-default-sensor⑥">(3)</a>
+    <li><a href="#ref-for-default-sensor">5.3. Default sensor</a> <a href="#ref-for-default-sensor①">(2)</a> <a href="#ref-for-default-sensor②">(3)</a>
+    <li><a href="#ref-for-default-sensor③">6.1. Sensor Type</a>
+    <li><a href="#ref-for-default-sensor④">8.2. Connect to sensor</a> <a href="#ref-for-default-sensor⑤">(2)</a>
+    <li><a href="#ref-for-default-sensor⑥">9.6. Definition Requirements</a> <a href="#ref-for-default-sensor⑦">(2)</a> <a href="#ref-for-default-sensor⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="reading-change-threshold">
@@ -3662,26 +3656,18 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-type④">5.2. Sensor Types</a> <a href="#ref-for-sensor-type⑤">(2)</a> <a href="#ref-for-sensor-type⑥">(3)</a> <a href="#ref-for-sensor-type⑦">(4)</a> <a href="#ref-for-sensor-type⑧">(5)</a> <a href="#ref-for-sensor-type⑨">(6)</a> <a href="#ref-for-sensor-type①⓪">(7)</a> <a href="#ref-for-sensor-type①①">(8)</a>
     <li><a href="#ref-for-sensor-type①②">5.3. Default sensor</a> <a href="#ref-for-sensor-type①③">(2)</a> <a href="#ref-for-sensor-type①④">(3)</a> <a href="#ref-for-sensor-type①⑤">(4)</a> <a href="#ref-for-sensor-type①⑥">(5)</a> <a href="#ref-for-sensor-type①⑦">(6)</a>
     <li><a href="#ref-for-sensor-type①⑧">5.5. Sampling Frequency and Reporting Frequency</a>
-    <li><a href="#ref-for-sensor-type①⑨">6.1. Sensor Type</a> <a href="#ref-for-sensor-type②⓪">(2)</a> <a href="#ref-for-sensor-type②①">(3)</a> <a href="#ref-for-sensor-type②②">(4)</a> <a href="#ref-for-sensor-type②③">(5)</a> <a href="#ref-for-sensor-type②④">(6)</a>
-    <li><a href="#ref-for-sensor-type②⑤">6.2. Sensor</a> <a href="#ref-for-sensor-type②⑥">(2)</a>
-    <li><a href="#ref-for-sensor-type②⑦">7.1.2. Sensor internal slots</a>
-    <li><a href="#ref-for-sensor-type②⑧">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-type②⑨">9. Extensibility</a> <a href="#ref-for-sensor-type③⓪">(2)</a>
-    <li><a href="#ref-for-sensor-type③①">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type③②">(2)</a> <a href="#ref-for-sensor-type③③">(3)</a> <a href="#ref-for-sensor-type③④">(4)</a>
-    <li><a href="#ref-for-sensor-type③⑤">9.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-type①⑨">6.1. Sensor Type</a> <a href="#ref-for-sensor-type②⓪">(2)</a> <a href="#ref-for-sensor-type②①">(3)</a> <a href="#ref-for-sensor-type②②">(4)</a> <a href="#ref-for-sensor-type②③">(5)</a>
+    <li><a href="#ref-for-sensor-type②④">6.2. Sensor</a> <a href="#ref-for-sensor-type②⑤">(2)</a>
+    <li><a href="#ref-for-sensor-type②⑥">8.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-type②⑦">9. Extensibility</a> <a href="#ref-for-sensor-type②⑧">(2)</a>
+    <li><a href="#ref-for-sensor-type②⑨">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type③⓪">(2)</a> <a href="#ref-for-sensor-type③①">(3)</a> <a href="#ref-for-sensor-type③②">(4)</a>
+    <li><a href="#ref-for-sensor-type③③">9.7. Extending the Permission API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="associated-sensors">
    <b><a href="#associated-sensors">#associated-sensors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-sensors">6.1. Sensor Type</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="identifying-parameters">
-   <b><a href="#identifying-parameters">#identifying-parameters</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-identifying-parameters">8.1. Construct sensor object</a> <a href="#ref-for-identifying-parameters①">(2)</a>
-    <li><a href="#ref-for-identifying-parameters②">9.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
@@ -3720,27 +3706,27 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor">3. A note on Feature Detection of Hardware Features</a>
     <li><a href="#ref-for-sensor①">5.3. Default sensor</a>
     <li><a href="#ref-for-sensor②">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-sensor③">(2)</a>
-    <li><a href="#ref-for-sensor④">6.1. Sensor Type</a> <a href="#ref-for-sensor⑤">(2)</a>
-    <li><a href="#ref-for-sensor⑥">6.2. Sensor</a>
-    <li><a href="#ref-for-sensor⑦">7.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor⑧">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-sensor⑨">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor①⓪">(2)</a> <a href="#ref-for-sensor①①">(3)</a> <a href="#ref-for-sensor①②">(4)</a> <a href="#ref-for-sensor①③">(5)</a>
-    <li><a href="#ref-for-sensor①④">7.1.11. Event handlers</a>
-    <li><a href="#ref-for-sensor①⑤">8.1. Construct sensor object</a> <a href="#ref-for-sensor①⑥">(2)</a> <a href="#ref-for-sensor①⑦">(3)</a>
-    <li><a href="#ref-for-sensor①⑧">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor①⑨">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor②⓪">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②①">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②②">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②③">8.10. Notify new reading</a>
-    <li><a href="#ref-for-sensor②④">8.11. Notify activated state</a>
-    <li><a href="#ref-for-sensor②⑤">8.12. Notify error</a>
-    <li><a href="#ref-for-sensor②⑥">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor②⑦">8.14. Request sensor access</a>
-    <li><a href="#ref-for-sensor②⑧">9.2. Naming</a> <a href="#ref-for-sensor②⑨">(2)</a> <a href="#ref-for-sensor③⓪">(3)</a>
-    <li><a href="#ref-for-sensor③①">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
-    <li><a href="#ref-for-sensor③②">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor③③">9.7. Extending the Permission API</a> <a href="#ref-for-sensor③④">(2)</a>
+    <li><a href="#ref-for-sensor④">6.1. Sensor Type</a>
+    <li><a href="#ref-for-sensor⑤">6.2. Sensor</a>
+    <li><a href="#ref-for-sensor⑥">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor⑦">7.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-sensor⑧">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor⑨">(2)</a> <a href="#ref-for-sensor①⓪">(3)</a> <a href="#ref-for-sensor①①">(4)</a>
+    <li><a href="#ref-for-sensor①②">7.1.11. Event handlers</a>
+    <li><a href="#ref-for-sensor①③">8.1. Construct sensor object</a> <a href="#ref-for-sensor①④">(2)</a> <a href="#ref-for-sensor①⑤">(3)</a>
+    <li><a href="#ref-for-sensor①⑥">8.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor①⑦">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor①⑧">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor①⑨">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②⓪">8.9. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②①">8.10. Notify new reading</a>
+    <li><a href="#ref-for-sensor②②">8.11. Notify activated state</a>
+    <li><a href="#ref-for-sensor②③">8.12. Notify error</a>
+    <li><a href="#ref-for-sensor②④">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor②⑤">8.14. Request sensor access</a>
+    <li><a href="#ref-for-sensor②⑥">9.2. Naming</a> <a href="#ref-for-sensor②⑦">(2)</a> <a href="#ref-for-sensor②⑧">(3)</a>
+    <li><a href="#ref-for-sensor②⑨">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-sensor③⓪">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor③①">9.7. Extending the Permission API</a> <a href="#ref-for-sensor③②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
@@ -3849,13 +3835,6 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot">8.4. Deactivate a sensor object</a>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot①">8.9. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot②">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot③">(3)</a>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot④">8.10. Notify new reading</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-identifyingparameters-slot">
-   <b><a href="#dom-sensor-identifyingparameters-slot">#dom-sensor-identifyingparameters-slot</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-identifyingparameters-slot①">8.2. Connect to sensor</a> <a href="#ref-for-dom-sensor-identifyingparameters-slot②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensorerrorevent">


### PR DESCRIPTION
This patch:
- Reworks the 'Connect to Sensor' abstract operation, so that
  it properly handles multiple device sensors
- Drops 'identifying parameters' as those are unnecessary
  unless the Sensor Discovery functionality is in place.
  We might put them back when fixing #7.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/sensors/dropIdentifyingParamaters.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/d98e38c...pozdnyakov:7600ff4.html)