### PR TITLE
Sensor must not expose GC behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -946,8 +946,18 @@ The [=task source=] for the [=tasks=] mentioned in this specification is the <df
 Note: the nodes in the diagram above represent the states of a {{Sensor}} object and they should not be
 confused with the possible states of the underlying [=platform sensor=] or [=device sensor=].
 
-When a {{Sensor}} object is eligible for garbage collection, the user agent must
-invoke [=deactivate a sensor object=] with this object as argument.
+### Sensor garbage collection ### {#sensor-garbage-collection}
+
+A {{Sensor}} object whose {{[[state]]}} is "activating" must not be garbage collected
+if there are any event listeners registered for "activated" events, "reading" events,
+or "error" events.
+
+A {{Sensor}} object whose {{[[state]]}} is "activated" must not be garbage collected
+if there are any event listeners registered for "reading" events, or "error" events.
+
+When a {{Sensor}} object whose {{[[state]]}} is "activated" or "activating" is
+eligible for garbage collection, the user agent must invoke [=deactivate a sensor
+object=] with this object as argument.
 
 ### Sensor internal slots ### {#sensor-internal-slots}
 

--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-12-12">12 December 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-12-14">14 December 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1570,16 +1570,17 @@ that can be extended to accommodate different sensor types.</p>
        <a href="#the-sensor-interface"><span class="secno">7.1</span> <span class="content">The Sensor Interface</span></a>
        <ol class="toc">
         <li><a href="#sensor-lifecycle"><span class="secno">7.1.1</span> <span class="content">Sensor lifecycle</span></a>
-        <li><a href="#sensor-internal-slots"><span class="secno">7.1.2</span> <span class="content">Sensor internal slots</span></a>
-        <li><a href="#sensor-activated"><span class="secno">7.1.3</span> <span class="content">Sensor.activated</span></a>
-        <li><a href="#sensor-has-reading"><span class="secno">7.1.4</span> <span class="content">Sensor.hasReading</span></a>
-        <li><a href="#sensor-timestamp"><span class="secno">7.1.5</span> <span class="content">Sensor.timestamp</span></a>
-        <li><a href="#sensor-start"><span class="secno">7.1.6</span> <span class="content">Sensor.start()</span></a>
-        <li><a href="#sensor-stop"><span class="secno">7.1.7</span> <span class="content">Sensor.stop()</span></a>
-        <li><a href="#sensor-onreading"><span class="secno">7.1.8</span> <span class="content">Sensor.onreading</span></a>
-        <li><a href="#sensor-onactivate"><span class="secno">7.1.9</span> <span class="content">Sensor.onactivate</span></a>
-        <li><a href="#sensor-onerror"><span class="secno">7.1.10</span> <span class="content">Sensor.onerror</span></a>
-        <li><a href="#event-handlers"><span class="secno">7.1.11</span> <span class="content">Event handlers</span></a>
+        <li><a href="#sensor-garbage-collection"><span class="secno">7.1.2</span> <span class="content">Sensor garbage collection</span></a>
+        <li><a href="#sensor-internal-slots"><span class="secno">7.1.3</span> <span class="content">Sensor internal slots</span></a>
+        <li><a href="#sensor-activated"><span class="secno">7.1.4</span> <span class="content">Sensor.activated</span></a>
+        <li><a href="#sensor-has-reading"><span class="secno">7.1.5</span> <span class="content">Sensor.hasReading</span></a>
+        <li><a href="#sensor-timestamp"><span class="secno">7.1.6</span> <span class="content">Sensor.timestamp</span></a>
+        <li><a href="#sensor-start"><span class="secno">7.1.7</span> <span class="content">Sensor.start()</span></a>
+        <li><a href="#sensor-stop"><span class="secno">7.1.8</span> <span class="content">Sensor.stop()</span></a>
+        <li><a href="#sensor-onreading"><span class="secno">7.1.9</span> <span class="content">Sensor.onreading</span></a>
+        <li><a href="#sensor-onactivate"><span class="secno">7.1.10</span> <span class="content">Sensor.onactivate</span></a>
+        <li><a href="#sensor-onerror"><span class="secno">7.1.11</span> <span class="content">Sensor.onerror</span></a>
+        <li><a href="#event-handlers"><span class="secno">7.1.12</span> <span class="content">Event handlers</span></a>
        </ol>
       <li>
        <a href="#the-sensor-error-event-interface"><span class="secno">7.2</span> <span class="content">The SensorErrorEvent Interface</span></a>
