### PR TITLE
Clarify the conditions to expose sensor readings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -75,6 +75,10 @@ urlPrefix: https://wicg.github.io/feature-policy/; spec: FEATURE-POLICY
     text: feature name
     text: policy-controlled feature
     text: allowed to use
+urlPrefix: https://www.w3.org/TR/permissions; spec: PERMISSIONS
+  type: dfn
+    text: permission name
+    text: permission state
 </pre>
 <pre class=link-defaults>
 spec: webidl; type:dfn; text:attribute
@@ -744,9 +748,14 @@ never exceed the [=sampling frequency=] for the given [=sensor type=].
 ## Conditions to expose sensor readings ## {#concepts-can-expose-sensor-readings}
 
 The user agent must verify that all [=mandatory conditions=] are satisfied to ensure it
-<dfn>can expose sensor readings</dfn> to a given [=active document=].
+<dfn>can expose sensor readings</dfn> to the {{Sensor}} objects of a certain
+[=sensor type|type=] that belong to a certain [=active document=].
 
 The <dfn>mandatory conditions</dfn> are the following:
+ - The given document is a [=responsible document=] of a [=secure context=].
+ - For each [=permission name=] from the [=sensor type=]'s associated
+   [=sensor permission names=] [=ordered set|set=], the corresponding permission's
+   [=permission state|state=] is "granted".
  - [=document visibility state|Visibility state=] of the document is "visible".
  - The document is [=allowed to use=] all the [=policy-controlled features=] associated
    with the given [=sensor type=].
@@ -771,9 +780,9 @@ A [=sensor type=] has a [=ordered set|set=] of <dfn export>associated sensors</d
 A [=sensor type=] may have a [=default sensor=].
 
 A [=sensor type=] has a [=set/is empty|nonempty=] [=ordered set|set=] of associated
-{{PermissionName|PermissionNames}} referred as <dfn export>sensor permission names</dfn>.
+[=permission names=] referred to as <dfn export>sensor permission names</dfn>.
 
-Note: multiple [=sensor types=] may share the same {{PermissionName}}.
+Note: multiple [=sensor types=] may share the same [=permission name=].
 
 A [=sensor type=] has a [=permission revocation algorithm=].
 
@@ -788,25 +797,23 @@ A [=sensor type=] has a [=permission revocation algorithm=].
 </div>
 
 A [=sensor type=] has a [=set/is empty|nonempty=] [=ordered set|set=] of associated
-[=feature names=] referred as <dfn export>sensor feature names</dfn>.
+[=feature names=] referred to as <dfn export>sensor feature names</dfn>.
 
 <h3 id="model-sensor">Sensor</h3>
 
-A [=platform sensor=] has an associated [=ordered set|set=]
-of <dfn>activated sensor objects</dfn>.
-This set is initially [=set/is empty|empty=].
+The current [=browsing context=]'s [=platform sensor=] has an associated [=ordered set|set=]
+of <dfn>activated sensor objects</dfn>, which is initially [=set/is empty|empty=] and an
+associated <dfn>latest reading</dfn> [=ordered map|map=], which holds the latest available [=sensor readings=].
 
-The current [=browsing context=]'s [=platform sensor=] has an associated <dfn>latest reading</dfn>
-[=ordered map|map=] which holds the latest available [=sensor readings=].
-
-Note: User agents can share [=latest reading=] [=ordered map|map=] between different
+Note: User agents can share the [=latest reading=] [=ordered map|map=] and
+the [=activated sensor objects=] [=ordered set|set=] between different
 [=browsing context|contexts=] only if the [=origins=] of these contexts' [=active documents=]
 are [=same origin-domain=].
 
 Any time a new [=sensor reading=] for a [=platform sensor=] is obtained and if the user agent
 [=can expose sensor readings=] to the current [=browsing context=]'s [=active document=],
-[=update latest reading=] is invoked with the [=platform sensor=]
-and the [=sensor reading=] as arguments.
+the user agent invokes [=update latest reading=] with the [=platform sensor=] and
+the [=sensor reading=] as arguments.
 
 The [=latest reading=] [=ordered map|map=] contains an [=map/entry=] whose [=map/key=] is
 "timestamp" and whose [=map/value=] is a high resolution timestamp that estimates the
@@ -1637,8 +1644,8 @@ each [=sensor type=] in [=extension specifications=]:
     Its [=attributes=] which expose [=sensor readings=] are [=read only=] and
     their getters must return the result of invoking [=get value from latest reading=]
     with <strong>this</strong> and [=attribute=] [=identifier=] as arguments.
