### PR TITLE
Increment Previous Version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Status: ED
 Group: dap
 ED: https://w3c.github.io/sensors/
 TR: https://www.w3.org/TR/generic-sensor/
-Previous Version: https://www.w3.org/TR/2017/WD-generic-sensor-20170809/
+Previous Version: https://www.w3.org/TR/2017/WD-generic-sensor-20171002/
 Editor: Rick Waldron 50572, JS Foundation
 Editor: Mikhail Pozdnyakov 78325, Intel Corporation, https://intel.com/
 Editor: Alexander Shalamov 78335, Intel Corporation, https://intel.com/

--- a/index.html
+++ b/index.html
@@ -1183,8 +1183,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 349d758672bdfc395c895cca900784a2944ab548" name="generator">
+  <meta content="Bikeshed version b6673ffeec5d413f06f072c4e836aeb981424403" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
+  <meta content="40b0b614c589a4fee7b7046e7f2a2ef569a360c1" name="document-revision">
 <style>
     emu-val {
       font-weight: bold;
@@ -1458,7 +1459,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-04">4 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-05">5 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1466,7 +1467,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Latest published version:
      <dd><a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
      <dt>Previous Versions:
-     <dd><a href="https://www.w3.org/TR/2017/WD-generic-sensor-20170809/" rel="prev">https://www.w3.org/TR/2017/WD-generic-sensor-20170809/</a>
+     <dd><a href="https://www.w3.org/TR/2017/WD-generic-sensor-20171002/" rel="prev">https://www.w3.org/TR/2017/WD-generic-sensor-20171002/</a>
      <dt>Feedback:
      <dd><span><a href="mailto:public-device-apis@w3.org?subject=%5Bgeneric-sensor%5D%20YOUR%20TOPIC%20HERE">public-device-apis@w3.org</a> with subject line “<kbd>[generic-sensor] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-device-apis/" rel="discussion">archives</a>)</span>
      <dd><a href="https://github.com/w3c/sensors">GitHub</a> (<a href="https://github.com/w3c/sensors/issues/new">new issue</a>, <a href="https://github.com/w3c/sensors/milestone/2">level 1 issues</a>, <a href="https://github.com/w3c/sensors/issues">all issues</a>)


### PR DESCRIPTION
We should actually do this for all concrete sensor specs too, although there's now a tool in place that notifies if there's a newer TR publication available, for example see https://www.w3.org/TR/2017/WD-accelerometer-20170418/

Currently, each time we publish with Echidna we need to remember to bump the `Previous Version:` metadata.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/sensors/fix-metadata.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/40b0b61...2eb06ca.html)