@@ -2216,10 +2217,17 @@ same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browse
    </svg>
    <p class="note" role="note"><span>Note:</span> the nodes in the diagram above represent the states of a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object and they should not be
 confused with the possible states of the underlying <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> or <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑤">device sensor</a>.</p>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object is eligible for garbage collection, the user agent must
-invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor object</a> with this object as argument.</p>
-   <h4 class="heading settled" data-level="7.1.2" id="sensor-internal-slots"><span class="secno">7.1.2. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
-   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> are created
+   <h4 class="heading settled" data-level="7.1.2" id="sensor-garbage-collection"><span class="secno">7.1.2. </span><span class="content">Sensor garbage collection</span><a class="self-link" href="#sensor-garbage-collection"></a></h4>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot">[[state]]</a></code> is "activating" must not be garbage collected
+if there are any event listeners registered for "activated" events, "reading" events,
+or "error" events.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①">[[state]]</a></code> is "activated" must not be garbage collected
+if there are any event listeners registered for "reading" events, or "error" events.</p>
+   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot②">[[state]]</a></code> is "activated" or "activating" is
+eligible for garbage collection, the user agent must invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor
+object</a> with this object as argument.</p>
+   <h4 class="heading settled" data-level="7.1.3" id="sensor-internal-slots"><span class="secno">7.1.3. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
    <p></p>
    <table class="vert data" id="sensor-slots">
@@ -2230,7 +2238,7 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object which is one of
+      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
@@ -2239,12 +2247,12 @@ with the internal slots described in the following table:</p>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
       <td>
        A double representing frequency in Hz that is used to calculate
-                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> object. 
+                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object. 
        <p>This slot holds the provided <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> value.
                 It is initially unset.</p>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑦">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object,
+      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑦">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
@@ -2253,18 +2261,18 @@ with the internal slots described in the following table:</p>
                 notified after a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">sensor reading</a> was reported.
                 It is initially false.
    </table>
-   <h4 class="heading settled" data-level="7.1.3" id="sensor-activated"><span class="secno">7.1.3. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
+   <h4 class="heading settled" data-level="7.1.4" id="sensor-activated"><span class="secno">7.1.4. </span><span class="content">Sensor.activated</span><a class="self-link" href="#sensor-activated"></a></h4>
    <div class="algorithm" data-algorithm="is sensor activated">
     <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-activated" id="ref-for-dom-sensor-activated">activated</a></code> attribute must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If <strong>this</strong>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot">[[state]]</a></code> is "activated",
+      <p>If <strong>this</strong>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot③">[[state]]</a></code> is "activated",
   return true.</p>
      <li data-md="">
       <p>Otherwise, return false.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="7.1.4" id="sensor-has-reading"><span class="secno">7.1.4. </span><span class="content">Sensor.hasReading</span><a class="self-link" href="#sensor-has-reading"></a></h4>
+   <h4 class="heading settled" data-level="7.1.5" id="sensor-has-reading"><span class="secno">7.1.5. </span><span class="content">Sensor.hasReading</span><a class="self-link" href="#sensor-has-reading"></a></h4>
    <div class="algorithm" data-algorithm="sensor has reading">
     <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-hasreading" id="ref-for-dom-sensor-hasreading">hasReading</a></code> attribute must run these steps:</p>
     <ol>
@@ -2276,20 +2284,20 @@ with the internal slots described in the following table:</p>
       <p>Otherwise, return false.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="7.1.5" id="sensor-timestamp"><span class="secno">7.1.5. </span><span class="content">Sensor.timestamp</span><a class="self-link" href="#sensor-timestamp"></a></h4>
