### PR TITLE
Adopt "test as you commit" policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,11 @@ If you added a contributor by mistake, you can remove them in a comment with:
 If you are making a pull request on behalf of someone else but you had no part in designing the 
 feature, you can remove yourself with the above syntax.
 
+# Tests
+
+For normative changes, a corresponding
+[web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. Typically,
+both PRs will be merged at the same time. Note that a test change that contradicts the spec should
+not be merged before the corresponding spec change. If testing is not practical, please explain why
+and if appropriate [file an issue](https://github.com/w3c/web-platform-tests/issues/new) to follow
+up later. Add the `type:untestable` or `type:missing-coverage` label as appropriate.


### PR DESCRIPTION
This is a proposal to adopt the "test as you commit" policy for the Generic Sensor API. As discussed in https://github.com/w3c/dap-charter/issues/48, the proposed plan is to adopt a similar policy for all Device and Sensors WG's deliverables in the long term.

I suggest we use the Generic Sensor API Level 1 as a test drive, since it is feature complete, has an implementation that is expected to be conformant, and most importantly a test suite that is nearly complete (missing tests for `hasReading` IIRC).

The language _highly appreciated_ is to say we have some leeway should we want to incubate e.g. Level 2 features without tests first. 

Cc @rakuco @foolip @Honry