### PR TITLE
Fix Tobie's URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,7 +10,7 @@ Previous Version: https://www.w3.org/TR/2017/WD-generic-sensor-20171002/
 Editor: Rick Waldron 50572, JS Foundation
 Editor: Mikhail Pozdnyakov 78325, Intel Corporation, https://intel.com/
 Editor: Alexander Shalamov 78335, Intel Corporation, https://intel.com/
-Former Editor: Tobie Langel 60809, Codespeaks&#44; formerly on behalf of Intel Corporation, http://tobie.me, tobie@codespeaks.com
+Former Editor: Tobie Langel 60809, Codespeaks&#44; formerly on behalf of Intel Corporation, http://www.tobie.me, tobie@codespeaks.com
 Abstract:
   This specification defines a framework for exposing sensor data
   to the Open Web Platform in a consistent way.

--- a/index.html
+++ b/index.html
@@ -1185,6 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 2d63ad75df4c3282ed7d8d3fb42b0c483a131ce1" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
+  <meta content="f298a40ade225d723b27e639689376d80e15221c" name="document-revision">
 <style>
     emu-val {
       font-weight: bold;
@@ -1475,7 +1476,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dd class="editor p-author h-card vcard" data-editor-id="78325"><a class="p-name fn u-url url" href="https://intel.com/">Mikhail Pozdnyakov</a> (<span class="p-org org">Intel Corporation</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="78335"><a class="p-name fn u-url url" href="https://intel.com/">Alexander Shalamov</a> (<span class="p-org org">Intel Corporation</span>)
      <dt class="editor">Former Editor:
-     <dd class="editor p-author h-card vcard" data-editor-id="60809"><a class="p-name fn u-url url" href="http://tobie.me">Tobie Langel</a> (<span class="p-org org">Codespeaks, formerly on behalf of Intel Corporation</span>) <a class="u-email email" href="mailto:tobie@codespeaks.com">tobie@codespeaks.com</a>
+     <dd class="editor p-author h-card vcard" data-editor-id="60809"><a class="p-name fn u-url url" href="http://www.tobie.me">Tobie Langel</a> (<span class="p-org org">Codespeaks, formerly on behalf of Intel Corporation</span>) <a class="u-email email" href="mailto:tobie@codespeaks.com">tobie@codespeaks.com</a>
      <dt>Other:
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/generic-sensor">Test suite</a>, <a href="https://github.com/w3c/sensors/commits/master/index.bs">latest version history</a>, <a href="https://github.com/w3c/sensors/commits/gh-pages/index.bs">previous version history</a>
     </dl>


### PR DESCRIPTION
@tobie, the URL to your site was invalid, so fixed it.

Would prefer to use HTTPS instead, but there seems to be an issue with https://www.tobie.me and https://tobie.me/ currently?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/sensors/fix-tobie.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/sensors/f298a40...0f14ac9.html)