+   <h4 class="heading settled" data-level="7.1.6" id="sensor-timestamp"><span class="secno">7.1.6. </span><span class="content">Sensor.timestamp</span><a class="self-link" href="#sensor-timestamp"></a></h4>
    <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp">timestamp</a></code> attribute returns
 the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <strong>this</strong> and "timestamp" as arguments.</p>
-   <h4 class="heading settled" data-level="7.1.6" id="sensor-start"><span class="secno">7.1.6. </span><span class="content">Sensor.start()</span><a class="self-link" href="#sensor-start"></a></h4>
+   <h4 class="heading settled" data-level="7.1.7" id="sensor-start"><span class="secno">7.1.7. </span><span class="content">Sensor.start()</span><a class="self-link" href="#sensor-start"></a></h4>
    <div class="algorithm" data-algorithm="to start a sensor">
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-start" id="ref-for-dom-sensor-start">start()</a></code> method must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor_state</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①">[[state]]</a></code>.</p>
+      <p>Let <var>sensor_state</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot④">[[state]]</a></code>.</p>
      <li data-md="">
       <p>If <var>sensor_state</var> is either "activating"
   or "activated", then return.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot②">[[state]]</a></code> to "activating".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑤">[[state]]</a></code> to "activating".</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
@@ -2325,14 +2333,14 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
       </ol>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="7.1.7" id="sensor-stop"><span class="secno">7.1.7. </span><span class="content">Sensor.stop()</span><a class="self-link" href="#sensor-stop"></a></h4>
+   <h4 class="heading settled" data-level="7.1.8" id="sensor-stop"><span class="secno">7.1.8. </span><span class="content">Sensor.stop()</span><a class="self-link" href="#sensor-stop"></a></h4>
    <div class="algorithm" data-algorithm="to stop a sensor">
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-stop" id="ref-for-dom-sensor-stop">stop()</a></code> method must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot③">[[state]]</a></code> is "idle", then return.</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑥">[[state]]</a></code> is "idle", then return.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot④">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑦">[[state]]</a></code> to "idle".</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
       <ol>
@@ -2341,17 +2349,17 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
       </ol>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="7.1.8" id="sensor-onreading"><span class="secno">7.1.8. </span><span class="content">Sensor.onreading</span><a class="self-link" href="#sensor-onreading"></a></h4>
+   <h4 class="heading settled" data-level="7.1.9" id="sensor-onreading"><span class="secno">7.1.9. </span><span class="content">Sensor.onreading</span><a class="self-link" href="#sensor-onreading"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading">onreading</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler③">EventHandler</a></code> which is called
 to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">reading</a> is available.</p>
-   <h4 class="heading settled" data-level="7.1.9" id="sensor-onactivate"><span class="secno">7.1.9. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler④">EventHandler</a></code> which is called when <strong>this</strong>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑤">[[state]]</a></code> transitions from "activating" to "activated".</p>
-   <h4 class="heading settled" data-level="7.1.10" id="sensor-onerror"><span class="secno">7.1.10. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
+   <h4 class="heading settled" data-level="7.1.10" id="sensor-onactivate"><span class="secno">7.1.10. </span><span class="content">Sensor.onactivate</span><a class="self-link" href="#sensor-onactivate"></a></h4>
+   <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onactivate" id="ref-for-dom-sensor-onactivate">onactivate</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler④">EventHandler</a></code> which is called when <strong>this</strong>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑧">[[state]]</a></code> transitions from "activating" to "activated".</p>
+   <h4 class="heading settled" data-level="7.1.11" id="sensor-onerror"><span class="secno">7.1.11. </span><span class="content">Sensor.onerror</span><a class="self-link" href="#sensor-onerror"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#dom-sensor-onerror" id="ref-for-dom-sensor-onerror">onerror</a></code> is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler⑤">EventHandler</a></code> which is called whenever
 an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type" id="ref-for-dfn-exception-type">exception</a> cannot be handled synchronously.</p>
-   <h4 class="heading settled" data-level="7.1.11" id="event-handlers"><span class="secno">7.1.11. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
+   <h4 class="heading settled" data-level="7.1.12" id="event-handlers"><span class="secno">7.1.12. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers①">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type①">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> interface:</p>
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> interface:</p>
    <table class="def">
     <thead>
      <tr>
