### PR TITLE
Clarify construction of subclasses

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,6 +74,7 @@ urlPrefix: https://wicg.github.io/feature-policy/; spec: FEATURE-POLICY
     text: default allowlist
     text: feature name
     text: policy-controlled feature
+    text: allowed to use
 </pre>
 <pre class=link-defaults>
 spec: webidl; type:dfn; text:attribute
@@ -1209,30 +1210,41 @@ Gets the {{DOMException}} object passed to {{SensorErrorEventInit}}.
 
 <h2 id="abstract-operations">Abstract Operations</h2>
 
-<h3 dfn export>Construct sensor object</h3>
+<h3 dfn export>Initialize a sensor object</h3>
 
-<div algorithm="construct sensor object">
+<div algorithm="initialize a sensor object">
 
     : input
+    :: |sensor_instance|, a {{Sensor}} object.
     :: |options|, a {{SensorOptions}} object.
     : output
-    :: A {{Sensor}} object.
+    :: None
 
-    1.  [=set/For each=] |feature_name| of the associated [=sensor feature names=],
-        1. If [=active document=] is not [=allowed to use=] the
-           [=policy-controlled feature=] named |feature_name|, then:
-           1.  [=Throw=] a {{SecurityError}} {{DOMException}}.
-    1.  Let |sensor_instance| be a new {{Sensor}} object,
     1.  If |options|.{{frequency!!dict-member}} is [=present=], then
         1.  Set |sensor_instance|.{{[[frequency]]}} to |options|.{{frequency!!dict-member}}.
 
         Note: there is not guarantee that the requested |options|.{{frequency!!dict-member}}
         can be respected. The actual [=sampling frequency=] can be calculated using
         {{Sensor}} {{Sensor/timestamp!!attribute}} attributes.
-    1.  Set |sensor_instance|.{{[[state]]}} to "idle".
-    1.  Return |sensor_instance|.
 </div>
 
+<h3 dfn export>Check sensor policy-controlled features</h3>
+
+<div algorithm="check sensor policy-controlled features">
+
+    : input
+    :: |sensor_type|, a [=sensor type=].
+    : output
+    :: True if all of the associated [=sensor feature names=] are [=allowed to use=],
+       false otherwise.
+
+    1.  Let |feature_names| be the |sensor_type|'s associated [=sensor feature names=].
+    1.  [=set/For each=] |feature_name| of |feature_names|,
+        1. If [=active document=] is not [=allowed to use=] the
+           [=policy-controlled feature=] named |feature_name|, then:
+           1.  Return false.
+    1.  Return true.
+</div>
 
 <h3 dfn export>Connect to sensor</h3>
 

--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-15">15 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-19">19 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1591,20 +1591,21 @@ that can be extended to accommodate different sensor types.</p>
     <li>
      <a href="#abstract-operations"><span class="secno">8</span> <span class="content">Abstract Operations</span></a>
      <ol class="toc">
-      <li><a href="#construct-sensor-object"><span class="secno">8.1</span> <span class="content">Construct sensor object</span></a>
-      <li><a href="#connect-to-sensor"><span class="secno">8.2</span> <span class="content">Connect to sensor</span></a>
-      <li><a href="#activate-a-sensor-object"><span class="secno">8.3</span> <span class="content">Activate a sensor object</span></a>
-      <li><a href="#deactivate-a-sensor-object"><span class="secno">8.4</span> <span class="content">Deactivate a sensor object</span></a>
-      <li><a href="#revoke-sensor-permission"><span class="secno">8.5</span> <span class="content">Revoke sensor permission</span></a>
-      <li><a href="#set-sensor-settings"><span class="secno">8.6</span> <span class="content">Set sensor settings</span></a>
-      <li><a href="#update-latest-reading"><span class="secno">8.7</span> <span class="content">Update latest reading</span></a>
-      <li><a href="#find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.8</span> <span class="content">Find the reporting frequency of a sensor object</span></a>
-      <li><a href="#report-latest-reading-updated"><span class="secno">8.9</span> <span class="content">Report latest reading updated</span></a>
-      <li><a href="#notify-new-reading"><span class="secno">8.10</span> <span class="content">Notify new reading</span></a>
-      <li><a href="#notify-activated-state"><span class="secno">8.11</span> <span class="content">Notify activated state</span></a>
-      <li><a href="#notify-error"><span class="secno">8.12</span> <span class="content">Notify error</span></a>
-      <li><a href="#get-value-from-latest-reading"><span class="secno">8.13</span> <span class="content">Get value from latest reading</span></a>
-      <li><a href="#request-sensor-access"><span class="secno">8.14</span> <span class="content">Request sensor access</span></a>
+      <li><a href="#initialize-a-sensor-object"><span class="secno">8.1</span> <span class="content">Initialize a sensor object</span></a>
+      <li><a href="#check-sensor-policy-controlled-features"><span class="secno">8.2</span> <span class="content">Check sensor policy-controlled features</span></a>
+      <li><a href="#connect-to-sensor"><span class="secno">8.3</span> <span class="content">Connect to sensor</span></a>
+      <li><a href="#activate-a-sensor-object"><span class="secno">8.4</span> <span class="content">Activate a sensor object</span></a>
+      <li><a href="#deactivate-a-sensor-object"><span class="secno">8.5</span> <span class="content">Deactivate a sensor object</span></a>
+      <li><a href="#revoke-sensor-permission"><span class="secno">8.6</span> <span class="content">Revoke sensor permission</span></a>
+      <li><a href="#set-sensor-settings"><span class="secno">8.7</span> <span class="content">Set sensor settings</span></a>
+      <li><a href="#update-latest-reading"><span class="secno">8.8</span> <span class="content">Update latest reading</span></a>
+      <li><a href="#find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.9</span> <span class="content">Find the reporting frequency of a sensor object</span></a>
+      <li><a href="#report-latest-reading-updated"><span class="secno">8.10</span> <span class="content">Report latest reading updated</span></a>
+      <li><a href="#notify-new-reading"><span class="secno">8.11</span> <span class="content">Notify new reading</span></a>
+      <li><a href="#notify-activated-state"><span class="secno">8.12</span> <span class="content">Notify activated state</span></a>
+      <li><a href="#notify-error"><span class="secno">8.13</span> <span class="content">Notify error</span></a>
+      <li><a href="#get-value-from-latest-reading"><span class="secno">8.14</span> <span class="content">Get value from latest reading</span></a>
+      <li><a href="#request-sensor-access"><span class="secno">8.15</span> <span class="content">Request sensor access</span></a>
      </ol>
     <li>
      <a href="#extensibility"><span class="secno">9</span> <span class="content">Extensibility</span></a>
