### PR TITLE
Clarify construction of subclasses

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1214,15 +1214,17 @@ Gets the {{DOMException}} object passed to {{SensorErrorEventInit}}.
 <div algorithm="construct sensor object">
 
     : input
+    :: |sensorInterface|, an [=identifier=] of the [=interface=]
+       whose [=inherited interfaces=] contains {{Sensor}}.
     :: |options|, a {{SensorOptions}} object.
     : output
-    :: A {{Sensor}} object.
+    :: An object of the |sensorInterface| type.
 
     1.  [=set/For each=] |feature_name| of the associated [=sensor feature names=],
         1. If [=active document=] is not [=allowed to use=] the
            [=policy-controlled feature=] named |feature_name|, then:
            1.  [=Throw=] a {{SecurityError}} {{DOMException}}.
-    1.  Let |sensor_instance| be a new {{Sensor}} object,
+    1.  Let |sensor_instance| be a new instance of the [=interface=] identified by |sensorInterface|,
     1.  If |options|.{{frequency!!dict-member}} is [=present=], then
         1.  Set |sensor_instance|.{{[[frequency]]}} to |options|.{{frequency!!dict-member}}.
 

--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-15">15 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-16">16 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2430,10 +2430,12 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
+      <p><var>sensorInterface</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code>.</p>
+     <dd data-md="">
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p>An object of the <var>sensorInterface</var> type.</p>
     </dl>
     <ol>
      <li data-md="">
@@ -2447,14 +2449,14 @@ that must be supported as attributes by the objects implementing the <code class
         </ol>
       </ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object,</p>
+      <p>Let <var>sensor_instance</var> be a new instance of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface②">interface</a> identified by <var>sensorInterface</var>,</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
      <li data-md="">
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> to "idle".</p>
      <li data-md="">
@@ -2466,7 +2468,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>,
@@ -2506,7 +2508,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2527,7 +2529,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2647,7 +2649,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2680,7 +2682,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2743,7 +2745,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2762,7 +2764,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2787,7 +2789,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
      <dt data-md="">output
@@ -2806,7 +2808,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
@@ -2837,7 +2839,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
@@ -2889,16 +2891,16 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
 named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
 named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
 with the "Sensor" suffix.
 For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> subclass that
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> subclass that
 hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
@@ -2946,12 +2948,12 @@ and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a> should focus primarily on
 exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="9.5" id="multiple-sensors"><span class="secno">9.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
-   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> with
+   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> with
 equal construction parameters, as it can lead to unnecessary hardware resources consumption.</p>
-   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensor</a></code> instance instead of
+   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instance instead of
 creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
 handler.</p>
-   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> can be created when they
+   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> can be created when they
 are intended to be used with different settings, such as: <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑨">requested sampling frequency</a>,
 accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a>.</p>
    <h3 class="heading settled" data-level="9.6" id="definition-reqs"><span class="secno">9.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
@@ -2959,12 +2961,12 @@ accuracy or other settings defined in <a data-link-type="dfn" href="#extension-s
 each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface③">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces②">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
   Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤③">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
-  their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
+  their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier③">identifier</a> as arguments.</p>
     <li data-md="">
      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①⓪">sensor fusion</a> (otherwise, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionNames</a></code> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor types</a> must be used).</p>
    </ul>
@@ -2980,8 +2982,8 @@ for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③�
   especially when doing so would not make sense.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①①">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
    <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑤">sensor readings</a> from