@@ -2390,7 +2398,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2404,16 +2412,16 @@ that must be supported as attributes by the objects implementing the <code class
         </ol>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object,</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑥">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> to "idle".</p>
      <li data-md="">
       <p>Return <var>sensor_instance</var>.</p>
     </ol>
@@ -2423,7 +2431,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>,
@@ -2463,7 +2471,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2484,7 +2492,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2604,7 +2612,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2637,7 +2645,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2700,7 +2708,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2719,14 +2727,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑦">[[state]]</a></code> to "activated".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①⓪">[[state]]</a></code> to "activated".</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
@@ -2744,7 +2752,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
      <dt data-md="">output
@@ -2753,7 +2761,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑧">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①①">[[state]]</a></code> to "idle".</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire③">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
@@ -2763,7 +2771,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
@@ -2772,7 +2780,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> is "activated",</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①②">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
         <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①④">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a>.</p>
@@ -2788,7 +2796,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
@@ -2840,16 +2848,16 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
 named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
 named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
 with the "Sensor" suffix.
 For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> subclass that
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> subclass that
 hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑥">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
@@ -2897,12 +2905,12 @@ and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑤">extension specifications</a> should focus primarily on
 exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="9.5" id="multiple-sensors"><span class="secno">9.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
-   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a> with
+   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a> with
 equal construction parameters, as it can lead to unnecessary hardware resources consumption.</p>
-   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> instance instead of
+   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instance instead of
 creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
 handler.</p>
-   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> can be created when they
+   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> can be created when they
 are intended to be used with different settings, such as: <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑨">requested sampling frequency</a>,
 accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑥">extension specifications</a>.</p>
    <h3 class="heading settled" data-level="9.6" id="definition-reqs"><span class="secno">9.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
@@ -2910,7 +2918,7 @@ accuracy or other settings defined in <a data-link-type="dfn" href="#extension-s
 each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
@@ -2931,8 +2939,8 @@ for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③�
   especially when doing so would not make sense.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤①">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤①">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①①">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
    <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor readings</a> from