@@ -1844,7 +1845,7 @@ Thus all interfaces defined by this specification
 or <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification">extension specifications</a> are only available within a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts">secure context</a>.</p>
    <h4 class="heading settled" data-level="4.2.2" id="feature-policy"><span class="secno">4.2.2. </span><span class="content">Feature Policy</span><span id="browsing-context"></span><a class="self-link" href="#feature-policy"></a></h4>
    <p>To avoid the privacy risk of sharing <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑦">sensor readings</a> with contexts unfamiliar
-to the user, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑧">sensor readings</a> are only available for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">documents</a> which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use" id="ref-for-allowed-to-use">allowed to use</a> the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a> for
+to the user, <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑧">sensor readings</a> are only available for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">documents</a> which are <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use">allowed to use</a> the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a> for
 the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①">sensor type</a>. See <a data-link-type="biblio" href="#biblio-feature-policy">[FEATURE-POLICY]</a> for more details.</p>
    <h4 class="heading settled" data-level="4.2.3" id="losing-focus"><span class="secno">4.2.3. </span><span class="content">Losing Focus</span><a class="self-link" href="#losing-focus"></a></h4>
    <p>When the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> loses focus,
@@ -2063,7 +2064,7 @@ never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-
     <li data-md="">
      <p><a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dom-document-visibilitystate" id="ref-for-dom-document-visibilitystate">Visibility state</a> of the document is "visible".</p>
     <li data-md="">
-     <p>The document is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> all the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature①">policy-controlled features</a> associated
+     <p>The document is <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> all the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature①">policy-controlled features</a> associated
  with the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a>.</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context" id="ref-for-currently-focused-area-of-a-top-level-browsing-context">Currently focused area</a> belongs to a document whose origin is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a> with the origin of the given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>.</p>
@@ -2425,48 +2426,62 @@ that must be supported as attributes by the objects implementing the <code class
    <h4 class="heading settled" data-level="7.2.1" id="sensor-error-event-error"><span class="secno">7.2.1. </span><span class="content">SensorErrorEvent.error</span><a class="self-link" href="#sensor-error-event-error"></a></h4>
    <p>Gets the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code> object passed to <code class="idl"><a data-link-type="idl" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit①">SensorErrorEventInit</a></code>.</p>
    <h2 class="heading settled" data-level="8" id="abstract-operations"><span class="secno">8. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
-   <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.1" data-lt="Construct sensor object" id="construct-sensor-object"><span class="secno">8.1. </span><span class="content">Construct sensor object</span><a class="self-link" href="#construct-sensor-object"></a></h3>
-   <div class="algorithm" data-algorithm="construct sensor object">
+   <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.1" data-lt="Initialize a sensor object" id="initialize-a-sensor-object"><span class="secno">8.1. </span><span class="content">Initialize a sensor object</span><a class="self-link" href="#initialize-a-sensor-object"></a></h3>
+   <div class="algorithm" data-algorithm="initialize a sensor object">
     <dl>
      <dt data-md="">input
+     <dd data-md="">
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>feature_name</var> of the associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names">sensor feature names</a>,</p>
-      <ol>
-       <li data-md="">
-        <p>If <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document⑤">active document</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a> the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> named <var>feature_name</var>, then:</p>
-        <ol>
-         <li data-md="">
-          <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">Throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>.</p>
-        </ol>
-      </ol>
-     <li data-md="">
-      <p>Let <var>sensor_instance</var> be a new <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object,</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
        <li data-md="">
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
-     <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> to "idle".</p>
-     <li data-md="">
-      <p>Return <var>sensor_instance</var>.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="8.2" data-lt="Connect to sensor" id="connect-to-sensor"><span class="secno">8.2. </span><span class="content">Connect to sensor</span></h3>
+   <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.2" data-lt="Check sensor policy-controlled features" id="check-sensor-policy-controlled-features"><span class="secno">8.2. </span><span class="content">Check sensor policy-controlled features</span><a class="self-link" href="#check-sensor-policy-controlled-features"></a></h3>
+   <div class="algorithm" data-algorithm="check sensor policy-controlled features">
+    <dl>
+     <dt data-md="">input
+     <dd data-md="">
+      <p><var>sensor_type</var>, a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a>.</p>
+     <dt data-md="">output
+     <dd data-md="">
+      <p>True if all of the associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names">sensor feature names</a> are <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a>,
+ false otherwise.</p>
+    </dl>
+    <ol>
+     <li data-md="">
+      <p>Let <var>feature_names</var> be the <var>sensor_type</var>’s associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names①">sensor feature names</a>.</p>
+     <li data-md="">
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>feature_name</var> of <var>feature_names</var>,</p>
+      <ol>
+       <li data-md="">
+        <p>If <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document⑤">active document</a> is not <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use③">allowed to use</a> the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> named <var>feature_name</var>, then:</p>
+        <ol>
+         <li data-md="">
+          <p>Return false.</p>
+        </ol>
+      </ol>
+     <li data-md="">
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="8.3" data-lt="Connect to sensor" id="connect-to-sensor"><span class="secno">8.3. </span><span class="content">Connect to sensor</span></h3>
    <div class="algorithm" data-algorithm="connect to sensor">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>,
@@ -2474,7 +2489,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a> of <var>sensor_instance</var>.</p>
+      <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a> of <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If the device has a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑦">device sensor</a> which can provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">readings</a> for <var>type</var>, then</p>
       <ol>
@@ -2501,12 +2516,12 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Return false.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.3" data-lt="Activate a sensor object" data-noexport="" id="activate-a-sensor-object"><span class="secno">8.3. </span><span class="content">Activate a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.4" data-lt="Activate a sensor object" data-noexport="" id="activate-a-sensor-object"><span class="secno">8.4. </span><span class="content">Activate a sensor object</span></h3>
    <div class="algorithm" data-algorithm="activate a sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2522,12 +2537,12 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Queue a task to run <a data-link-type="dfn" href="#notify-activated-state" id="ref-for-notify-activated-state">notify activated state</a> with <var>sensor_instance</var> as an argument.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.4" data-lt="Deactivate a sensor object" data-noexport="" id="deactivate-a-sensor-object"><span class="secno">8.4. </span><span class="content">Deactivate a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.5" data-lt="Deactivate a sensor object" data-noexport="" id="deactivate-a-sensor-object"><span class="secno">8.5. </span><span class="content">Deactivate a sensor object</span></h3>
    <div class="algorithm" data-algorithm="deactivate a sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2552,7 +2567,7 @@ that must be supported as attributes by the objects implementing the <code class
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.5" data-lt="Revoke sensor permission" data-noexport="" id="revoke-sensor-permission"><span class="secno">8.5. </span><span class="content">Revoke sensor permission</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.6" data-lt="Revoke sensor permission" data-noexport="" id="revoke-sensor-permission"><span class="secno">8.6. </span><span class="content">Revoke sensor permission</span></h3>
    <div class="algorithm" data-algorithm="revoke sensor permission">
     <dl>
      <dt data-md="">input