--   A {{PermissionName}}, if the [=sensor type=] is not representing
-    [=sensor fusion=] (otherwise, {{PermissionName|PermissionNames}}
+-   A [=permission name=], if the [=sensor type=] is not representing
+    [=sensor fusion=] (otherwise, [=permission names=]
     associated with the fusion source [=sensor types=] must be used).
 
 An [=extension specification=] may specify the following definitions
@@ -1655,8 +1662,8 @@ for each [=sensor types=]:
 <h3 id="permission-api">Extending the Permission API</h3>
 
 An implementation of the {{Sensor}} interface for each [=sensor type=] must protect its
-[=sensor reading|reading=] by associated {{PermissionName}} or {{PermissionDescriptor}}.
-A [=Low-level=] {{Sensor|sensor}} may use its interface name as a {{PermissionName}},
+[=sensor reading|reading=] by associated [=permission name=] or {{PermissionDescriptor}}.
+A [=Low-level=] {{Sensor|sensor}} may use its interface name as a [=permission name=],
 for instance, "gyroscope" or "accelerometer". [=sensor fusion|Fusion sensors=] must
 [=request permission to use|request permission to access=] each of the sensors that are
 used as a source of fusion.

--- a/index.html
+++ b/index.html
@@ -1453,7 +1453,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-27">27 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-01">1 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2058,14 +2058,18 @@ the "reading" event is <a data-link-type="dfn" href="https://dom.spec.whatwg.org
 user agent obtains them from the underlying platform, therefore the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency">reporting frequency</a> can
 never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑥">sampling frequency</a> for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">sensor type</a>.</p>
    <h3 class="heading settled" data-level="5.6" id="concepts-can-expose-sensor-readings"><span class="secno">5.6. </span><span class="content">Conditions to expose sensor readings</span><a class="self-link" href="#concepts-can-expose-sensor-readings"></a></h3>
-   <p>The user agent must verify that all <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions">mandatory conditions</a> are satisfied to ensure it <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="can-expose-sensor-readings">can expose sensor readings</dfn> to a given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>.</p>
+   <p>The user agent must verify that all <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions">mandatory conditions</a> are satisfied to ensure it <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="can-expose-sensor-readings">can expose sensor readings</dfn> to the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensor</a></code> objects of a certain <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">type</a> that belong to a certain <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mandatory-conditions">mandatory conditions</dfn> are the following:</p>
    <ul>
+    <li data-md="">
+     <p>The given document is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document">responsible document</a> of a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts①">secure context</a>.</p>
+    <li data-md="">
+     <p>For each <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name">permission name</a> from the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a>'s associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a>, the corresponding permission’s <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-state" id="ref-for-permission-state">state</a> is "granted".</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://w3c.github.io/page-visibility#dom-document-visibilitystate" id="ref-for-dom-document-visibilitystate">Visibility state</a> of the document is "visible".</p>
     <li data-md="">
      <p>The document is <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> all the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature①">policy-controlled features</a> associated
- with the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a>.</p>
+ with the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a>.</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context" id="ref-for-currently-focused-area-of-a-top-level-browsing-context">Currently focused area</a> belongs to a document whose origin is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a> with the origin of the given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>.</p>
     <li data-md="">
@@ -2074,20 +2078,20 @@ never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-
    <p class="note" role="note"><span>Note:</span> In order to release hardware resources, the user agent can request underlying <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑧">platform sensor</a> to suspend notifications about newly available readings until it <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings">can expose sensor readings</a>.</p>
    <h2 class="heading settled" data-level="6" id="model"><span class="secno">6. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="model-sensor-type"><span class="secno">6.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensor</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> may have a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a> of associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionNames</a></code> referred as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-permission-names">sensor permission names</dfn>.</p>
-   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor types</a> may share the same <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">PermissionName</a></code>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has an associated <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensor</a></code>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a> may have a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of associated <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name①">permission names</a> referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-permission-names">sensor permission names</dfn>.</p>
+   <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor types</a> may share the same <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name②">permission name</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
    <div class="algorithm" data-algorithm="generic sensor permission revocation algorithm">
-    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname②">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
+    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
     <ol>
      <li data-md="">
-      <p>For each <var>sensor_type</var> whose <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names">permission names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>permission_name</var>:</p>
+      <p>For each <var>sensor_type</var> whose <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names①">permission names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>permission_name</var>:</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>sensor</var> in <var>sensor_type</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of <a data-link-type="dfn" href="#associated-sensors" id="ref-for-associated-sensors">associated sensors</a>,</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>sensor</var> in <var>sensor_type</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of <a data-link-type="dfn" href="#associated-sensors" id="ref-for-associated-sensors">associated sensors</a>,</p>
         <ol>
          <li data-md="">
           <p>Invoke <a data-link-type="dfn" href="#revoke-sensor-permission" id="ref-for-revoke-sensor-permission">revoke sensor permission</a> with <var>sensor</var> as argument.</p>
@@ -2095,30 +2099,32 @@ never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-
       </ol>
     </ol>
    </div>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name">feature names</a> referred as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-feature-names">sensor feature names</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">set</a> of associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name">feature names</a> referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-feature-names">sensor feature names</dfn>.</p>
    <h3 class="heading settled" data-level="6.2" id="model-sensor"><span class="secno">6.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>.
-This set is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty②">empty</a>.</p>
-   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③④">sensor readings</a>.</p>
-   <p class="note" role="note"><span>Note:</span> User agents can share <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2②">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document③">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain①">same origin-domain</a>.</p>
-   <p>Any time a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①①">platform sensor</a> is obtained and if the user agent <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings①">can expose sensor readings</a> to the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>, <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> is invoked with the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①②">platform sensor</a> and the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑥">sensor reading</a> as arguments.</p>
+   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>, which is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty②">empty</a> and an
+associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>, which holds the latest available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③④">sensor readings</a>.</p>
+   <p class="note" role="note"><span>Note:</span> User agents can share the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> and
+the <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑥">set</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2" id="ref-for-origin-2②">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document③">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain①">same origin-domain</a>.</p>
+   <p>Any time a new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑤">sensor reading</a> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a> is obtained and if the user agent <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings①">can expose sensor readings</a> to the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>,
+the user agent invokes <a data-link-type="dfn" href="#update-latest-reading" id="ref-for-update-latest-reading">update latest reading</a> with the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①①">platform sensor</a> and
+the <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑥">sensor reading</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is
 "timestamp" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> is a high resolution timestamp that estimates the <a data-link-type="dfn" href="#reading-timestamp" id="ref-for-reading-timestamp②">reading timestamp</a> expressed in milliseconds since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin">time origin</a>.</p>
    <p class="note" role="note"><span>Note:</span> The accuracy of the <a data-link-type="dfn" href="#reading-timestamp" id="ref-for-reading-timestamp③">reading timestamp</a> estimate depends on the underlying
 platform interfaces that expose it.</p>
    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading②">latest reading</a>["timestamp"] is initially set to null,
 unless the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading③">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a> caches a previous <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑦">reading</a>.</p>
-   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading④">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a>.
+   <p>The other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> of the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading④">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a> hold the values of the different quantities measured by the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①②">platform sensor</a>.
 The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> of these <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry②">entries</a> must match
 the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier">identifier</a> defined by
-the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a>'s associated interface.
+the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a>'s associated interface.
 The return value of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute①">attribute</a> getter is
-easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑨">sensor type</a>'s associated interface
+easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a>'s associated interface
 and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute②">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier①">identifier</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑤">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry③">entries</a> is initially set to null.</p>
-   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①④">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
-   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty③">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
-by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
+   <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
+   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty③">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑦">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
+by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑦">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
 defined by the underlying platform.</p>
    <p class="note" role="note"><span>Note:</span> For example, the user agent may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency">optimal sampling frequency</a> as a Least Common
 Denominator (LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot①">provided frequencies</a></code> capped
@@ -2126,13 +2132,13 @@ by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequ
    <div class="example" id="example-509cb3c1">
     <a class="self-link" href="#example-509cb3c1"></a> 
     <p>This example illustrates a possible implementation of the described <a href="#model">Model</a>.</p>
-    <p>In the diagram below several <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑦">Sensor</a></code> objects from two
+    <p>In the diagram below several <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑧">Sensor</a></code> objects from two
 different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> interact with a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②④">device sensor</a>.</p>
     <p><img alt="Generic Sensor Model" src="images/generic_sensor_model.png" srcset="images/generic_sensor_model.svg"></p>
-    <p>The <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑧">Sensor</a></code> object in "idle" <a href="#sensor-lifecycle">state</a> is not among the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑤">platform sensor</a>'s <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated sensor objects</a> and thus it does not interact with the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑤">device sensor</a>.</p>
-    <p>In this example there is a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a> instance per <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a>.</p>
-    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑥">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map⑤">map</a> is shared between <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> objects from the
-same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">context</a> and is updated at rate equal to <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> of the corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>.</p>
+    <p>The <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> object in "idle" <a href="#sensor-lifecycle">state</a> is not among the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①④">platform sensor</a>'s <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects④">activated sensor objects</a> and thus it does not interact with the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑤">device sensor</a>.</p>
+    <p>In this example there is a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑤">platform sensor</a> instance per <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a>.</p>
+    <p>The <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑥">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map⑤">map</a> is shared between <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> objects from the
+same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">context</a> and is updated at rate equal to <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑤">requested sampling frequency</a> of the corresponding <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑥">platform sensor</a>.</p>
    </div>
    <h2 class="heading settled" data-level="7" id="api"><span class="secno">7. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="the-sensor-interface"><span class="secno">7.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
@@ -2152,12 +2158,12 @@ same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browse
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⓪">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>.</p>
    <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
    <div class="example" id="example-f144a057">
-    <a class="self-link" href="#example-f144a057"></a> In the following example, firstly, we check whether the user agent has permission to access <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">sensor readings</a>, then we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a> activation,
+    <a class="self-link" href="#example-f144a057"></a> In the following example, firstly, we check whether the user agent has permission to access <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑧">sensor readings</a>, then we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> activation,
     error conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings③⑨">sensor readings</a>. The example
-    measures and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a>. 
+    measures and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a>. 
     <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
 <pre class="highlight">navigator<span class="p">.</span>permissions<span class="p">.</span>query<span class="p">({</span> name<span class="o">:</span> <span class="s1">'accelerometer'</span> <span class="p">}).</span>then<span class="p">(</span>result <span class="p">=></span> <span class="p">{</span>
     <span class="k">if</span> <span class="p">(</span>result<span class="p">.</span>state <span class="o">===</span> <span class="s1">'denied'</span><span class="p">)</span> <span class="p">{</span>
@@ -2251,19 +2257,19 @@ same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browse
      </g>
     </g>
    </svg>
-   <p class="note" role="note"><span>Note:</span> the nodes in the diagram above represent the states of a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①①">Sensor</a></code> object and they should not be
-confused with the possible states of the underlying <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> or <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑥">device sensor</a>.</p>
+   <p class="note" role="note"><span>Note:</span> the nodes in the diagram above represent the states of a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object and they should not be
+confused with the possible states of the underlying <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⓪">platform sensor</a> or <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑥">device sensor</a>.</p>
    <h4 class="heading settled" data-level="7.1.2" id="sensor-garbage-collection"><span class="secno">7.1.2. </span><span class="content">Sensor garbage collection</span><a class="self-link" href="#sensor-garbage-collection"></a></h4>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot">[[state]]</a></code> is "activating" must not be garbage collected
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot">[[state]]</a></code> is "activating" must not be garbage collected
 if there are any event listeners registered for "activated" events, "reading" events,
 or "error" events.</p>
-   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①">[[state]]</a></code> is "activated" must not be garbage collected
+   <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①">[[state]]</a></code> is "activated" must not be garbage collected
 if there are any event listeners registered for "reading" events, or "error" events.</p>
-   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot②">[[state]]</a></code> is "activated" or "activating" is
+   <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot②">[[state]]</a></code> is "activated" or "activating" is
 eligible for garbage collection, the user agent must invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor
 object</a> with this object as argument.</p>
    <h4 class="heading settled" data-level="7.1.3" id="sensor-internal-slots"><span class="secno">7.1.3. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
-   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> are created
+   <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
    <p></p>
    <table class="vert data" id="sensor-slots">
@@ -2274,7 +2280,7 @@ with the internal slots described in the following table:</p>
     <tbody>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
-      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object which is one of
+      <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
@@ -2283,12 +2289,12 @@ with the internal slots described in the following table:</p>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
       <td>
        A double representing frequency in Hz that is used to calculate
-                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object. 
+                the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object. 
        <p>This slot holds the provided <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> value.
                 It is initially unset.</p>
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
-      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑧">Sensor</a></code> object,
+      <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⓪">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="http://w3c.github.io/hr-time/#time-origin" id="ref-for-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
@@ -2395,7 +2401,7 @@ to notify that new <a data-link-type="dfn" href="#sensor-readings" id="ref-for-s
 an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-type" id="ref-for-dfn-exception-type">exception</a> cannot be handled synchronously.</p>
    <h4 class="heading settled" data-level="7.1.12" id="event-handlers"><span class="secno">7.1.12. </span><span class="content">Event handlers</span><a class="self-link" href="#event-handlers"></a></h4>
    <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers①">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type①">event handler event types</a>)
-that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> interface:</p>
+that must be supported as attributes by the objects implementing the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> interface:</p>
    <table class="def">
     <thead>
      <tr>
@@ -2431,7 +2437,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code> object.</p>
      <dt data-md="">output
@@ -2445,7 +2451,7 @@ that must be supported as attributes by the objects implementing the <code class
        <li data-md="">
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
+      <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.2" data-lt="Check sensor policy-controlled features" id="check-sensor-policy-controlled-features"><span class="secno">8.2. </span><span class="content">Check sensor policy-controlled features</span><a class="self-link" href="#check-sensor-policy-controlled-features"></a></h3>
@@ -2453,7 +2459,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_type</var>, a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a>.</p>
+      <p><var>sensor_type</var>, a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor type</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>True if all of the associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names">sensor feature names</a> are <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a>,
@@ -2481,20 +2487,20 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a>,
+      <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a> of <var>sensor_instance</var>.</p>
+      <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a> of <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If the device has a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑦">device sensor</a> which can provide <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④③">readings</a> for <var>type</var>, then</p>
       <ol>
        <li data-md="">
-        <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a> corresponding
+        <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a> corresponding
   to this <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑧">device sensor</a>.</p>
        <li data-md="">
         <p>Return true.</p>
@@ -2506,7 +2512,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>If <var>type</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>, then</p>
         <ol>
          <li data-md="">
-          <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> corresponding
+          <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a> corresponding
   to <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑤">default sensor</a>.</p>
          <li data-md="">
           <p>Return true.</p>
@@ -2521,16 +2527,16 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects④">activated sensor objects</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑤">activated sensor objects</a>.</p>
      <li data-md="">
       <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings">set sensor settings</a> with <var>sensor</var> as argument.</p>
      <li data-md="">
@@ -2542,7 +2548,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2552,12 +2558,12 @@ that must be supported as attributes by the objects implementing the <code class
       <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task①">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue">task queue</a> associated
   with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑤">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> <var>sensor_instance</var>,</p>
+      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑥">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> <var>sensor_instance</var>,</p>
       <ol>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑥">activated sensor objects</a>.</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑦">activated sensor objects</a>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings①">set sensor settings</a> with <var>sensor</var> as argument.</p>
        <li data-md="">
@@ -2572,14 +2578,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑥">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑦">activated sensor objects</a>.</p>
+      <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑧">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑧">activated sensor objects</a>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>s</var> of <var>activated_sensors</var>,</p>
       <ol>
@@ -2597,14 +2603,14 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑧">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty④">is empty</a>,</p>
+      <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑨">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty④">is empty</a>,</p>
       <ol>
        <li data-md="">
         <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑦">requested sampling frequency</a> to null.</p>
@@ -2628,7 +2634,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
+      <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
      <dd data-md="">
       <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑦">sensor reading</a>.</p>
      <dt data-md="">output
@@ -2644,7 +2650,7 @@ that must be supported as attributes by the objects implementing the <code class
   value of <var>reading</var>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑦">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑨">activated sensor objects</a>.</p>
+      <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①⓪">activated sensor objects</a>.</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
       <ol>
@@ -2662,7 +2668,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
@@ -2677,7 +2683,7 @@ that must be supported as attributes by the objects implementing the <code class
         <p>if <var>f</var> is set,</p>
         <ol>
          <li data-md="">
-          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a>.</p>
+          <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
         </ol>
        <li data-md="">
         <p>Otherwise,</p>
@@ -2695,7 +2701,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2758,7 +2764,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2777,7 +2783,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
       <p>None</p>
@@ -2788,7 +2794,7 @@ that must be supported as attributes by the objects implementing the <code class
      <li data-md="">
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
       <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a>["timestamp"] is not null,</p>
       <ol>
@@ -2802,7 +2808,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>.</p>
      <dt data-md="">output
@@ -2821,7 +2827,7 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
      <dd data-md="">
       <p><var>key</var>, a string representing the name of the value.</p>
      <dt data-md="">output
@@ -2833,7 +2839,7 @@ that must be supported as attributes by the objects implementing the <code class
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①①">[[state]]</a></code> is "activated",</p>
       <ol>
        <li data-md="">
-        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①④">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a>.</p>
+        <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①④">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a>.</p>
        <li data-md="">
         <p>If the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification③">extension specification</a> defines a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>sensor_instance</var>,</p>
         <ol>
@@ -2852,16 +2858,16 @@ that must be supported as attributes by the objects implementing the <code class
     <dl>
      <dt data-md="">input
      <dd data-md="">
-      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③①">Sensor</a></code> object.</p>
+      <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-state" id="ref-for-permission-state">permission state</a>.</p>
+      <p>A <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-state" id="ref-for-permission-state①">permission state</a>.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a> associated with <var>sensor_instance</var>.</p>
+      <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a> associated with <var>sensor_instance</var>.</p>
      <li data-md="">
-      <p>Let <var>sensor_permissions</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑧">set</a> of <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names①">permission names</a>.</p>
+      <p>Let <var>sensor_permissions</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①⓪">set</a> of <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">permission names</a>.</p>
      <li data-md="">
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
       <ol>
@@ -2884,9 +2890,9 @@ that must be supported as attributes by the objects implementing the <code class
    </div>
    <h2 class="heading settled" data-level="9" id="extensibility"><span class="secno">9. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a>.</p>
+   <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor types</a>.</p>
    <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport="" id="extension-specification">extension specifications</dfn> are encouraged to focus on a
-single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
+single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
    <p>For an up-to-date list of <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification④">extension specifications</a>, please refer to <a data-link-type="biblio" href="#biblio-generic-sensor-usecases">[GENERIC-SENSOR-USECASES]</a> and <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> documents.</p>
    <h3 class="heading settled" data-level="9.1" id="extension-security-and-privacy"><span class="secno">9.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
@@ -2904,16 +2910,16 @@ on a case by case basis</a>,</p>
 by the same-origin policy.</p>
    </ul>
    <h3 class="heading settled" data-level="9.2" id="naming"><span class="secno">9.2. </span><span class="content">Naming</span><a class="self-link" href="#naming"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③②">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
-named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a>.
+   <p><code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑧">low-level</a> sensors should be
+named after their associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③④">platform sensor</a>.
 So for example, the interface associated with a gyroscope
-should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③③">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
-named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measures
+should be simply named <code>Gyroscope</code>. <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> interfaces for <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑧">high-level</a> sensors should be
+named by combining the physical quantity the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑤">platform sensor</a> measures
 with the "Sensor" suffix.
-For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> measuring
+For example, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑥">platform sensor</a> measuring
 the distance at which an object is from it
 may see its associated interface called <code>ProximitySensor</code>.</p>
-   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③④">Sensor</a></code> subclass that
+   <p>Attributes of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> subclass that
 hold <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings④⑨">sensor readings</a> values
 should be named after the full name of these values.
 For example, the <code>Thermometer</code> interface should hold
@@ -2961,42 +2967,42 @@ and design more performant systems.</p>
    <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a> should focus primarily on
 exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="9.5" id="multiple-sensors"><span class="secno">9.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
-   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑤">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③④">sensor type</a> with
+   <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> with
 equal construction parameters, as it can lead to unnecessary hardware resources consumption.</p>
-   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑥">Sensor</a></code> instance instead of
-creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
+   <p>In cases when multiple observers are interested in notifications of a newly available <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤②">sensor reading</a>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener①">event listener</a> can be added on a single <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensor</a></code> instance instead of
+creating multiple instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> and using simple <code class="idl"><a data-link-type="idl" href="#dom-sensor-onreading" id="ref-for-dom-sensor-onreading①">onreading</a></code> event
 handler.</p>
-   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑦">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> can be created when they
+   <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor type</a> can be created when they
 are intended to be used with different settings, such as: <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑨">requested sampling frequency</a>,
 accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a>.</p>
    <h3 class="heading settled" data-level="9.6" id="definition-reqs"><span class="secno">9.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">extension specifications</a>:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">extension specifications</a>:</p>
    <ul>
     <li data-md="">
-     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
+     <p>An <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces①">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code>.
   This interface must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.
   Its <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤③">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and
   their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①⓪">sensor fusion</a> (otherwise, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">PermissionNames</a></code> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor types</a> must be used).</p>
+     <p>A <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name③">permission name</a>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①⓪">sensor fusion</a> (otherwise, <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name④">permission names</a> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor types</a> must be used).</p>
    </ul>
    <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⓪">extension specification</a> may specify the following definitions
-for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor types</a>:</p>
+for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor types</a>:</p>
    <ul>
     <li data-md="">
      <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions③">SensorOptions</a></code>.</p>
     <li data-md="">
-     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑧">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">type</a>,
+     <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑦">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③⓪">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③⓪">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
   especially when doing so would not make sense.</p>
    </ul>
    <h3 class="heading settled" data-level="9.7" id="permission-api"><span class="secno">9.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑨">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">PermissionName</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
-A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">sensor</a></code> may use its interface name as a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑥">PermissionName</a></code>,
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">sensor type</a> must protect its <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤④">reading</a> by associated <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name⑤">permission name</a> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code>.
+A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://www.w3.org/TR/permissions#permission-name" id="ref-for-permission-name⑥">permission name</a>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①①">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
    <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑤">sensor readings</a> from
@@ -3014,17 +3020,17 @@ for accelerometer sensor is given below.</p>
 };
 </pre>
    <h3 class="heading settled" data-level="9.8" id="feature-policy-api"><span class="secno">9.8. </span><span class="content">Extending the Feature Policy API</span><a class="self-link" href="#feature-policy-api"></a></h3>
-   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④①">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">sensor type</a> has one
+   <p>An implementation of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑥">sensor type</a> has one
 (if <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①②">sensor fusion</a> is not performed) or several <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature③">policy-controlled features</a> that control whether or not this implementation can be used in a document.</p>
    <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature④">features</a>' <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist">default allowlist</a> is <code>["self"]</code>.</p>
-   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> interface
+   <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> of <code>["self"]</code> allows <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">Sensor</a></code> interface
 implementation usage in same-origin nested frames but prevents third-party content
 from <a data-link-type="dfn" href="#sensor-readings" id="ref-for-sensor-readings⑤⑥">sensor readings</a> access.</p>
-   <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
+   <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①①">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name①">feature names</a> of
 every associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑤">feature</a>.</p>
-   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
+   <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④④">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name" id="ref-for-feature-name②">feature name</a>,
 for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specification</a> tells
-otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">sensor permission names</a>.</p>
+otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑦">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names③">sensor permission names</a>.</p>
    <div class="example html" id="example-924ff346">
     <a class="self-link" href="#example-924ff346"></a> The accelerometer feature is selectively enabled for third-party origin by adding <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allow-attribute" id="ref-for-allow-attribute">allow attribute</a> to the frame container element: 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://third-party.com"</span> <span class="na">allow</span><span class="o">=</span><span class="s">"accelerometer"</span><span class="p">/>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
@@ -3160,7 +3166,7 @@ for their editorial input.</p>
     <a class="self-link" href="#example-f839f6c8"></a> 
     <p>This is an example of an informative example.</p>
    </div>
-   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑥">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
+   <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑧">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
     Although all of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③②">sensors</a> used a examples
     would be great candidates for building atop the Generic Sensor API,
     their inclusion in this document does not imply that the relevant Working Groups
@@ -3440,6 +3446,7 @@ for their editorial input.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">same origin-domain</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">spin the event loop</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
@@ -3475,8 +3482,9 @@ for their editorial input.</p>
      <li><a href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor">PermissionDescriptor</a>
      <li><a href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a>
      <li><a href="https://w3c.github.io/permissions/#new-information-about-the-users-intent">new information about the user's intent</a>
+     <li><a href="https://www.w3.org/TR/permissions#permission-name">permission name</a>
      <li><a href="https://w3c.github.io/permissions/#permission-revocation-algorithm">permission revocation algorithm</a>
-     <li><a href="https://w3c.github.io/permissions/#permission-state">permission state</a>
+     <li><a href="https://www.w3.org/TR/permissions#permission-state">permission state</a>
      <li><a href="https://w3c.github.io/permissions/#request-permission-to-use">request permission to use</a>
     </ul>
    <li>
@@ -3703,22 +3711,22 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor⑥">5.4. Reading change threshold</a>
     <li><a href="#ref-for-concept-platform-sensor⑦">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-concept-platform-sensor⑧">5.6. Conditions to expose sensor readings</a>
-    <li><a href="#ref-for-concept-platform-sensor⑨">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a> <a href="#ref-for-concept-platform-sensor①①">(3)</a> <a href="#ref-for-concept-platform-sensor①②">(4)</a> <a href="#ref-for-concept-platform-sensor①③">(5)</a> <a href="#ref-for-concept-platform-sensor①④">(6)</a> <a href="#ref-for-concept-platform-sensor①⑤">(7)</a> <a href="#ref-for-concept-platform-sensor①⑥">(8)</a> <a href="#ref-for-concept-platform-sensor①⑦">(9)</a>
-    <li><a href="#ref-for-concept-platform-sensor①⑧">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑨">(2)</a> <a href="#ref-for-concept-platform-sensor②⓪">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor②①">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-concept-platform-sensor②②">7.1.3. Sensor internal slots</a>
-    <li><a href="#ref-for-concept-platform-sensor②③">8.3. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②④">(2)</a> <a href="#ref-for-concept-platform-sensor②⑤">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑥">8.4. Activate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑦">8.5. Deactivate a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑧">8.6. Revoke sensor permission</a>
-    <li><a href="#ref-for-concept-platform-sensor②⑨">8.7. Set sensor settings</a>
-    <li><a href="#ref-for-concept-platform-sensor③⓪">8.8. Update latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③①">8.9. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-concept-platform-sensor③②">8.12. Notify activated state</a>
-    <li><a href="#ref-for-concept-platform-sensor③③">8.14. Get value from latest reading</a>
-    <li><a href="#ref-for-concept-platform-sensor③④">8.15. Request sensor access</a>
-    <li><a href="#ref-for-concept-platform-sensor③⑤">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑥">(2)</a> <a href="#ref-for-concept-platform-sensor③⑦">(3)</a>
-    <li><a href="#ref-for-concept-platform-sensor③⑧">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-concept-platform-sensor⑨">6.2. Sensor</a> <a href="#ref-for-concept-platform-sensor①⓪">(2)</a> <a href="#ref-for-concept-platform-sensor①①">(3)</a> <a href="#ref-for-concept-platform-sensor①②">(4)</a> <a href="#ref-for-concept-platform-sensor①③">(5)</a> <a href="#ref-for-concept-platform-sensor①④">(6)</a> <a href="#ref-for-concept-platform-sensor①⑤">(7)</a> <a href="#ref-for-concept-platform-sensor①⑥">(8)</a>
+    <li><a href="#ref-for-concept-platform-sensor①⑦">7.1. The Sensor Interface</a> <a href="#ref-for-concept-platform-sensor①⑧">(2)</a> <a href="#ref-for-concept-platform-sensor①⑨">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor②⓪">7.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-concept-platform-sensor②①">7.1.3. Sensor internal slots</a>
+    <li><a href="#ref-for-concept-platform-sensor②②">8.3. Connect to sensor</a> <a href="#ref-for-concept-platform-sensor②③">(2)</a> <a href="#ref-for-concept-platform-sensor②④">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑤">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑥">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑦">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑧">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-concept-platform-sensor②⑨">8.8. Update latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③⓪">8.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-concept-platform-sensor③①">8.12. Notify activated state</a>
+    <li><a href="#ref-for-concept-platform-sensor③②">8.14. Get value from latest reading</a>
+    <li><a href="#ref-for-concept-platform-sensor③③">8.15. Request sensor access</a>
+    <li><a href="#ref-for-concept-platform-sensor③④">9.2. Naming</a> <a href="#ref-for-concept-platform-sensor③⑤">(2)</a> <a href="#ref-for-concept-platform-sensor③⑥">(3)</a>
+    <li><a href="#ref-for-concept-platform-sensor③⑦">9.6. Definition Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-level">
@@ -3823,16 +3831,16 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-type⑥">5.2. Sensor Types</a> <a href="#ref-for-sensor-type⑦">(2)</a> <a href="#ref-for-sensor-type⑧">(3)</a> <a href="#ref-for-sensor-type⑨">(4)</a> <a href="#ref-for-sensor-type①⓪">(5)</a> <a href="#ref-for-sensor-type①①">(6)</a> <a href="#ref-for-sensor-type①②">(7)</a> <a href="#ref-for-sensor-type①③">(8)</a>
     <li><a href="#ref-for-sensor-type①④">5.3. Default sensor</a> <a href="#ref-for-sensor-type①⑤">(2)</a> <a href="#ref-for-sensor-type①⑥">(3)</a> <a href="#ref-for-sensor-type①⑦">(4)</a> <a href="#ref-for-sensor-type①⑧">(5)</a> <a href="#ref-for-sensor-type①⑨">(6)</a>
     <li><a href="#ref-for-sensor-type②⓪">5.5. Sampling Frequency and Reporting Frequency</a>
-    <li><a href="#ref-for-sensor-type②①">5.6. Conditions to expose sensor readings</a>
-    <li><a href="#ref-for-sensor-type②②">6.1. Sensor Type</a> <a href="#ref-for-sensor-type②③">(2)</a> <a href="#ref-for-sensor-type②④">(3)</a> <a href="#ref-for-sensor-type②⑤">(4)</a> <a href="#ref-for-sensor-type②⑥">(5)</a> <a href="#ref-for-sensor-type②⑦">(6)</a>
-    <li><a href="#ref-for-sensor-type②⑧">6.2. Sensor</a> <a href="#ref-for-sensor-type②⑨">(2)</a>
-    <li><a href="#ref-for-sensor-type③⓪">8.2. Check sensor policy-controlled features</a>
-    <li><a href="#ref-for-sensor-type③①">8.3. Connect to sensor</a>
-    <li><a href="#ref-for-sensor-type③②">9. Extensibility</a> <a href="#ref-for-sensor-type③③">(2)</a>
-    <li><a href="#ref-for-sensor-type③④">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor-type③⑤">(2)</a> <a href="#ref-for-sensor-type③⑥">(3)</a>
-    <li><a href="#ref-for-sensor-type③⑦">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type③⑧">(2)</a> <a href="#ref-for-sensor-type③⑨">(3)</a> <a href="#ref-for-sensor-type④⓪">(4)</a> <a href="#ref-for-sensor-type④①">(5)</a> <a href="#ref-for-sensor-type④②">(6)</a>
-    <li><a href="#ref-for-sensor-type④③">9.7. Extending the Permission API</a>
-    <li><a href="#ref-for-sensor-type④④">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-type④⑤">(2)</a>
+    <li><a href="#ref-for-sensor-type②①">5.6. Conditions to expose sensor readings</a> <a href="#ref-for-sensor-type②②">(2)</a> <a href="#ref-for-sensor-type②③">(3)</a>
+    <li><a href="#ref-for-sensor-type②④">6.1. Sensor Type</a> <a href="#ref-for-sensor-type②⑤">(2)</a> <a href="#ref-for-sensor-type②⑥">(3)</a> <a href="#ref-for-sensor-type②⑦">(4)</a> <a href="#ref-for-sensor-type②⑧">(5)</a> <a href="#ref-for-sensor-type②⑨">(6)</a>
+    <li><a href="#ref-for-sensor-type③⓪">6.2. Sensor</a> <a href="#ref-for-sensor-type③①">(2)</a>
+    <li><a href="#ref-for-sensor-type③②">8.2. Check sensor policy-controlled features</a>
+    <li><a href="#ref-for-sensor-type③③">8.3. Connect to sensor</a>
+    <li><a href="#ref-for-sensor-type③④">9. Extensibility</a> <a href="#ref-for-sensor-type③⑤">(2)</a>
+    <li><a href="#ref-for-sensor-type③⑥">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor-type③⑦">(2)</a> <a href="#ref-for-sensor-type③⑧">(3)</a>
+    <li><a href="#ref-for-sensor-type③⑨">9.6. Definition Requirements</a> <a href="#ref-for-sensor-type④⓪">(2)</a> <a href="#ref-for-sensor-type④①">(3)</a> <a href="#ref-for-sensor-type④②">(4)</a> <a href="#ref-for-sensor-type④③">(5)</a> <a href="#ref-for-sensor-type④④">(6)</a>
+    <li><a href="#ref-for-sensor-type④⑤">9.7. Extending the Permission API</a>
+    <li><a href="#ref-for-sensor-type④⑥">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor-type④⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="associated-sensors">
@@ -3844,9 +3852,10 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="sensor-permission-names">
    <b><a href="#sensor-permission-names">#sensor-permission-names</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sensor-permission-names">6.1. Sensor Type</a>
-    <li><a href="#ref-for-sensor-permission-names①">8.15. Request sensor access</a>
-    <li><a href="#ref-for-sensor-permission-names②">9.8. Extending the Feature Policy API</a>
+    <li><a href="#ref-for-sensor-permission-names">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-sensor-permission-names①">6.1. Sensor Type</a>
+    <li><a href="#ref-for-sensor-permission-names②">8.15. Request sensor access</a>
+    <li><a href="#ref-for-sensor-permission-names③">9.8. Extending the Feature Policy API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sensor-feature-names">
@@ -3859,12 +3868,12 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="activated-sensor-objects">
    <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-activated-sensor-objects">6.2. Sensor</a> <a href="#ref-for-activated-sensor-objects①">(2)</a> <a href="#ref-for-activated-sensor-objects②">(3)</a> <a href="#ref-for-activated-sensor-objects③">(4)</a>
-    <li><a href="#ref-for-activated-sensor-objects④">8.4. Activate a sensor object</a>
-    <li><a href="#ref-for-activated-sensor-objects⑤">8.5. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects⑥">(2)</a>
-    <li><a href="#ref-for-activated-sensor-objects⑦">8.6. Revoke sensor permission</a>
-    <li><a href="#ref-for-activated-sensor-objects⑧">8.7. Set sensor settings</a>
-    <li><a href="#ref-for-activated-sensor-objects⑨">8.8. Update latest reading</a>
+    <li><a href="#ref-for-activated-sensor-objects">6.2. Sensor</a> <a href="#ref-for-activated-sensor-objects①">(2)</a> <a href="#ref-for-activated-sensor-objects②">(3)</a> <a href="#ref-for-activated-sensor-objects③">(4)</a> <a href="#ref-for-activated-sensor-objects④">(5)</a>
+    <li><a href="#ref-for-activated-sensor-objects⑤">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-activated-sensor-objects⑥">8.5. Deactivate a sensor object</a> <a href="#ref-for-activated-sensor-objects⑦">(2)</a>
+    <li><a href="#ref-for-activated-sensor-objects⑧">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-activated-sensor-objects⑨">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-activated-sensor-objects①⓪">8.8. Update latest reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="latest-reading">
@@ -3893,29 +3902,30 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor①">5.1. Sensors</a>
     <li><a href="#ref-for-sensor②">5.3. Default sensor</a>
     <li><a href="#ref-for-sensor③">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-sensor④">(2)</a>
-    <li><a href="#ref-for-sensor⑤">6.1. Sensor Type</a>
-    <li><a href="#ref-for-sensor⑥">6.2. Sensor</a> <a href="#ref-for-sensor⑦">(2)</a> <a href="#ref-for-sensor⑧">(3)</a> <a href="#ref-for-sensor⑨">(4)</a>
-    <li><a href="#ref-for-sensor①⓪">7.1. The Sensor Interface</a>
-    <li><a href="#ref-for-sensor①①">7.1.1. Sensor lifecycle</a>
-    <li><a href="#ref-for-sensor①②">7.1.2. Sensor garbage collection</a> <a href="#ref-for-sensor①③">(2)</a> <a href="#ref-for-sensor①④">(3)</a>
-    <li><a href="#ref-for-sensor①⑤">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor①⑥">(2)</a> <a href="#ref-for-sensor①⑦">(3)</a> <a href="#ref-for-sensor①⑧">(4)</a>
-    <li><a href="#ref-for-sensor①⑨">7.1.12. Event handlers</a>
-    <li><a href="#ref-for-sensor②⓪">8.1. Initialize a sensor object</a> <a href="#ref-for-sensor②①">(2)</a>
-    <li><a href="#ref-for-sensor②②">8.3. Connect to sensor</a>
-    <li><a href="#ref-for-sensor②③">8.4. Activate a sensor object</a>
-    <li><a href="#ref-for-sensor②④">8.5. Deactivate a sensor object</a>
-    <li><a href="#ref-for-sensor②⑤">8.9. Find the reporting frequency of a sensor object</a>
-    <li><a href="#ref-for-sensor②⑥">8.10. Report latest reading updated</a>
-    <li><a href="#ref-for-sensor②⑦">8.11. Notify new reading</a>
-    <li><a href="#ref-for-sensor②⑧">8.12. Notify activated state</a>
-    <li><a href="#ref-for-sensor②⑨">8.13. Notify error</a>
-    <li><a href="#ref-for-sensor③⓪">8.14. Get value from latest reading</a>
-    <li><a href="#ref-for-sensor③①">8.15. Request sensor access</a>
-    <li><a href="#ref-for-sensor③②">9.2. Naming</a> <a href="#ref-for-sensor③③">(2)</a> <a href="#ref-for-sensor③④">(3)</a>
-    <li><a href="#ref-for-sensor③⑤">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑥">(2)</a> <a href="#ref-for-sensor③⑦">(3)</a>
-    <li><a href="#ref-for-sensor③⑧">9.6. Definition Requirements</a>
-    <li><a href="#ref-for-sensor③⑨">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④⓪">(2)</a>
-    <li><a href="#ref-for-sensor④①">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④②">(2)</a> <a href="#ref-for-sensor④③">(3)</a>
+    <li><a href="#ref-for-sensor⑤">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-sensor⑥">6.1. Sensor Type</a>
+    <li><a href="#ref-for-sensor⑦">6.2. Sensor</a> <a href="#ref-for-sensor⑧">(2)</a> <a href="#ref-for-sensor⑨">(3)</a> <a href="#ref-for-sensor①⓪">(4)</a>
+    <li><a href="#ref-for-sensor①①">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-sensor①②">7.1.1. Sensor lifecycle</a>
+    <li><a href="#ref-for-sensor①③">7.1.2. Sensor garbage collection</a> <a href="#ref-for-sensor①④">(2)</a> <a href="#ref-for-sensor①⑤">(3)</a>
+    <li><a href="#ref-for-sensor①⑥">7.1.3. Sensor internal slots</a> <a href="#ref-for-sensor①⑦">(2)</a> <a href="#ref-for-sensor①⑧">(3)</a> <a href="#ref-for-sensor①⑨">(4)</a>
+    <li><a href="#ref-for-sensor②⓪">7.1.12. Event handlers</a>
+    <li><a href="#ref-for-sensor②①">8.1. Initialize a sensor object</a> <a href="#ref-for-sensor②②">(2)</a>
+    <li><a href="#ref-for-sensor②③">8.3. Connect to sensor</a>
+    <li><a href="#ref-for-sensor②④">8.4. Activate a sensor object</a>
+    <li><a href="#ref-for-sensor②⑤">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-sensor②⑥">8.9. Find the reporting frequency of a sensor object</a>
+    <li><a href="#ref-for-sensor②⑦">8.10. Report latest reading updated</a>
+    <li><a href="#ref-for-sensor②⑧">8.11. Notify new reading</a>
+    <li><a href="#ref-for-sensor②⑨">8.12. Notify activated state</a>
+    <li><a href="#ref-for-sensor③⓪">8.13. Notify error</a>
+    <li><a href="#ref-for-sensor③①">8.14. Get value from latest reading</a>
+    <li><a href="#ref-for-sensor③②">8.15. Request sensor access</a>
+    <li><a href="#ref-for-sensor③③">9.2. Naming</a> <a href="#ref-for-sensor③④">(2)</a> <a href="#ref-for-sensor③⑤">(3)</a>
+    <li><a href="#ref-for-sensor③⑥">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a> <a href="#ref-for-sensor③⑦">(2)</a> <a href="#ref-for-sensor③⑧">(3)</a>
+    <li><a href="#ref-for-sensor③⑨">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-sensor④⓪">9.7. Extending the Permission API</a> <a href="#ref-for-sensor④①">(2)</a>
+    <li><a href="#ref-for-sensor④②">9.8. Extending the Feature Policy API</a> <a href="#ref-for-sensor④③">(2)</a> <a href="#ref-for-sensor④④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-sensor-activated">


### PR DESCRIPTION
This patch consolidates all the necessary conditions to
expose sensor readings to a single list at
https://w3c.github.io/sensors/#can-expose-sensor-readings
in order to make them more explicit and improve readability.

It also brings clarifications to the Sensor model description
and minor editorial changes (corrected references to the definitions
from the PERMISSIONS specification).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/sensors/pull/347.html" title="Last updated on Mar 1, 2018, 8:03 AM GMT (e955ea0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/347/84a49b3...pozdnyakov:e955ea0.html" title="Last updated on Mar 1, 2018, 8:03 AM GMT (e955ea0)">Diff</a>