@@ -2950,15 +2958,15 @@ for accelerometer sensor is given below.</p>
 };
 </pre>
    <h3 class="heading settled" data-level="9.8" id="feature-policy-api"><span class="secno">9.8. </span><span class="content">Extending the Feature Policy API</span><a class="self-link" href="#feature-policy-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor type</a> has one
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor type</a> has one
 (if <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①②">sensor fusion</a> is not performed) or several <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature③">policy-controlled features</a> that control whether or not this implementation can be used in a document.</p>
    <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature④">features</a>' <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist">default allowlist</a> is <code>["self"]</code>.</p>
-   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">Sensor</a></code> interface
+   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface
 implementation usage in same-origin nested frames but prevents third-party content
 from <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤③">sensor readings</a> access.</p>
    <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names①">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
 every associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑤">feature</a>.</p>
-   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
+   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
 for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⓪">extension specification</a> tells
 otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">sensor permission names</a>.</p>
    <div class="example html" id="example-924ff346">
@@ -3275,12 +3283,12 @@ for their editorial input.</p>
    <li><a href="#extension-specification">extension specification</a><span>, in §9</span>
    <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §8.7</span>
    <li><a href="#dom-sensoroptions-frequency">frequency</a><span>, in §7.1</span>
-   <li><a href="#dom-sensor-frequency-slot">[[frequency]]</a><span>, in §7.1.2</span>
+   <li><a href="#dom-sensor-frequency-slot">[[frequency]]</a><span>, in §7.1.3</span>
    <li><a href="#generic-sensor-permission-revocation-algorithm">generic sensor permission revocation algorithm</a><span>, in §6.1</span>
    <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.12</span>
    <li><a href="#dom-sensor-hasreading">hasReading</a><span>, in §7.1</span>
    <li><a href="#high-level">high-level</a><span>, in §5.2</span>
-   <li><a href="#dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a><span>, in §7.1.2</span>
+   <li><a href="#dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a><span>, in §7.1.3</span>
    <li><a href="#latest-reading">latest reading</a><span>, in §6.2</span>
    <li><a href="#limit-max-frequency">Limit maximum sampling frequency</a><span>, in §4.3</span>
    <li><a href="#limit-number-of-delivered-readings">Limit number of delivered readings</a><span>, in §4.3.2</span>
@@ -3293,7 +3301,7 @@ for their editorial input.</p>
    <li><a href="#dom-sensor-onerror">onerror</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-onreading">onreading</a><span>, in §7.1</span>
    <li><a href="#optimal-sampling-frequency">optimal sampling frequency</a><span>, in §6.2</span>
-   <li><a href="#dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a><span>, in §7.1.2</span>
+   <li><a href="#dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a><span>, in §7.1.3</span>
    <li><a href="#concept-platform-sensor">platform sensor</a><span>, in §5.1</span>
    <li><a href="#raw-sensor-readings">raw sensor readings</a><span>, in §5.1</span>
    <li><a href="#reading-change-threshold">reading change threshold</a><span>, in §5.4</span>
@@ -3322,7 +3330,7 @@ for their editorial input.</p>
    <li><a href="#smart-sensors">Smart sensors</a><span>, in §5.2</span>
    <li><a href="#specific-conditions">Specific conditions</a><span>, in §5.6</span>
    <li><a href="#dom-sensor-start">start()</a><span>, in §7.1</span>
-   <li><a href="#dom-sensor-state-slot">[[state]]</a><span>, in §7.1.2</span>
+   <li><a href="#dom-sensor-state-slot">[[state]]</a><span>, in §7.1.3</span>
    <li><a href="#dom-sensor-stop">stop()</a><span>, in §7.1</span>
    <li><a href="#stop-sensor">Stop the sensor altogether</a><span>, in §4.3.1</span>
    <li><a href="#dom-sensor-timestamp">timestamp</a><span>, in §7.1</span>
@@ -3591,8 +3599,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings②⑦">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-sensor-readings②⑧">(2)</a> <a href="#ref-for-sensor-readings②⑨">(3)</a> <a href="#ref-for-sensor-readings③⓪">(4)</a>
     <li><a href="#ref-for-sensor-readings③①">6.2. Sensor</a> <a href="#ref-for-sensor-readings③②">(2)</a> <a href="#ref-for-sensor-readings③③">(3)</a> <a href="#ref-for-sensor-readings③④">(4)</a>
     <li><a href="#ref-for-sensor-readings③⑤">7.1. The Sensor Interface</a> <a href="#ref-for-sensor-readings③⑥">(2)</a>
-    <li><a href="#ref-for-sensor-readings③⑦">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor-readings③⑧">(2)</a>
-    <li><a href="#ref-for-sensor-readings③⑨">7.1.8. Sensor.onreading</a>
+    <li><a href="#ref-for-sensor-readings③⑦">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor-readings③⑧">(2)</a>
+    <li><a href="#ref-for-sensor-readings③⑨">7.1.9. Sensor.onreading</a>
     <li><a href="#ref-for-sensor-readings④⓪">8.2. Connect to sensor</a> <a href="#ref-for-sensor-readings④①">(2)</a>
     <li><a href="#ref-for-sensor-readings④②">8.6. Set sensor settings</a> <a href="#ref-for-sensor-readings④③">(2)</a>
     <li><a href="#ref-for-sensor-readings④④">8.7. Update latest reading</a>
@@ -3615,7 +3623,7 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor⑨">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a> <a href="#ref-for-concept-platform-sensor①①">(3)</a> <a href="#ref-for-concept-platform-sensor①②">(4)</a> <a href="#ref-for-concept-platform-sensor①③">(5)</a> <a href="#ref-for-concept-platform-sensor①④">(6)</a> <a href="#ref-for-concept-platform-sensor①⑤">(7)</a> <a href="#ref-for-concept-platform-sensor①⑥">(8)</a> <a href="#ref-for-concept-platform-sensor①⑦">(9)</a>
     <li><a href="#ref-for-concept-platform-sensor①⑧">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑨">(2)</a> <a href="#ref-for-concept-platform-sensor②⓪">(3)</a>
     <li><a href="#ref-for-concept-platform-sensor②①">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-concept-platform-sensor②②">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-platform-sensor②②">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-concept-platform-sensor②③">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②④">(2)</a> <a href="#ref-for-concept-platform-sensor②⑤">(3)</a>
     <li><a href="#ref-for-concept-platform-sensor②⑥">8.3. Activate a sensor object</a>
     <li><a href="#ref-for-concept-platform-sensor②⑦">8.4. Deactivate a sensor object</a>
@@ -3695,7 +3703,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-requested-sampling-frequency">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-requested-sampling-frequency①">(2)</a> <a href="#ref-for-requested-sampling-frequency②">(3)</a>
     <li><a href="#ref-for-requested-sampling-frequency③">6.2. Sensor</a> <a href="#ref-for-requested-sampling-frequency④">(2)</a> <a href="#ref-for-requested-sampling-frequency⑤">(3)</a>
-    <li><a href="#ref-for-requested-sampling-frequency⑥">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-requested-sampling-frequency⑥">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-requested-sampling-frequency⑦">8.6. Set sensor settings</a> <a href="#ref-for-requested-sampling-frequency⑧">(2)</a>
     <li><a href="#ref-for-requested-sampling-frequency⑨">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
@@ -3704,7 +3712,7 @@ for their editorial input.</p>
    <b><a href="#reporting-frequency">#reporting-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reporting-frequency">5.5. Sampling Frequency and Reporting Frequency</a>
-    <li><a href="#ref-for-reporting-frequency①">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-reporting-frequency①">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-reporting-frequency②">8.8. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
@@ -3803,81 +3811,82 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor④">6.1. Sensor Type</a>
     <li><a href="#ref-for-sensor⑤">6.2. Sensor</a> <a href="#ref-for-sensor⑥">(2)</a> <a href="#ref-for-sensor⑦">(3)</a> <a href="#ref-for-sensor⑧">(4)</a>
     <li><a href="#ref-for-sensor⑨">7.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor①⓪">7.1.1. Sensor lifecycle</a> <a href="#ref-for-sensor①①">(2)</a>
-    <li><a href="#ref-for-sensor①②">7.1.2. Sensor internal slots</a> <a href="#ref-for-sensor①③">(2)</a> <a href="#ref-for-sensor①④">(3)</a> <a href="#ref-for-sensor①⑤">(4)</a>
-    <li><a href="#ref-for-sensor①⑥">7.1.11. Event handlers</a>
-    <li><a href="#ref-for-sensor①⑦">8.1. Construct sensor object</a> <a href="#ref-for-sensor①⑧">(2)</a> <a href="#ref-for-sensor①⑨">(3)</a>
-    <li><a href="#ref-for-sensor②⓪">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor②①">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor②②">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②③">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②④">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②⑤">8.10. Notify new reading</a>
-    <li><a href="#ref-for-sensor②⑥">8.11. Notify activated state</a>
-    <li><a href="#ref-for-sensor②⑦">8.12. Notify error</a>
-    <li><a href="#ref-for-sensor②⑧">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor②⑨">8.14. Request sensor access</a>
-    <li><a href="#ref-for-sensor③⓪">9.2. Naming</a> <a href="#ref-for-sensor③①">(2)</a> <a href="#ref-for-sensor③②">(3)</a>
-    <li><a href="#ref-for-sensor③③">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③④">(2)</a> <a href="#ref-for-sensor③⑤">(3)</a>
-    <li><a href="#ref-for-sensor③⑥">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor③⑦">9.7. Extending the Permission API</a> <a href="#ref-for-sensor③⑧">(2)</a>
-    <li><a href="#ref-for-sensor③⑨">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④⓪">(2)</a> <a href="#ref-for-sensor④①">(3)</a>
+    <li><a href="#ref-for-sensor①⓪">7.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-sensor①①">7.1.2. Sensor garbage collection</a> <a href="#ref-for-sensor①②">(2)</a> <a href="#ref-for-sensor①③">(3)</a>
+    <li><a href="#ref-for-sensor①④">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor①⑤">(2)</a> <a href="#ref-for-sensor①⑥">(3)</a> <a href="#ref-for-sensor①⑦">(4)</a>
+    <li><a href="#ref-for-sensor①⑧">7.1.12. Event handlers</a>
+    <li><a href="#ref-for-sensor①⑨">8.1. Construct sensor object</a> <a href="#ref-for-sensor②⓪">(2)</a> <a href="#ref-for-sensor②①">(3)</a>
+    <li><a href="#ref-for-sensor②②">8.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor②③">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor②④">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor②⑤">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②⑥">8.9. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②⑦">8.10. Notify new reading</a>
+    <li><a href="#ref-for-sensor②⑧">8.11. Notify activated state</a>
+    <li><a href="#ref-for-sensor②⑨">8.12. Notify error</a>
+    <li><a href="#ref-for-sensor③⓪">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor③①">8.14. Request sensor access</a>
+    <li><a href="#ref-for-sensor③②">9.2. Naming</a> <a href="#ref-for-sensor③③">(2)</a> <a href="#ref-for-sensor③④">(3)</a>
+    <li><a href="#ref-for-sensor③⑤">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑥">(2)</a> <a href="#ref-for-sensor③⑦">(3)</a>
+    <li><a href="#ref-for-sensor③⑧">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor③⑨">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④⓪">(2)</a>
+    <li><a href="#ref-for-sensor④①">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④②">(2)</a> <a href="#ref-for-sensor④③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
    <b><a href="#dom-sensor-activated">#dom-sensor-activated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-activated">7.1.3. Sensor.activated</a>
+    <li><a href="#ref-for-dom-sensor-activated">7.1.4. Sensor.activated</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-hasreading">
    <b><a href="#dom-sensor-hasreading">#dom-sensor-hasreading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-hasreading">7.1.4. Sensor.hasReading</a>
+    <li><a href="#ref-for-dom-sensor-hasreading">7.1.5. Sensor.hasReading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-timestamp">
    <b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-timestamp">7.1.5. Sensor.timestamp</a>
+    <li><a href="#ref-for-dom-sensor-timestamp">7.1.6. Sensor.timestamp</a>
     <li><a href="#ref-for-dom-sensor-timestamp①">8.1. Construct sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-start">
    <b><a href="#dom-sensor-start">#dom-sensor-start</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-start">7.1.6. Sensor.start()</a>
+    <li><a href="#ref-for-dom-sensor-start">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-stop">
    <b><a href="#dom-sensor-stop">#dom-sensor-stop</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-stop">7.1.7. Sensor.stop()</a>
+    <li><a href="#ref-for-dom-sensor-stop">7.1.8. Sensor.stop()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onreading">
    <b><a href="#dom-sensor-onreading">#dom-sensor-onreading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onreading">7.1.8. Sensor.onreading</a>
+    <li><a href="#ref-for-dom-sensor-onreading">7.1.9. Sensor.onreading</a>
     <li><a href="#ref-for-dom-sensor-onreading①">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onactivate">
    <b><a href="#dom-sensor-onactivate">#dom-sensor-onactivate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onactivate">7.1.9. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensor-onactivate">7.1.10. Sensor.onactivate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-onerror">
    <b><a href="#dom-sensor-onerror">#dom-sensor-onerror</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-onerror">7.1.10. Sensor.onerror</a>
+    <li><a href="#ref-for-dom-sensor-onerror">7.1.11. Sensor.onerror</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensoroptions">
    <b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-sensoroptions">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-dictdef-sensoroptions">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">8.1. Construct sensor object</a>
     <li><a href="#ref-for-dictdef-sensoroptions②">9.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions③">(2)</a>
    </ul>
@@ -3885,7 +3894,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="dom-sensoroptions-frequency">
    <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensoroptions-frequency">7.1.2. Sensor internal slots</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-dom-sensoroptions-frequency①">8.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency②">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency③">(3)</a>
    </ul>
   </aside>
@@ -3898,14 +3907,15 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="dom-sensor-state-slot">
    <b><a href="#dom-sensor-state-slot">#dom-sensor-state-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-state-slot">7.1.3. Sensor.activated</a>
-    <li><a href="#ref-for-dom-sensor-state-slot①">7.1.6. Sensor.start()</a> <a href="#ref-for-dom-sensor-state-slot②">(2)</a>
-    <li><a href="#ref-for-dom-sensor-state-slot③">7.1.7. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot④">(2)</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑤">7.1.9. Sensor.onactivate</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑥">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑦">8.11. Notify activated state</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑧">8.12. Notify error</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑨">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-dom-sensor-state-slot">7.1.2. Sensor garbage collection</a> <a href="#ref-for-dom-sensor-state-slot①">(2)</a> <a href="#ref-for-dom-sensor-state-slot②">(3)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot③">7.1.4. Sensor.activated</a>
+    <li><a href="#ref-for-dom-sensor-state-slot④">7.1.7. Sensor.start()</a> <a href="#ref-for-dom-sensor-state-slot⑤">(2)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot⑥">7.1.8. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot⑦">(2)</a>
+    <li><a href="#ref-for-dom-sensor-state-slot⑧">7.1.10. Sensor.onactivate</a>
+    <li><a href="#ref-for-dom-sensor-state-slot⑨">8.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-state-slot①⓪">8.11. Notify activated state</a>
+    <li><a href="#ref-for-dom-sensor-state-slot①①">8.12. Notify error</a>
+    <li><a href="#ref-for-dom-sensor-state-slot①②">8.13. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-frequency-slot">
@@ -3954,20 +3964,20 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="connect-to-sensor">
    <b><a href="#connect-to-sensor">#connect-to-sensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-connect-to-sensor">7.1.6. Sensor.start()</a>
+    <li><a href="#ref-for-connect-to-sensor">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activate-a-sensor-object">
    <b><a href="#activate-a-sensor-object">#activate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activate-a-sensor-object">7.1.6. Sensor.start()</a>
+    <li><a href="#ref-for-activate-a-sensor-object">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="deactivate-a-sensor-object">
    <b><a href="#deactivate-a-sensor-object">#deactivate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-deactivate-a-sensor-object">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-deactivate-a-sensor-object①">7.1.7. Sensor.stop()</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object">7.1.2. Sensor garbage collection</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object①">7.1.8. Sensor.stop()</a>
     <li><a href="#ref-for-deactivate-a-sensor-object②">8.5. Revoke sensor permission</a>
    </ul>
   </aside>
@@ -4018,7 +4028,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="notify-error">
    <b><a href="#notify-error">#notify-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-error">7.1.6. Sensor.start()</a> <a href="#ref-for-notify-error①">(2)</a>
+    <li><a href="#ref-for-notify-error">7.1.7. Sensor.start()</a> <a href="#ref-for-notify-error①">(2)</a>
     <li><a href="#ref-for-notify-error②">8.5. Revoke sensor permission</a>
    </ul>
   </aside>
@@ -4026,15 +4036,15 @@ for their editorial input.</p>
    <b><a href="#get-value-from-latest-reading">#get-value-from-latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-value-from-latest-reading">6.2. Sensor</a>
-    <li><a href="#ref-for-get-value-from-latest-reading①">7.1.4. Sensor.hasReading</a>
-    <li><a href="#ref-for-get-value-from-latest-reading②">7.1.5. Sensor.timestamp</a>
+    <li><a href="#ref-for-get-value-from-latest-reading①">7.1.5. Sensor.hasReading</a>
+    <li><a href="#ref-for-get-value-from-latest-reading②">7.1.6. Sensor.timestamp</a>
     <li><a href="#ref-for-get-value-from-latest-reading③">9.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-sensor-access">
    <b><a href="#request-sensor-access">#request-sensor-access</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-sensor-access">7.1.6. Sensor.start()</a>
+    <li><a href="#ref-for-request-sensor-access">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extension-specification">


### PR DESCRIPTION
The Sensor objects which have relevant event listeners need
to stay alive as long as it is possible that the event listener
might get called.

Fixes #337


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/sensors/pull/338.html" title="Last updated on Dec 14, 2017, 11:28 AM GMT (9fd7eeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/338/78efa11...pozdnyakov:9fd7eeb.html" title="Last updated on Dec 14, 2017, 11:28 AM GMT (9fd7eeb)">Diff</a>