@@ -2571,13 +2586,13 @@ that must be supported as attributes by the objects implementing the <code class
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object②">deactivate a sensor object</a> with <var>s</var> as argument.</p>
        <li data-md="">
-        <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception②">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>.</p>
+        <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception②">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>.</p>
        <li data-md="">
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error②">notify error</a> with <var>e</var> and <var>s</var> as arguments.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.6" data-lt="Set sensor settings" data-noexport="" id="set-sensor-settings"><span class="secno">8.6. </span><span class="content">Set sensor settings</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.7" data-lt="Set sensor settings" data-noexport="" id="set-sensor-settings"><span class="secno">8.7. </span><span class="content">Set sensor settings</span></h3>
    <div class="algorithm" data-algorithm="set sensor settings">
     <dl>
      <dt data-md="">input
@@ -2608,7 +2623,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑧">requested sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency①">optimal sampling frequency</a>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.7" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">8.7. </span><span class="content">Update latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.8" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">8.8. </span><span class="content">Update latest reading</span></h3>
    <div class="algorithm" data-algorithm="update latest reading">
     <dl>
      <dt data-md="">input
@@ -2642,12 +2657,12 @@ that must be supported as attributes by the objects implementing the <code class
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.8" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.8. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.9" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.9. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
    <div class="algorithm" data-algorithm="find the reporting frequency of a sensor object">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2675,12 +2690,12 @@ that must be supported as attributes by the objects implementing the <code class
       <p>return <var>frequency</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.9" data-lt="Report latest reading updated" data-noexport="" id="report-latest-reading-updated"><span class="secno">8.9. </span><span class="content">Report latest reading updated</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.10" data-lt="Report latest reading updated" data-noexport="" id="report-latest-reading-updated"><span class="secno">8.10. </span><span class="content">Report latest reading updated</span></h3>
    <div class="algorithm" data-algorithm="report latest reading updated">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2738,12 +2753,12 @@ that must be supported as attributes by the objects implementing the <code class
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.10" data-lt="Notify new reading" data-noexport="" id="notify-new-reading"><span class="secno">8.10. </span><span class="content">Notify new reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.11" data-lt="Notify new reading" data-noexport="" id="notify-new-reading"><span class="secno">8.11. </span><span class="content">Notify new reading</span></h3>
    <div class="algorithm" data-algorithm="notify new reading">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2757,19 +2772,19 @@ that must be supported as attributes by the objects implementing the <code class
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire①">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.11" data-lt="Notify activated state" data-noexport="" id="notify-activated-state"><span class="secno">8.11. </span><span class="content">Notify activated state</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.12" data-lt="Notify activated state" data-noexport="" id="notify-activated-state"><span class="secno">8.12. </span><span class="content">Notify activated state</span></h3>
    <div class="algorithm" data-algorithm="notify activated state">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①⓪">[[state]]</a></code> to "activated".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> to "activated".</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
@@ -2782,31 +2797,31 @@ that must be supported as attributes by the objects implementing the <code class
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.12" data-lt="Notify error" data-noexport="" id="notify-error"><span class="secno">8.12. </span><span class="content">Notify error</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.13" data-lt="Notify error" data-noexport="" id="notify-error"><span class="secno">8.13. </span><span class="content">Notify error</span></h3>
    <div class="algorithm" data-algorithm="notify error">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
      <dd data-md="">
-      <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
+      <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①①">[[state]]</a></code> to "idle".</p>
+      <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①⓪">[[state]]</a></code> to "idle".</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire③">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.13" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">8.13. </span><span class="content">Get value from latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.14" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">8.14. </span><span class="content">Get value from latest reading</span></h3>
    <div class="algorithm" data-algorithm="get value from latest reading">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
@@ -2815,7 +2830,7 @@ that must be supported as attributes by the objects implementing the <code class
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①②">[[state]]</a></code> is "activated",</p>
+      <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①①">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
         <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①④">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a>.</p>
@@ -2832,12 +2847,12 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Otherwise, return null.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.14" data-lt="Request sensor access" data-noexport="" id="request-sensor-access"><span class="secno">8.14. </span><span class="content">Request sensor access</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.15" data-lt="Request sensor access" data-noexport="" id="request-sensor-access"><span class="secno">8.15. </span><span class="content">Request sensor access</span></h3>
    <div class="algorithm" data-algorithm="request sensor access">
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
@@ -2869,9 +2884,9 @@ that must be supported as attributes by the objects implementing the <code class
    </div>
    <h2 class="heading settled" data-level="9" id="extensibility"><span class="secno">9. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor types</a>.</p>
+   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a>.</p>
    <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport="" id="extension-specification">extension specifications</dfn> are encouraged to focus on a
-single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
+single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
    <p>For an up-to-date list of <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification④">extension specifications</a>, please refer to <a data-link-type="biblio" href="#biblio-generic-sensor-usecases">[GENERIC-SENSOR-USECASES]</a> and <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> documents.</p>
    <h3 class="heading settled" data-level="9.1" id="extension-security-and-privacy"><span class="secno">9.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
@@ -2889,16 +2904,16 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
 named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
 named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
 with the "Sensor" suffix.
 For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> subclass that
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> subclass that
 hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
@@ -2946,42 +2961,42 @@ and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a> should focus primarily on
 exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="9.5" id="multiple-sensors"><span class="secno">9.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
-   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> with
+   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> with
 equal construction parameters, as it can lead to unnecessary hardware resources consumption.</p>
-   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensor</a></code> instance instead of
-creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
+   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instance instead of
+creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
 handler.</p>
-   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> can be created when they
+   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> can be created when they
 are intended to be used with different settings, such as: <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑨">requested sampling frequency</a>,
 accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a>.</p>
    <h3 class="heading settled" data-level="9.6" id="definition-reqs"><span class="secno">9.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">extension specifications</a>:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
   Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤③">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①⓪">sensor fusion</a> (otherwise, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionNames</a></code> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor types</a> must be used).</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①⓪">sensor fusion</a> (otherwise, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionNames</a></code> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor types</a> must be used).</p>
    </ul>
    <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⓪">extension specification</a> may specify the following definitions
-for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor types</a>:</p>
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor types</a>:</p>
    <ul>
     <li data-md="">
      <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions③">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑧">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">type</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑧">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑦">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③⓪">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③⓪">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
   especially when doing so would not make sense.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①①">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
    <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑤">sensor readings</a> from