@@ -2999,15 +3001,15 @@ for accelerometer sensor is given below.</p>
 };
 </pre>
    <h3 class="heading settled" data-level="9.8" id="feature-policy-api"><span class="secno">9.8. </span><span class="content">Extending the Feature Policy API</span><a class="self-link" href="#feature-policy-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor type</a> has one
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor type</a> has one
 (if <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①②">sensor fusion</a> is not performed) or several <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature③">policy-controlled features</a> that control whether or not this implementation can be used in a document.</p>
    <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature④">features</a>' <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist">default allowlist</a> is <code>["self"]</code>.</p>
-   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">Sensor</a></code> interface
+   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface
 implementation usage in same-origin nested frames but prevents third-party content
 from <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑥">sensor readings</a> access.</p>
    <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names①">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
 every associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑤">feature</a>.</p>
-   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④④">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
+   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
 for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specification</a> tells
 otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">sensor permission names</a>.</p>
    <div class="example html" id="example-924ff346">
@@ -3883,22 +3885,22 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor①②">7.1.2. Sensor garbage collection</a> <a href="#ref-for-sensor①③">(2)</a> <a href="#ref-for-sensor①④">(3)</a>
     <li><a href="#ref-for-sensor①⑤">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor①⑥">(2)</a> <a href="#ref-for-sensor①⑦">(3)</a> <a href="#ref-for-sensor①⑧">(4)</a>
     <li><a href="#ref-for-sensor①⑨">7.1.12. Event handlers</a>
-    <li><a href="#ref-for-sensor②⓪">8.1. Construct sensor object</a> <a href="#ref-for-sensor②①">(2)</a> <a href="#ref-for-sensor②②">(3)</a>
-    <li><a href="#ref-for-sensor②③">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor②④">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor②⑤">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②⑥">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②⑦">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②⑧">8.10. Notify new reading</a>
-    <li><a href="#ref-for-sensor②⑨">8.11. Notify activated state</a>
-    <li><a href="#ref-for-sensor③⓪">8.12. Notify error</a>
-    <li><a href="#ref-for-sensor③①">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor③②">8.14. Request sensor access</a>
-    <li><a href="#ref-for-sensor③③">9.2. Naming</a> <a href="#ref-for-sensor③④">(2)</a> <a href="#ref-for-sensor③⑤">(3)</a>
-    <li><a href="#ref-for-sensor③⑥">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑦">(2)</a> <a href="#ref-for-sensor③⑧">(3)</a>
-    <li><a href="#ref-for-sensor③⑨">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor④⓪">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④①">(2)</a>
-    <li><a href="#ref-for-sensor④②">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④③">(2)</a> <a href="#ref-for-sensor④④">(3)</a>
+    <li><a href="#ref-for-sensor②⓪">8.1. Construct sensor object</a> <a href="#ref-for-sensor②①">(2)</a>
+    <li><a href="#ref-for-sensor②②">8.2. Connect to sensor</a>
+    <li><a href="#ref-for-sensor②③">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor②④">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor②⑤">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②⑥">8.9. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②⑦">8.10. Notify new reading</a>
+    <li><a href="#ref-for-sensor②⑧">8.11. Notify activated state</a>
+    <li><a href="#ref-for-sensor②⑨">8.12. Notify error</a>
+    <li><a href="#ref-for-sensor③⓪">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor③①">8.14. Request sensor access</a>
+    <li><a href="#ref-for-sensor③②">9.2. Naming</a> <a href="#ref-for-sensor③③">(2)</a> <a href="#ref-for-sensor③④">(3)</a>
+    <li><a href="#ref-for-sensor③⑤">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑥">(2)</a> <a href="#ref-for-sensor③⑦">(3)</a>
+    <li><a href="#ref-for-sensor③⑧">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor③⑨">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④⓪">(2)</a>
+    <li><a href="#ref-for-sensor④①">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④②">(2)</a> <a href="#ref-for-sensor④③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">


### PR DESCRIPTION
The "construct sensor object" abstract operation now
consideres the actual Sensor subclass type.

Fixes #342


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/sensors/pull/344.html" title="Last updated on Feb 16, 2018, 12:08 PM GMT (94a2f92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/344/a9be1c1...pozdnyakov:94a2f92.html" title="Last updated on Feb 16, 2018, 12:08 PM GMT (94a2f92)">Diff</a>