@@ -2999,17 +3014,17 @@ for accelerometer sensor is given below.</p>
 };
 </pre>
    <h3 class="heading settled" data-level="9.8" id="feature-policy-api"><span class="secno">9.8. </span><span class="content">Extending the Feature Policy API</span><a class="self-link" href="#feature-policy-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor type</a> has one
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">sensor type</a> has one
 (if <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①②">sensor fusion</a> is not performed) or several <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature③">policy-controlled features</a> that control whether or not this implementation can be used in a document.</p>
    <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature④">features</a>' <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist">default allowlist</a> is <code>["self"]</code>.</p>
-   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">Sensor</a></code> interface
+   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface
 implementation usage in same-origin nested frames but prevents third-party content
 from <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑥">sensor readings</a> access.</p>
-   <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names①">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
+   <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
 every associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑤">feature</a>.</p>
-   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④④">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
+   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
 for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specification</a> tells
-otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">sensor permission names</a>.</p>
+otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">sensor permission names</a>.</p>
    <div class="example html" id="example-924ff346">
     <a class="self-link" href="#example-924ff346"></a> The accelerometer feature is selectively enabled for third-party origin by adding <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allow-attribute" id="ref-for-allow-attribute">allow attribute</a> to the frame container element: 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://third-party.com"</span> <span class="na">allow</span><span class="o">=</span><span class="s">"accelerometer"</span><span class="p">/>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
@@ -3021,7 +3036,7 @@ response header:
 <pre class="highlight">Feature<span class="o">-</span>Policy<span class="o">:</span> <span class="p">{</span><span class="s2">"accelerometer"</span><span class="o">:</span> <span class="p">[]}</span>
 </pre>
    </div>
-   <p><a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①③">Fusion sensors</a> must use <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> of the sensors
+   <p><a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①③">Fusion sensors</a> must use <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names④">sensor feature names</a> of the sensors
 that are used as a source of fusion.</p>
    <div class="example html" id="example-33abe2f9">
     <a class="self-link" href="#example-33abe2f9"></a> Allow third-party origin to use accelerometer, magnetometer and gyroscope features
@@ -3145,7 +3160,7 @@ for their editorial input.</p>
     <a class="self-link" href="#example-f839f6c8"></a> 
     <p>This is an example of an informative example.</p>
    </div>
-   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
+   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑥">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
     Although all of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③②">sensors</a> used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
@@ -3302,17 +3317,17 @@ for their editorial input.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#activate-a-sensor-object">Activate a sensor object</a><span>, in §8.2</span>
+   <li><a href="#activate-a-sensor-object">Activate a sensor object</a><span>, in §8.3</span>
    <li><a href="#dom-sensor-activated">activated</a><span>, in §7.1</span>
    <li><a href="#activated-sensor-objects">activated sensor objects</a><span>, in §6.2</span>
    <li><a href="#associated-sensors">associated sensors</a><span>, in §6.1</span>
    <li><a href="#biaxial">biaxial</a><span>, in §5.1</span>
    <li><a href="#calibration">calibration</a><span>, in §5.1</span>
    <li><a href="#can-expose-sensor-readings">can expose sensor readings</a><span>, in §5.6</span>
+   <li><a href="#check-sensor-policy-controlled-features">Check sensor policy-controlled features</a><span>, in §8.1</span>
    <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §Unnumbered section</span>
-   <li><a href="#connect-to-sensor">Connect to sensor</a><span>, in §8.1</span>
-   <li><a href="#construct-sensor-object">Construct sensor object</a><span>, in §8</span>
-   <li><a href="#deactivate-a-sensor-object">Deactivate a sensor object</a><span>, in §8.3</span>
+   <li><a href="#connect-to-sensor">Connect to sensor</a><span>, in §8.2</span>
+   <li><a href="#deactivate-a-sensor-object">Deactivate a sensor object</a><span>, in §8.4</span>
    <li><a href="#default-sensor">default sensor</a><span>, in §5.3</span>
    <li><a href="#concept-device-sensor">device sensor</a><span>, in §5.1</span>
    <li><a href="#equivalent">equivalent</a><span>, in §Unnumbered section</span>
@@ -3323,13 +3338,14 @@ for their editorial input.</p>
      <li><a href="#dom-sensorerroreventinit-error">dict-member for SensorErrorEventInit</a><span>, in §7.2</span>
     </ul>
    <li><a href="#extension-specification">extension specification</a><span>, in §9</span>
-   <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §8.7</span>
+   <li><a href="#find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a><span>, in §8.8</span>
    <li><a href="#dom-sensoroptions-frequency">frequency</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-frequency-slot">[[frequency]]</a><span>, in §7.1.3</span>
    <li><a href="#generic-sensor-permission-revocation-algorithm">generic sensor permission revocation algorithm</a><span>, in §6.1</span>
-   <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.12</span>
+   <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.13</span>
    <li><a href="#dom-sensor-hasreading">hasReading</a><span>, in §7.1</span>
    <li><a href="#high-level">high-level</a><span>, in §5.2</span>
+   <li><a href="#initialize-a-sensor-object">Initialize a sensor object</a><span>, in §8</span>
    <li><a href="#dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a><span>, in §7.1.3</span>
    <li><a href="#latest-reading">latest reading</a><span>, in §6.2</span>
    <li><a href="#limit-max-frequency">Limit maximum sampling frequency</a><span>, in §4.3</span>
@@ -3337,9 +3353,9 @@ for their editorial input.</p>
    <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §5.1</span>
    <li><a href="#low-level">low-level</a><span>, in §5.2</span>
    <li><a href="#mandatory-conditions">mandatory conditions</a><span>, in §5.6</span>
-   <li><a href="#notify-activated-state">Notify activated state</a><span>, in §8.10</span>
-   <li><a href="#notify-error">Notify error</a><span>, in §8.11</span>
-   <li><a href="#notify-new-reading">Notify new reading</a><span>, in §8.9</span>
+   <li><a href="#notify-activated-state">Notify activated state</a><span>, in §8.11</span>
+   <li><a href="#notify-error">Notify error</a><span>, in §8.12</span>
+   <li><a href="#notify-new-reading">Notify new reading</a><span>, in §8.10</span>
    <li><a href="#dom-sensor-onactivate">onactivate</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-onerror">onerror</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-onreading">onreading</a><span>, in §7.1</span>
@@ -3352,10 +3368,10 @@ for their editorial input.</p>
    <li><a href="#reading-value">reading value</a><span>, in §5.1</span>
    <li><a href="#reduce-accuracy">Reduce accuracy</a><span>, in §4.3.3</span>
    <li><a href="#reporting-frequency">reporting frequency</a><span>, in §5.5</span>
-   <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §8.8</span>
+   <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §8.9</span>
    <li><a href="#requested-sampling-frequency">requested sampling frequency</a><span>, in §5.5</span>
-   <li><a href="#request-sensor-access">Request sensor access</a><span>, in §8.13</span>
-   <li><a href="#revoke-sensor-permission">Revoke sensor permission</a><span>, in §8.4</span>
+   <li><a href="#request-sensor-access">Request sensor access</a><span>, in §8.14</span>
+   <li><a href="#revoke-sensor-permission">Revoke sensor permission</a><span>, in §8.5</span>
    <li><a href="#sampling-frequency">sampling frequency</a><span>, in §5.5</span>
    <li><a href="#sensor">Sensor</a><span>, in §7.1</span>
    <li><a href="#sensorerrorevent">SensorErrorEvent</a><span>, in §7.2</span>
@@ -3369,7 +3385,7 @@ for their editorial input.</p>
    <li><a href="#sensor-readings">sensor readings</a><span>, in §5.1</span>
    <li><a href="#sensor-task-source">sensor task source</a><span>, in §7.1</span>
    <li><a href="#sensor-type">sensor type</a><span>, in §6.1</span>
-   <li><a href="#set-sensor-settings">Set sensor settings</a><span>, in §8.5</span>
+   <li><a href="#set-sensor-settings">Set sensor settings</a><span>, in §8.6</span>
    <li><a href="#smart-sensors">Smart sensors</a><span>, in §5.2</span>
    <li><a href="#spatial-sensor">spatial sensor</a><span>, in §5.1</span>
    <li><a href="#specific-conditions">Specific conditions</a><span>, in §5.6</span>
@@ -3380,7 +3396,7 @@ for their editorial input.</p>
    <li><a href="#dom-sensor-timestamp">timestamp</a><span>, in §7.1</span>
    <li><a href="#triaxial">triaxial</a><span>, in §5.1</span>
    <li><a href="#uniaxial">uniaxial</a><span>, in §5.1</span>
-   <li><a href="#update-latest-reading">Update latest reading</a><span>, in §8.6</span>
+   <li><a href="#update-latest-reading">Update latest reading</a><span>, in §8.7</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -3399,6 +3415,7 @@ for their editorial input.</p>
     <a data-link-type="biblio">[FEATURE-POLICY]</a> defines the following terms:
     <ul>
      <li><a href="https://wicg.github.io/feature-policy/#allow-attribute">allow attribute</a>
+     <li><a href="https://wicg.github.io/feature-policy/#allowed-to-use">allowed to use</a>
      <li><a href="https://wicg.github.io/feature-policy/#default-allowlist">default allowlist</a>
      <li><a href="https://wicg.github.io/feature-policy/#feature-name">feature name</a>
      <li><a href="https://wicg.github.io/feature-policy/#policy-controlled-feature">policy-controlled feature</a>
@@ -3414,7 +3431,6 @@ for their editorial input.</p>
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">allowed to use</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">currently focused area</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a>
@@ -3483,7 +3499,6 @@ for their editorial input.</p>
      <li><a href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a>
      <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
      <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
-     <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a>
      <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
@@ -3496,7 +3511,6 @@ for their editorial input.</p>
      <li><a href="https://heycam.github.io/webidl/#dfn-interface">interface</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-read-only">read only</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -3599,7 +3613,7 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-device-sensor②③">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-concept-device-sensor②④">6.2. Sensor</a> <a href="#ref-for-concept-device-sensor②⑤">(2)</a>
     <li><a href="#ref-for-concept-device-sensor②⑥">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-concept-device-sensor②⑦">8.2. Connect to sensor</a> <a href="#ref-for-concept-device-sensor②⑧">(2)</a> <a href="#ref-for-concept-device-sensor②⑨">(3)</a>
+    <li><a href="#ref-for-concept-device-sensor②⑦">8.3. Connect to sensor</a> <a href="#ref-for-concept-device-sensor②⑧">(2)</a> <a href="#ref-for-concept-device-sensor②⑨">(3)</a>
     <li><a href="#ref-for-concept-device-sensor③⓪">9.6. Definition Requirements</a>
     <li><a href="#ref-for-concept-device-sensor③①">9.9. Example WebIDL</a>
    </ul>
@@ -3649,10 +3663,10 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-readings③⑧">7.1. The Sensor Interface</a> <a href="#ref-for-sensor-readings③⑨">(2)</a>
     <li><a href="#ref-for-sensor-readings④⓪">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor-readings④①">(2)</a>
     <li><a href="#ref-for-sensor-readings④②">7.1.9. Sensor.onreading</a>
-    <li><a href="#ref-for-sensor-readings④③">8.2. Connect to sensor</a> <a href="#ref-for-sensor-readings④④">(2)</a>
-    <li><a href="#ref-for-sensor-readings④⑤">8.6. Set sensor settings</a> <a href="#ref-for-sensor-readings④⑥">(2)</a>
-    <li><a href="#ref-for-sensor-readings④⑦">8.7. Update latest reading</a>
-    <li><a href="#ref-for-sensor-readings④⑧">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor-readings④③">8.3. Connect to sensor</a> <a href="#ref-for-sensor-readings④④">(2)</a>
+    <li><a href="#ref-for-sensor-readings④⑤">8.7. Set sensor settings</a> <a href="#ref-for-sensor-readings④⑥">(2)</a>
+    <li><a href="#ref-for-sensor-readings④⑦">8.8. Update latest reading</a>
+    <li><a href="#ref-for-sensor-readings④⑧">8.14. Get value from latest reading</a>
     <li><a href="#ref-for-sensor-readings④⑨">9.2. Naming</a> <a href="#ref-for-sensor-readings⑤⓪">(2)</a>
     <li><a href="#ref-for-sensor-readings⑤①">9.3. Unit</a>
     <li><a href="#ref-for-sensor-readings⑤②">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
@@ -3665,7 +3679,7 @@ for their editorial input.</p>
    <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">5.1. Sensors</a> <a href="#ref-for-local-coordinate-system①">(2)</a> <a href="#ref-for-local-coordinate-system②">(3)</a>
-    <li><a href="#ref-for-local-coordinate-system③">8.13. Get value from latest reading</a> <a href="#ref-for-local-coordinate-system④">(2)</a>
+    <li><a href="#ref-for-local-coordinate-system③">8.14. Get value from latest reading</a> <a href="#ref-for-local-coordinate-system④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="spatial-sensor">
@@ -3691,16 +3705,16 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor①⑧">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑨">(2)</a> <a href="#ref-for-concept-platform-sensor②⓪">(3)</a>
     <li><a href="#ref-for-concept-platform-sensor②①">7.1.1. Sensor lifecycle</a>
     <li><a href="#ref-for-concept-platform-sensor②②">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-platform-sensor②③">8.2. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②④">(2)</a> <a href="#ref-for-concept-platform-sensor②⑤">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑥">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑦">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑧">8.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑨">8.6. Set sensor settings</a>
-    <li><a href="#ref-for-concept-platform-sensor③⓪">8.7. Update latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③①">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor③②">8.11. Notify activated state</a>
-    <li><a href="#ref-for-concept-platform-sensor③③">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③④">8.14. Request sensor access</a>
+    <li><a href="#ref-for-concept-platform-sensor②③">8.3. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②④">(2)</a> <a href="#ref-for-concept-platform-sensor②⑤">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑥">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑦">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑧">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑨">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-concept-platform-sensor③⓪">8.8. Update latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③①">8.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor③②">8.12. Notify activated state</a>
+    <li><a href="#ref-for-concept-platform-sensor③③">8.14. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③④">8.15. Request sensor access</a>
     <li><a href="#ref-for-concept-platform-sensor③⑤">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑥">(2)</a> <a href="#ref-for-concept-platform-sensor③⑦">(3)</a>
     <li><a href="#ref-for-concept-platform-sensor③⑧">9.6. Definition Requirements</a>
    </ul>
@@ -3742,7 +3756,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-default-sensor">5.3. Default sensor</a> <a href="#ref-for-default-sensor①">(2)</a> <a href="#ref-for-default-sensor②">(3)</a>
     <li><a href="#ref-for-default-sensor③">6.1. Sensor Type</a>
-    <li><a href="#ref-for-default-sensor④">8.2. Connect to sensor</a> <a href="#ref-for-default-sensor⑤">(2)</a>
+    <li><a href="#ref-for-default-sensor④">8.3. Connect to sensor</a> <a href="#ref-for-default-sensor⑤">(2)</a>
     <li><a href="#ref-for-default-sensor⑥">9.6. Definition Requirements</a> <a href="#ref-for-default-sensor⑦">(2)</a> <a href="#ref-for-default-sensor⑧">(3)</a>
    </ul>
   </aside>
@@ -3760,8 +3774,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-sampling-frequency②">4.3.3. Limit number of delivered readings</a>
     <li><a href="#ref-for-sampling-frequency③">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-sampling-frequency④">(2)</a> <a href="#ref-for-sampling-frequency⑤">(3)</a> <a href="#ref-for-sampling-frequency⑥">(4)</a>
     <li><a href="#ref-for-sampling-frequency⑦">6.2. Sensor</a> <a href="#ref-for-sampling-frequency⑧">(2)</a>
-    <li><a href="#ref-for-sampling-frequency⑨">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-sampling-frequency①⓪">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sampling-frequency⑨">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-sampling-frequency①⓪">8.9. Find the reporting frequency of a sensor object</a>
     <li><a href="#ref-for-sampling-frequency①①">9.7. Extending the Permission API</a>
    </ul>
   </aside>
@@ -3771,7 +3785,7 @@ for their editorial input.</p>
     <li><a href="#ref-for-requested-sampling-frequency">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-requested-sampling-frequency①">(2)</a> <a href="#ref-for-requested-sampling-frequency②">(3)</a>
     <li><a href="#ref-for-requested-sampling-frequency③">6.2. Sensor</a> <a href="#ref-for-requested-sampling-frequency④">(2)</a> <a href="#ref-for-requested-sampling-frequency⑤">(3)</a>
     <li><a href="#ref-for-requested-sampling-frequency⑥">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-requested-sampling-frequency⑦">8.6. Set sensor settings</a> <a href="#ref-for-requested-sampling-frequency⑧">(2)</a>
+    <li><a href="#ref-for-requested-sampling-frequency⑦">8.7. Set sensor settings</a> <a href="#ref-for-requested-sampling-frequency⑧">(2)</a>
     <li><a href="#ref-for-requested-sampling-frequency⑨">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
   </aside>
@@ -3780,7 +3794,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-reporting-frequency">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-reporting-frequency①">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-reporting-frequency②">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-reporting-frequency②">8.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="can-expose-sensor-readings">
@@ -3810,12 +3824,13 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-type②①">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-sensor-type②②">6.1. Sensor Type</a> <a href="#ref-for-sensor-type②③">(2)</a> <a href="#ref-for-sensor-type②④">(3)</a> <a href="#ref-for-sensor-type②⑤">(4)</a> <a href="#ref-for-sensor-type②⑥">(5)</a> <a href="#ref-for-sensor-type②⑦">(6)</a>
     <li><a href="#ref-for-sensor-type②⑧">6.2. Sensor</a> <a href="#ref-for-sensor-type②⑨">(2)</a>
-    <li><a href="#ref-for-sensor-type③⓪">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-type③①">9. Extensibility</a> <a href="#ref-for-sensor-type③②">(2)</a>
-    <li><a href="#ref-for-sensor-type③③">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor-type③④">(2)</a> <a href="#ref-for-sensor-type③⑤">(3)</a>
-    <li><a href="#ref-for-sensor-type③⑥">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type③⑦">(2)</a> <a href="#ref-for-sensor-type③⑧">(3)</a> <a href="#ref-for-sensor-type③⑨">(4)</a> <a href="#ref-for-sensor-type④⓪">(5)</a> <a href="#ref-for-sensor-type④①">(6)</a>
-    <li><a href="#ref-for-sensor-type④②">9.7. Extending the Permission API</a>
-    <li><a href="#ref-for-sensor-type④③">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-type④④">(2)</a>
+    <li><a href="#ref-for-sensor-type③⓪">8.2. Check sensor policy-controlled features</a>
+    <li><a href="#ref-for-sensor-type③①">8.3. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-type③②">9. Extensibility</a> <a href="#ref-for-sensor-type③③">(2)</a>
+    <li><a href="#ref-for-sensor-type③④">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor-type③⑤">(2)</a> <a href="#ref-for-sensor-type③⑥">(3)</a>
+    <li><a href="#ref-for-sensor-type③⑦">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type③⑧">(2)</a> <a href="#ref-for-sensor-type③⑨">(3)</a> <a href="#ref-for-sensor-type④⓪">(4)</a> <a href="#ref-for-sensor-type④①">(5)</a> <a href="#ref-for-sensor-type④②">(6)</a>
+    <li><a href="#ref-for-sensor-type④③">9.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-type④④">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-type④⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="associated-sensors">
@@ -3828,45 +3843,45 @@ for their editorial input.</p>
    <b><a href="#sensor-permission-names">#sensor-permission-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">6.1. Sensor Type</a>
-    <li><a href="#ref-for-sensor-permission-names①">8.14. Request sensor access</a>
+    <li><a href="#ref-for-sensor-permission-names①">8.15. Request sensor access</a>
     <li><a href="#ref-for-sensor-permission-names②">9.8. Extending the Feature Policy API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-feature-names">
    <b><a href="#sensor-feature-names">#sensor-feature-names</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-feature-names">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-sensor-feature-names①">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-feature-names②">(2)</a> <a href="#ref-for-sensor-feature-names③">(3)</a>
+    <li><a href="#ref-for-sensor-feature-names">8.2. Check sensor policy-controlled features</a> <a href="#ref-for-sensor-feature-names①">(2)</a>
+    <li><a href="#ref-for-sensor-feature-names②">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-feature-names③">(2)</a> <a href="#ref-for-sensor-feature-names④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
    <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activated-sensor-objects">6.2. Sensor</a> <a href="#ref-for-activated-sensor-objects①">(2)</a> <a href="#ref-for-activated-sensor-objects②">(3)</a> <a href="#ref-for-activated-sensor-objects③">(4)</a>
-    <li><a href="#ref-for-activated-sensor-objects④">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-activated-sensor-objects⑤">8.4. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects⑥">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects⑦">8.5. Revoke sensor permission</a>
-    <li><a href="#ref-for-activated-sensor-objects⑧">8.6. Set sensor settings</a>
-    <li><a href="#ref-for-activated-sensor-objects⑨">8.7. Update latest reading</a>
+    <li><a href="#ref-for-activated-sensor-objects④">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-activated-sensor-objects⑤">8.5. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects⑥">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects⑦">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-activated-sensor-objects⑧">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-activated-sensor-objects⑨">8.8. Update latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="latest-reading">
    <b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">6.2. Sensor</a> <a href="#ref-for-latest-reading①">(2)</a> <a href="#ref-for-latest-reading②">(3)</a> <a href="#ref-for-latest-reading③">(4)</a> <a href="#ref-for-latest-reading④">(5)</a> <a href="#ref-for-latest-reading⑤">(6)</a> <a href="#ref-for-latest-reading⑥">(7)</a>
-    <li><a href="#ref-for-latest-reading⑦">8.6. Set sensor settings</a> <a href="#ref-for-latest-reading⑧">(2)</a>
-    <li><a href="#ref-for-latest-reading⑨">8.7. Update latest reading</a> <a href="#ref-for-latest-reading①⓪">(2)</a>
-    <li><a href="#ref-for-latest-reading①①">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-latest-reading①②">8.10. Notify new reading</a>
-    <li><a href="#ref-for-latest-reading①③">8.11. Notify activated state</a>
-    <li><a href="#ref-for-latest-reading①④">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-latest-reading⑦">8.7. Set sensor settings</a> <a href="#ref-for-latest-reading⑧">(2)</a>
+    <li><a href="#ref-for-latest-reading⑨">8.8. Update latest reading</a> <a href="#ref-for-latest-reading①⓪">(2)</a>
+    <li><a href="#ref-for-latest-reading①①">8.10. Report latest reading updated</a>
+    <li><a href="#ref-for-latest-reading①②">8.11. Notify new reading</a>
+    <li><a href="#ref-for-latest-reading①③">8.12. Notify activated state</a>
+    <li><a href="#ref-for-latest-reading①④">8.14. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="optimal-sampling-frequency">
    <b><a href="#optimal-sampling-frequency">#optimal-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimal-sampling-frequency">6.2. Sensor</a>
-    <li><a href="#ref-for-optimal-sampling-frequency①">8.6. Set sensor settings</a>
+    <li><a href="#ref-for-optimal-sampling-frequency①">8.7. Set sensor settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor">
@@ -3883,22 +3898,22 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor①②">7.1.2. Sensor garbage collection</a> <a href="#ref-for-sensor①③">(2)</a> <a href="#ref-for-sensor①④">(3)</a>
     <li><a href="#ref-for-sensor①⑤">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor①⑥">(2)</a> <a href="#ref-for-sensor①⑦">(3)</a> <a href="#ref-for-sensor①⑧">(4)</a>
     <li><a href="#ref-for-sensor①⑨">7.1.12. Event handlers</a>
-    <li><a href="#ref-for-sensor②⓪">8.1. Construct sensor object</a> <a href="#ref-for-sensor②①">(2)</a> <a href="#ref-for-sensor②②">(3)</a>
-    <li><a href="#ref-for-sensor②③">8.2. Connect to sensor</a>
-    <li><a href="#ref-for-sensor②④">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor②⑤">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②⑥">8.8. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②⑦">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②⑧">8.10. Notify new reading</a>
-    <li><a href="#ref-for-sensor②⑨">8.11. Notify activated state</a>
-    <li><a href="#ref-for-sensor③⓪">8.12. Notify error</a>
-    <li><a href="#ref-for-sensor③①">8.13. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor③②">8.14. Request sensor access</a>
-    <li><a href="#ref-for-sensor③③">9.2. Naming</a> <a href="#ref-for-sensor③④">(2)</a> <a href="#ref-for-sensor③⑤">(3)</a>
-    <li><a href="#ref-for-sensor③⑥">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑦">(2)</a> <a href="#ref-for-sensor③⑧">(3)</a>
-    <li><a href="#ref-for-sensor③⑨">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor④⓪">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④①">(2)</a>
-    <li><a href="#ref-for-sensor④②">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④③">(2)</a> <a href="#ref-for-sensor④④">(3)</a>
+    <li><a href="#ref-for-sensor②⓪">8.1. Initialize a sensor object</a> <a href="#ref-for-sensor②①">(2)</a>
+    <li><a href="#ref-for-sensor②②">8.3. Connect to sensor</a>
+    <li><a href="#ref-for-sensor②③">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor②④">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor②⑤">8.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②⑥">8.10. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②⑦">8.11. Notify new reading</a>
+    <li><a href="#ref-for-sensor②⑧">8.12. Notify activated state</a>
+    <li><a href="#ref-for-sensor②⑨">8.13. Notify error</a>
+    <li><a href="#ref-for-sensor③⓪">8.14. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor③①">8.15. Request sensor access</a>
+    <li><a href="#ref-for-sensor③②">9.2. Naming</a> <a href="#ref-for-sensor③③">(2)</a> <a href="#ref-for-sensor③④">(3)</a>
+    <li><a href="#ref-for-sensor③⑤">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑥">(2)</a> <a href="#ref-for-sensor③⑦">(3)</a>
+    <li><a href="#ref-for-sensor③⑧">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor③⑨">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④⓪">(2)</a>
+    <li><a href="#ref-for-sensor④①">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④②">(2)</a> <a href="#ref-for-sensor④③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">
@@ -3917,7 +3932,7 @@ for their editorial input.</p>
    <b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-timestamp">7.1.6. Sensor.timestamp</a>
-    <li><a href="#ref-for-dom-sensor-timestamp①">8.1. Construct sensor object</a>
+    <li><a href="#ref-for-dom-sensor-timestamp①">8.1. Initialize a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-start">
@@ -3955,7 +3970,7 @@ for their editorial input.</p>
    <b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-dictdef-sensoroptions①">8.1. Construct sensor object</a>
+    <li><a href="#ref-for-dictdef-sensoroptions①">8.1. Initialize a sensor object</a>
     <li><a href="#ref-for-dictdef-sensoroptions②">9.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions③">(2)</a>
    </ul>
   </aside>
@@ -3963,13 +3978,13 @@ for their editorial input.</p>
    <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensoroptions-frequency">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-dom-sensoroptions-frequency①">8.1. Construct sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency②">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency③">(3)</a>
+    <li><a href="#ref-for-dom-sensoroptions-frequency①">8.1. Initialize a sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency②">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-task-source">
    <b><a href="#sensor-task-source">#sensor-task-source</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-task-source">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor-task-source">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-state-slot">
@@ -3980,46 +3995,45 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-sensor-state-slot④">7.1.7. Sensor.start()</a> <a href="#ref-for-dom-sensor-state-slot⑤">(2)</a>
     <li><a href="#ref-for-dom-sensor-state-slot⑥">7.1.8. Sensor.stop()</a> <a href="#ref-for-dom-sensor-state-slot⑦">(2)</a>
     <li><a href="#ref-for-dom-sensor-state-slot⑧">7.1.10. Sensor.onactivate</a>
-    <li><a href="#ref-for-dom-sensor-state-slot⑨">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-state-slot①⓪">8.11. Notify activated state</a>
-    <li><a href="#ref-for-dom-sensor-state-slot①①">8.12. Notify error</a>
-    <li><a href="#ref-for-dom-sensor-state-slot①②">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-dom-sensor-state-slot⑨">8.12. Notify activated state</a>
+    <li><a href="#ref-for-dom-sensor-state-slot①⓪">8.13. Notify error</a>
+    <li><a href="#ref-for-dom-sensor-state-slot①①">8.14. Get value from latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-frequency-slot">
    <b><a href="#dom-sensor-frequency-slot">#dom-sensor-frequency-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-frequency-slot">6.2. Sensor</a> <a href="#ref-for-dom-sensor-frequency-slot①">(2)</a>
-    <li><a href="#ref-for-dom-sensor-frequency-slot②">8.1. Construct sensor object</a>
-    <li><a href="#ref-for-dom-sensor-frequency-slot③">8.8. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-frequency-slot②">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-frequency-slot③">8.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot">
    <b><a href="#dom-sensor-lasteventfiredat-slot">#dom-sensor-lasteventfiredat-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot①">8.9. Report latest reading updated</a>
-    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot②">8.10. Notify new reading</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot①">8.10. Report latest reading updated</a>
+    <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot②">8.11. Notify new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-pendingreadingnotification-slot">
    <b><a href="#dom-sensor-pendingreadingnotification-slot">#dom-sensor-pendingreadingnotification-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot">8.4. Deactivate a sensor object</a>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot①">8.9. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot②">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot③">(3)</a>
-    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot④">8.10. Notify new reading</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot①">8.10. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot②">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot③">(3)</a>
+    <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot④">8.11. Notify new reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensorerrorevent">
    <b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensorerrorevent">8.12. Notify error</a>
+    <li><a href="#ref-for-sensorerrorevent">8.13. Notify error</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensorerrorevent-error">
    <b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-sensorerrorevent-error">8.12. Notify error</a>
+    <li><a href="#ref-for-dom-sensorerrorevent-error">8.13. Notify error</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-sensorerroreventinit">
@@ -4046,7 +4060,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-deactivate-a-sensor-object">7.1.2. Sensor garbage collection</a>
     <li><a href="#ref-for-deactivate-a-sensor-object①">7.1.8. Sensor.stop()</a>
-    <li><a href="#ref-for-deactivate-a-sensor-object②">8.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-deactivate-a-sensor-object②">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="revoke-sensor-permission">
@@ -4058,8 +4072,8 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="set-sensor-settings">
    <b><a href="#set-sensor-settings">#set-sensor-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-set-sensor-settings">8.3. Activate a sensor object</a>
-    <li><a href="#ref-for-set-sensor-settings①">8.4. Deactivate a sensor object</a>
+    <li><a href="#ref-for-set-sensor-settings">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-set-sensor-settings①">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="update-latest-reading">
@@ -4071,33 +4085,33 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="find-the-reporting-frequency-of-a-sensor-object">
    <b><a href="#find-the-reporting-frequency-of-a-sensor-object">#find-the-reporting-frequency-of-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object">8.9. Report latest reading updated</a>
+    <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object">8.10. Report latest reading updated</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="report-latest-reading-updated">
    <b><a href="#report-latest-reading-updated">#report-latest-reading-updated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-report-latest-reading-updated">8.7. Update latest reading</a>
+    <li><a href="#ref-for-report-latest-reading-updated">8.8. Update latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-new-reading">
    <b><a href="#notify-new-reading">#notify-new-reading</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-new-reading">8.9. Report latest reading updated</a> <a href="#ref-for-notify-new-reading①">(2)</a> <a href="#ref-for-notify-new-reading②">(3)</a> <a href="#ref-for-notify-new-reading③">(4)</a>
-    <li><a href="#ref-for-notify-new-reading④">8.11. Notify activated state</a>
+    <li><a href="#ref-for-notify-new-reading">8.10. Report latest reading updated</a> <a href="#ref-for-notify-new-reading①">(2)</a> <a href="#ref-for-notify-new-reading②">(3)</a> <a href="#ref-for-notify-new-reading③">(4)</a>
+    <li><a href="#ref-for-notify-new-reading④">8.12. Notify activated state</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-activated-state">
    <b><a href="#notify-activated-state">#notify-activated-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notify-activated-state">8.3. Activate a sensor object</a>
+    <li><a href="#ref-for-notify-activated-state">8.4. Activate a sensor object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="notify-error">
    <b><a href="#notify-error">#notify-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-error">7.1.7. Sensor.start()</a> <a href="#ref-for-notify-error①">(2)</a>
-    <li><a href="#ref-for-notify-error②">8.5. Revoke sensor permission</a>
+    <li><a href="#ref-for-notify-error②">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="get-value-from-latest-reading">
@@ -4121,7 +4135,7 @@ for their editorial input.</p>
     <li><a href="#ref-for-extension-specification">4.2.1. Secure Context</a>
     <li><a href="#ref-for-extension-specification①">5.1. Sensors</a>
     <li><a href="#ref-for-extension-specification②">5.6. Conditions to expose sensor readings</a>
-    <li><a href="#ref-for-extension-specification③">8.13. Get value from latest reading</a>
+    <li><a href="#ref-for-extension-specification③">8.14. Get value from latest reading</a>
     <li><a href="#ref-for-extension-specification④">9. Extensibility</a>
     <li><a href="#ref-for-extension-specification⑤">9.1. Security and Privacy</a>
     <li><a href="#ref-for-extension-specification⑥">9.3. Unit</a>


### PR DESCRIPTION
The "construct sensor object" abstract operation is
now split into "Initialize a sensor object" and
"Check sensor policy-controlled features".

The actual construction is to be performed in the
sensor extension specifications.

Fixes #342


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/sensors/pull/345.html" title="Last updated on Feb 19, 2018, 2:01 PM GMT (4adefd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/345/a9be1c1...pozdnyakov:4adefd0.html" title="Last updated on Feb 19, 2018, 2:01 PM GMT (4adefd0)">Diff</a>