### PR TITLE
Improve wording in the "Sensor garbage collection" session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1035,8 +1035,8 @@ A {{Sensor}} object whose {{[[state]]}} is "activated" must not be garbage colle
 if there are any event listeners registered for "reading" events, or "error" events.
 
 When a {{Sensor}} object whose {{[[state]]}} is "activated" or "activating" is
-eligible for garbage collection, the user agent must invoke [=deactivate a sensor
-object=] with this object as argument.
+garbage collected, the user agent must invoke [=deactivate a sensor object=]
+with this object as argument.
 
 ### Sensor internal slots ### {#sensor-internal-slots}
 

--- a/index.html
+++ b/index.html
@@ -993,57 +993,93 @@ Possible extra rowspan handling
 	.toc > li li          { font-weight: normal; }
 	.toc > li li li       { font-size:   95%;    }
 	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li .secno { font-size: 85%; }
 	.toc > li li li li li { font-size:   85%;    }
+	.toc > li li li li li .secno { font-size: 100%; }
 
-	.toc > li             { margin: 1.5rem 0;    }
-	.toc > li li          { margin: 0.3rem 0;    }
-	.toc > li li li       { margin-left: 2rem;   }
+	/* @supports not (display:grid) { */
+		.toc > li             { margin: 1.5rem 0;    }
+		.toc > li li          { margin: 0.3rem 0;    }
+		.toc > li li li       { margin-left: 2rem;   }
 
-	/* Section numbers in a column of their own */
-	.toc .secno {
-		float: left;
-		width: 4rem;
-		white-space: nowrap;
-	}
-	.toc > li li li li .secno {
-		font-size: 85%;
-	}
-	.toc > li li li li li .secno {
-		font-size: 100%;
-	}
+		/* Section numbers in a column of their own */
+		.toc .secno {
+			float: left;
+			width: 4rem;
+			white-space: nowrap;
+		}
 
-	:not(li) > .toc              { margin-left:  5rem; }
-	.toc .secno                  { margin-left: -5rem; }
-	.toc > li li li .secno       { margin-left: -7rem; }
-	.toc > li li li li .secno    { margin-left: -9rem; }
-	.toc > li li li li li .secno { margin-left: -11rem; }
+		.toc li {
+			clear: both;
+		}
 
-	/* Tighten up indentation in narrow ToCs */
-	@media (max-width: 30em) {
-		:not(li) > .toc              { margin-left:  4rem; }
-		.toc .secno                  { margin-left: -4rem; }
-		.toc > li li li              { margin-left:  1rem; }
-		.toc > li li li .secno       { margin-left: -5rem; }
-		.toc > li li li li .secno    { margin-left: -6rem; }
-		.toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
-		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
-		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
-		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
-		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
-		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
-	}
-	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
-	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
-	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
-	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
-	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+		:not(li) > .toc              { margin-left:  5rem; }
+		.toc .secno                  { margin-left: -5rem; }
+		.toc > li li li .secno       { margin-left: -7rem; }
+		.toc > li li li li .secno    { margin-left: -9rem; }
+		.toc > li li li li li .secno { margin-left: -11rem; }
 
-	.toc li {
-		clear: both;
+		/* Tighten up indentation in narrow ToCs */
+		@media (max-width: 30em) {
+			:not(li) > .toc              { margin-left:  4rem; }
+			.toc .secno                  { margin-left: -4rem; }
+			.toc > li li li              { margin-left:  1rem; }
+			.toc > li li li .secno       { margin-left: -5rem; }
+			.toc > li li li li .secno    { margin-left: -6rem; }
+			.toc > li li li li li .secno { margin-left: -7rem; }
+		}
+	/* } */
+
+	@supports (display:grid) {
+		/* Use #toc over .toc to override non-@supports rules. */
+		#toc {
+			display: grid;
+			align-content: start;
+			grid-template-columns: auto 1fr;
+			grid-column-gap: 1rem;
+			column-gap: 1rem;
+			grid-row-gap: .6rem;
+			row-gap: .6rem;
+		}
+		#toc h2 {
+			grid-column: 1 / -1;
+			margin-bottom: 0;
+		}
+		#toc ol,
+		#toc li,
+		#toc a {
+			display: contents;
+			/* Switch <a> to subgrid when supported */
+		}
+		#toc span {
+			margin: 0;
+		}
+		#toc > .toc > li > a > span {
+			/* The spans of the top-level list,
+			   comprising the first items of each top-level section. */
+			margin-top: 1.1rem;
+		}
+		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
+			grid-column: 1;
+			width: auto;
+			margin-left: 0;
+		}
+		#toc .content {
+			grid-column: 2;
+			width: auto;
+			margin-right: 1rem;
+		}
+		#toc .content:hover {
+			background: rgba(75%, 75%, 75%, .25);
+			border-bottom: 3px solid #054572;
+			margin-bottom: -3px;
+		}
+		#toc li li li .content {
+			margin-left: 1rem;
+		}
+		#toc li li li li .content {
+			margin-left: 2rem;
+		}
 	}
 
 
@@ -1183,7 +1219,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 1a927b7d2ff9a70dcdc5dc9f892fd154b7b64097" name="generator">
+  <meta content="Bikeshed version ab6bd5034a8c7446535677e7ab0c5afae7810c3b" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
 <style>
     svg g.edge text {
@@ -1292,6 +1328,17 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1356,104 +1403,104 @@ pre .property::before, pre .property::after {
 }</style>
 <style>/* style-dfn-panel */
 
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
 
-        .dfn-paneled { cursor: pointer; }
-        </style>
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-15">15 March 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-25">25 September 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1463,7 +1510,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/2017/WD-generic-sensor-20171018/" rel="prev">https://www.w3.org/TR/2017/WD-generic-sensor-20171018/</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-device-apis@w3.org?subject=%5Bgeneric-sensor%5D%20YOUR%20TOPIC%20HERE">public-device-apis@w3.org</a> with subject line “<kbd>[generic-sensor] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-device-apis/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-device-apis@w3.org?subject=%5Bgeneric-sensor%5D%20YOUR%20TOPIC%20HERE">public-device-apis@w3.org</a> with subject line “<kbd>[generic-sensor] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-device-apis/" rel="discussion">archives</a>)</span>
      <dd><a href="https://github.com/w3c/sensors">GitHub</a> (<a href="https://github.com/w3c/sensors/issues/new">new issue</a>, <a href="https://github.com/w3c/sensors/milestone/2">level 1 issues</a>, <a href="https://github.com/w3c/sensors/issues">all issues</a>)
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="50572"><span class="p-name fn">Rick Waldron</span> (<span class="p-org org">Bocoup, formerly on behalf of JS Foundation</span>)
@@ -1500,7 +1547,7 @@ that can be extended to accommodate different sensor types.</p>
 	preferably like this:
 	“[generic-sensor] <em>…summary of comment…</em>”.
 	All comments are welcome. </p>
-   <p> This document was produced by the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a>. </p>
+   <p> This document was produced by the <a href="https://www.w3.org/das/">Devices and Sensors Working Group</a>. </p>
    <p> This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
@@ -1690,23 +1737,23 @@ Resources on the topic are plentiful on and offline and
 the purpose of this section is not to discuss it further,
 but rather to put it in the context of detecting hardware-dependent features.</p>
    <p>Consider the below feature detection examples:</p>
-   <div class="example" id="example-b9d49fa6">
-    <a class="self-link" href="#example-b9d49fa6"></a> This simple example illustrates how to check whether the User Agent
+   <div class="example" id="example-250d1979">
+    <a class="self-link" href="#example-250d1979"></a> This simple example illustrates how to check whether the User Agent
     exposes an interface for a particular sensor type. To handle errors in a robust
     manner, please refer to <a href="#robust-example">this example</a>. 
-<pre class="highlight"><span class="k">if</span> <span class="p">(</span><span class="k">typeof</span> Gyroscope <span class="o">===</span> <span class="s2">"function"</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// run in circles...</span>
-<span class="c1"></span><span class="p">}</span>
+<pre class="highlight"><c- k>if</c-> <c- p>(</c-><c- k>typeof</c-> Gyroscope <c- o>===</c-> <c- u>"function"</c-><c- p>)</c-> <c- p>{</c->
+    <c- c1>// run in circles...</c->
+<c- p>}</c->
 
-<span class="k">if</span> <span class="p">(</span><span class="s2">"ProximitySensor"</span> <span class="k">in</span> window<span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// watch out!</span>
-<span class="c1"></span><span class="p">}</span>
+<c- k>if</c-> <c- p>(</c-><c- u>"ProximitySensor"</c-> <c- k>in</c-> window<c- p>)</c-> <c- p>{</c->
+    <c- c1>// watch out!</c->
+<c- p>}</c->
 
-<span class="k">if</span> <span class="p">(</span>window<span class="p">.</span>AmbientLightSensor<span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// go dark...</span>
-<span class="c1"></span><span class="p">}</span>
+<c- k>if</c-> <c- p>(</c->window<c- p>.</c->AmbientLightSensor<c- p>)</c-> <c- p>{</c->
+    <c- c1>// go dark...</c->
+<c- p>}</c->
 
-<span class="c1">// etc.</span>
+<c- c1>// etc.</c->
 </pre>
    </div>
    <p>All of these tell you something about the presence
@@ -1731,11 +1778,11 @@ etc.</p>
 which checks whether an API for the sought-after sensor actually exists,
 and defensive programming which includes:</p>
    <ol>
-    <li data-md="">
+    <li data-md>
      <p>checking for error thrown when instantiating a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor">Sensor</a></code> object,</p>
-    <li data-md="">
+    <li data-md>
      <p>listening to errors emitted by it,</p>
-    <li data-md="">
+    <li data-md>
      <p>handling all of the above graciously so that the user’s experience is
   enhanced by the possible usage of a sensor, not degraded by its
   absence.</p>
@@ -1745,29 +1792,29 @@ and defensive programming which includes:</p>
     in a robust manner. Web application may choose different options for error
     handling, for example, show notification, choose different sensor type or
     fallback to other API. 
-<pre class="highlight"><span class="kd">let</span> accelerometer <span class="o">=</span> <span class="kc">null</span><span class="p">;</span>
-<span class="k">try</span> <span class="p">{</span>
-    accelerometer <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span> frequency<span class="o">:</span> <span class="mi">10</span> <span class="p">});</span>
-    accelerometer<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'error'</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
-        <span class="c1">// Handle runtime errors.</span>
-<span class="c1"></span>        <span class="k">if</span> <span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name <span class="o">===</span> <span class="s1">'NotAllowedError'</span><span class="p">)</span> <span class="p">{</span>
-            console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Permission to access sensor was denied.'</span><span class="p">);</span>
-        <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name <span class="o">===</span> <span class="s1">'NotReadableError'</span> <span class="p">)</span> <span class="p">{</span>
-            console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Cannot connect to the sensor.'</span><span class="p">);</span>
-        <span class="p">}</span>
-    <span class="p">});</span>
-    accelerometer<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'reading'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> reloadOnShake<span class="p">(</span>accelerometer<span class="p">));</span>
-    accelerometer<span class="p">.</span>start<span class="p">();</span>
-<span class="p">}</span> <span class="k">catch</span> <span class="p">(</span>error<span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// Handle construction errors.</span>
-<span class="c1"></span>    <span class="k">if</span> <span class="p">(</span>error<span class="p">.</span>name <span class="o">===</span> <span class="s1">'SecurityError'</span><span class="p">)</span> <span class="p">{</span>
-        console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Sensor construction was blocked by the Feature Policy.'</span><span class="p">);</span>
-    <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span>error<span class="p">.</span>name <span class="o">===</span> <span class="s1">'ReferenceError'</span><span class="p">)</span> <span class="p">{</span>
-        console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Sensor is not supported by the User Agent.'</span><span class="p">);</span>
-    <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-        <span class="k">throw</span> error<span class="p">;</span>
-    <span class="p">}</span>
-<span class="p">}</span>
+<pre class="highlight"><c- a>let</c-> accelerometer <c- o>=</c-> <c- kc>null</c-><c- p>;</c->
+<c- k>try</c-> <c- p>{</c->
+    accelerometer <c- o>=</c-> <c- k>new</c-> Accelerometer<c- p>({</c-> frequency<c- o>:</c-> <c- mi>10</c-> <c- p>});</c->
+    accelerometer<c- p>.</c->addEventListener<c- p>(</c-><c- t>'error'</c-><c- p>,</c-> event <c- p>=></c-> <c- p>{</c->
+        <c- c1>// Handle runtime errors.</c->
+        <c- k>if</c-> <c- p>(</c->event<c- p>.</c->error<c- p>.</c->name <c- o>===</c-> <c- t>'NotAllowedError'</c-><c- p>)</c-> <c- p>{</c->
+            console<c- p>.</c->log<c- p>(</c-><c- t>'Permission to access sensor was denied.'</c-><c- p>);</c->
+        <c- p>}</c-> <c- k>else</c-> <c- k>if</c-> <c- p>(</c->event<c- p>.</c->error<c- p>.</c->name <c- o>===</c-> <c- t>'NotReadableError'</c-> <c- p>)</c-> <c- p>{</c->
+            console<c- p>.</c->log<c- p>(</c-><c- t>'Cannot connect to the sensor.'</c-><c- p>);</c->
+        <c- p>}</c->
+    <c- p>});</c->
+    accelerometer<c- p>.</c->addEventListener<c- p>(</c-><c- t>'reading'</c-><c- p>,</c-> <c- p>()</c-> <c- p>=></c-> reloadOnShake<c- p>(</c->accelerometer<c- p>));</c->
+    accelerometer<c- p>.</c->start<c- p>();</c->
+<c- p>}</c-> <c- k>catch</c-> <c- p>(</c->error<c- p>)</c-> <c- p>{</c->
+    <c- c1>// Handle construction errors.</c->
+    <c- k>if</c-> <c- p>(</c->error<c- p>.</c->name <c- o>===</c-> <c- t>'SecurityError'</c-><c- p>)</c-> <c- p>{</c->
+        console<c- p>.</c->log<c- p>(</c-><c- t>'Sensor construction was blocked by the Feature Policy.'</c-><c- p>);</c->
+    <c- p>}</c-> <c- k>else</c-> <c- k>if</c-> <c- p>(</c->error<c- p>.</c->name <c- o>===</c-> <c- t>'ReferenceError'</c-><c- p>)</c-> <c- p>{</c->
+        console<c- p>.</c->log<c- p>(</c-><c- t>'Sensor is not supported by the User Agent.'</c-><c- p>);</c->
+    <c- p>}</c-> <c- k>else</c-> <c- p>{</c->
+        <c- k>throw</c-> error<c- p>;</c->
+    <c- p>}</c->
+<c- p>}</c->
 </pre>
    </div>
    <h2 class="heading settled" data-level="4" id="security-and-privacy"><span class="secno">4. </span><span class="content">Security and privacy considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
@@ -1882,7 +1929,7 @@ they might also hinder or altogether prevent certain use cases.</p>
 for example when the user is carrying out specific actions,
 when other APIs which are known to amplify the level of the threat are in use,
 etc.</p>
-   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="4.3.1" data-lt="Limit maximum sampling frequency" data-noexport="" id="limit-max-frequency"><span class="secno">4.3.1. </span><span class="content">Limit maximum sampling frequency</span></h4>
+   <h4 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="4.3.1" data-lt="Limit maximum sampling frequency" data-noexport id="limit-max-frequency"><span class="secno">4.3.1. </span><span class="content">Limit maximum sampling frequency</span></h4>
    <p>User agents may mitigate certain threats by
 limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency">sampling frequency</a>.
 What upper limit to choose depends on the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③">sensor type</a>,
@@ -1890,13 +1937,13 @@ the kind of threats the user agent is trying to protect against,
 the expected resources of the attacker, etc.</p>
    <p>Limiting the maximum <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①">sampling frequency</a> prevents use cases
 which rely on low latency or high data density.</p>
-   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.2" data-lt="Stop the sensor altogether" data-noexport="" id="stop-sensor"><span class="secno">4.3.2. </span><span class="content">Stop the sensor altogether</span><a class="self-link" href="#stop-sensor"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.2" data-lt="Stop the sensor altogether" data-noexport id="stop-sensor"><span class="secno">4.3.2. </span><span class="content">Stop the sensor altogether</span><a class="self-link" href="#stop-sensor"></a></h4>
    <p>This is obviously a last-resort solution,
 but it can be extremely effective if it’s temporal,
 for example to prevent password skimming attempts
 when the user is entering credentials on a different origin (<a data-link-type="biblio" href="#biblio-rfc6454">[rfc6454]</a>)
 or in a different application.</p>
-   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.3" data-lt="Limit number of delivered readings" data-noexport="" id="limit-number-of-delivered-readings"><span class="secno">4.3.3. </span><span class="content">Limit number of delivered readings</span><a class="self-link" href="#limit-number-of-delivered-readings"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.3" data-lt="Limit number of delivered readings" data-noexport id="limit-number-of-delivered-readings"><span class="secno">4.3.3. </span><span class="content">Limit number of delivered readings</span><a class="self-link" href="#limit-number-of-delivered-readings"></a></h4>
    <p>An alternative to <a data-link-type="dfn" href="#limit-max-frequency" id="ref-for-limit-max-frequency">limiting the maximum sampling frequency</a> is to
 limit the number of <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①③">sensor readings</a> delivered to Web application developer,
 regardless of what frequency the sensor is polled at.
@@ -1904,7 +1951,7 @@ This allows use cases which have low latency requirement
 to increase <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency②">sampling frequency</a> without increasing the amount of data provided.</p>
    <p>Discarding intermediary readings prevents certain use cases,
 such as those relying on certain kinds of filters.</p>
-   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.4" data-lt="Reduce accuracy" data-noexport="" id="reduce-accuracy"><span class="secno">4.3.4. </span><span class="content">Reduce accuracy</span><a class="self-link" href="#reduce-accuracy"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.3.4" data-lt="Reduce accuracy" data-noexport id="reduce-accuracy"><span class="secno">4.3.4. </span><span class="content">Reduce accuracy</span><a class="self-link" href="#reduce-accuracy"></a></h4>
    <p>Reducing the accuracy of <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①④">sensor readings</a> or sensor <a data-link-type="dfn" href="#reading-timestamp" id="ref-for-reading-timestamp">reading timestamps</a> might also help mitigate certain threats,
 thus user agents should not provide
 unnecessarily verbose readouts of sensors data.</p>
@@ -1919,18 +1966,18 @@ about current and past use of the API.</p>
    <p class="note" role="note"><span>Note:</span> this does not imply keeping a log of the actual <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①⑦">sensor readings</a> which would have issues of its own.</p>
    <h2 class="heading settled" data-level="5" id="concepts"><span class="secno">5. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="concepts-sensors"><span class="secno">5.1. </span><span class="content">Sensors</span><a class="self-link" href="#concepts-sensors"></a></h3>
-   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-device-sensor">device sensor</dfn> refers to a device’s underlying
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="concept-device-sensor">device sensor</dfn> refers to a device’s underlying
 physical sensor instance.</p>
    <p>A <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑤">device sensor</a> measures a physical quantities
-and provides a corresponding <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-reading">sensor reading</dfn> which is a source of information about the environment.</p>
-   <p>Each <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①⑧">sensor reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport="" id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the physical quantity measured by the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑥">device sensor</a> at time <var>t<sub>n</sub></var> which is called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reading-timestamp">reading timestamp</dfn>.</p>
+and provides a corresponding <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sensor-reading">sensor reading</dfn> which is a source of information about the environment.</p>
+   <p>Each <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①⑧">sensor reading</a> is composed of the <dfn data-dfn-type="dfn" data-lt="reading value" data-noexport id="reading-value">values<a class="self-link" href="#reading-value"></a></dfn> of the physical quantity measured by the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑥">device sensor</a> at time <var>t<sub>n</sub></var> which is called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="reading-timestamp">reading timestamp</dfn>.</p>
    <p>If the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑦">device sensor</a> performs a spatial measurement (e.g.
 acceleration, angular velocity), it must be resolved in
-a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="local-coordinate-system">local coordinate system</dfn> that represents
+a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="local-coordinate-system">local coordinate system</dfn> that represents
 a reference frame for the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑧">device sensor</a>'s <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading①⑨">sensor readings</a>.
-A <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑨">device sensor</a> that provides such <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⓪">sensor readings</a> is referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="spatial-sensor">spatial sensor</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#spatial-sensor" id="ref-for-spatial-sensor">spatial sensor</a> can be <dfn data-dfn-type="dfn" data-noexport="" id="uniaxial">uniaxial<a class="self-link" href="#uniaxial"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="biaxial">biaxial<a class="self-link" href="#biaxial"></a></dfn>,
-or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="triaxial">triaxial</dfn>, depending on the number of orthogonal axes in
+A <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor⑨">device sensor</a> that provides such <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⓪">sensor readings</a> is referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="spatial-sensor">spatial sensor</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#spatial-sensor" id="ref-for-spatial-sensor">spatial sensor</a> can be <dfn data-dfn-type="dfn" data-noexport id="uniaxial">uniaxial<a class="self-link" href="#uniaxial"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport id="biaxial">biaxial<a class="self-link" href="#biaxial"></a></dfn>,
+or <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="triaxial">triaxial</dfn>, depending on the number of orthogonal axes in
 which it can perform simultaneous measurements.</p>
    <p>Scalar physical quantities (i.e. temperature) do not require
 a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> for resolution.</p>
@@ -1938,18 +1985,18 @@ a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coor
 a Cartesian coordinate system, which is defined relative to the
 device’s screen, so that X and Y axes are parallel to the screen
 dimentions and Z axis is perpendicular to the screen surface.</p>
-   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-platform-sensor">platform sensor</dfn> refers to platform interfaces,
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="concept-platform-sensor">platform sensor</dfn> refers to platform interfaces,
 with which the user agent interacts to obtain <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②①">sensor readings</a> for a single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④">sensor type</a> originated from one or more <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⓪">device sensors</a>.</p>
    <p><a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor">Platform sensor</a> can be defined by the underlying platform (e.g. in a native sensors framework)
 or by the user agent, if it has a direct access to <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①①">device sensor</a>.</p>
    <p>From the implementation perspective <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①">platform sensor</a> can be treated as a software proxy for the
 corresponding <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①②">device sensor</a>. It is possible to have multiple <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②">platform sensors</a> simultaneously
 interacting with the same <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①③">device sensor</a> if the underlying platform suppports it.</p>
-   <p>In simple case a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③">platform sensor</a> corresponds to a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①④">device sensor</a>,
-but if the provided <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②②">sensor readings</a> are product of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion">sensor fusion</a> performed
+   <p>In simple cases, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③">platform sensor</a> corresponds to a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①④">device sensor</a>,
+but if the provided <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②②">sensor readings</a> are a product of <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion">sensor fusion</a> performed
 in software, the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor④">platform sensor</a> corresponds to a set of <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑤">device sensors</a> involved in the <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①">sensor fusion</a> process.</p>
    <p>Discrepancies between a <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②③">sensor reading</a> and the corresponding physical quantity being measured
-are corrected through <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="calibration">calibration</dfn> that can happen at manufacturing time.
+are corrected through <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="calibration">calibration</dfn> that can happen at manufacturing time.
 Some sensors can require dynamic calibration to compensate unknown discrepancies.</p>
    <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑤">platform sensors</a> created through <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion②">sensor fusion</a> are sometimes
 called virtual or synthetic sensors. However, the specification doesn’t
@@ -1959,11 +2006,11 @@ make any practical distinction between them.</p>
 such as temperature, air pressure, heart-rate, or luminosity.</p>
    <p>For the purpose of this specification we distinguish between <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑥">sensor types</a>.</p>
    <p><a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑦">Sensor types</a> which are characterized by their implementation
-are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="low-level">low-level</dfn> sensors.
+are referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="low-level">low-level</dfn> sensors.
 For example a Gyroscope is a <a data-link-type="dfn" href="#low-level" id="ref-for-low-level②">low-level</a> <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type⑧">sensor type</a>.</p>
    <p>Sensors named after their <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②④">readings</a>,
 regardless of the implementation,
-are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-level">high-level</dfn> sensors.
+are said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="high-level">high-level</dfn> sensors.
 For instance, geolocation sensors provide information about the user’s location,
 but the precise means by which this data is obtained
 is purposefully left opaque
@@ -1985,13 +2032,13 @@ extensions to this specification (see <a href="#extensibility">§9 Extensibility
 are encouraged to provide domain-specific definitions of <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑤">high-level</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑥">low-level</a> sensors
 for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①①">sensor types</a> they are targeting.</p>
    <p><a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⑤">Sensor readings</a> from different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①②">sensor types</a> can be combined together
-through a process called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-fusion">sensor fusion</dfn>.
+through a process called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sensor-fusion">sensor fusion</dfn>.
 This process provides <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑥">higher-level</a> or
 more accurate data (often at the cost of increased latency).
 For example, the <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⑥">readings</a> of a <a data-link-type="dfn" href="#triaxial" id="ref-for-triaxial">triaxial</a> magnetometer
 needs to be combined with the <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⑦">readings</a> of an accelerometer
 to provide a correct bearing.</p>
-   <p><dfn data-dfn-type="dfn" data-noexport="" id="smart-sensors">Smart sensors<a class="self-link" href="#smart-sensors"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport="" id="sensor-hubs">sensor hubs<a class="self-link" href="#sensor-hubs"></a></dfn> have built-in compute resources which allow them
+   <p><dfn data-dfn-type="dfn" data-noexport id="smart-sensors">Smart sensors<a class="self-link" href="#smart-sensors"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport id="sensor-hubs">sensor hubs<a class="self-link" href="#sensor-hubs"></a></dfn> have built-in compute resources which allow them
 to carry out <a data-link-type="dfn" href="#calibration" id="ref-for-calibration">calibration</a> and <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑤">sensor fusion</a> at the hardware level,
 freeing up CPU resources and lowering battery consumption in the process.</p>
    <p><a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑥">Sensor fusion</a> can also be carried out in software if it cannot be
@@ -2005,18 +2052,18 @@ and generally limited to specific <a data-link-type="dfn" href="#sensor-type" id
 such as multiple accelerometers in 2-in-1 laptops.</p>
    <p>The API therefore makes it easy to interact with
 the device’s default (and often unique) <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑧">sensor</a> for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑤">type</a> simply by instantiating the corresponding <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①">Sensor</a></code> subclass.</p>
-   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">type</a>, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-sensor">default sensor</dfn> is chosen by the
+   <p>Indeed, without specific information identifying a particular <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor①⑨">sensor</a> of a given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑥">type</a>, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="default-sensor">default sensor</dfn> is chosen by the
 user agent.</p>
    <p>If the underlying platform provides an interface to find the <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor">default sensor</a>,
 the user agent must choose the sensor offered by the platform, otherwise the user agent
 itself defines which of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⓪">sensors</a> present on the device is
 the <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor①">default sensor</a>.</p>
-   <div class="example" id="example-bd37b819">
-    <a class="self-link" href="#example-bd37b819"></a> Listening to the default accelerometer changes: 
-<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span> frequency<span class="o">:</span> <span class="mi">30</span> <span class="p">});</span>
+   <div class="example" id="example-6532f9b9">
+    <a class="self-link" href="#example-6532f9b9"></a> Listening to the default accelerometer changes: 
+<pre class="highlight"><c- a>let</c-> sensor <c- o>=</c-> <c- k>new</c-> Accelerometer<c- p>({</c-> frequency<c- o>:</c-> <c- mi>30</c-> <c- p>});</c->
 
-sensor<span class="p">.</span>onreading <span class="o">=</span> <span class="p">()</span> <span class="p">=></span> <span class="p">{</span> <span class="p">...</span> <span class="p">}</span>
-sensor<span class="p">.</span>start<span class="p">();</span>
+sensor<c- p>.</c->onreading <c- o>=</c-> <c- p>()</c-> <c- p>=></c-> <c- p>{</c-> <c- p>...</c-> <c- p>}</c->
+sensor<c- p>.</c->start<c- p>();</c->
 </pre>
    </div>
    <p class="note" role="note"><span>Note:</span> extension to this specification may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor②">default sensor</a> when doing so wouldn’t make sense.
@@ -2026,88 +2073,88 @@ implementation of its interface can use multiple backends.</p>
 multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②②">device sensors</a> corresponding to the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑧">type</a> may coexist on the same device,
 specification extension will have to
 define ways to uniquely identify each one.</p>
-   <div class="example" id="example-fdd94e11">
-    <a class="self-link" href="#example-fdd94e11"></a> For example checking the pressure of the left rear tire: 
-<pre class="highlight"><span class="kd">var</span> sensor <span class="o">=</span> <span class="k">new</span> DirectTirePressureSensor<span class="p">({</span> position<span class="o">:</span> <span class="s2">"rear"</span><span class="p">,</span> side<span class="o">:</span> <span class="s2">"left"</span> <span class="p">});</span>
-sensor<span class="p">.</span>onreading <span class="o">=</span> _ <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>sensor<span class="p">.</span>pressure<span class="p">);</span>
-sensor<span class="p">.</span>start<span class="p">();</span>
+   <div class="example" id="example-a71cf25b">
+    <a class="self-link" href="#example-a71cf25b"></a> For example checking the pressure of the left rear tire: 
+<pre class="highlight"><c- a>var</c-> sensor <c- o>=</c-> <c- k>new</c-> DirectTirePressureSensor<c- p>({</c-> position<c- o>:</c-> <c- u>"rear"</c-><c- p>,</c-> side<c- o>:</c-> <c- u>"left"</c-> <c- p>});</c->
+sensor<c- p>.</c->onreading <c- o>=</c-> _ <c- p>=></c-> console<c- p>.</c->log<c- p>(</c->sensor<c- p>.</c->pressure<c- p>);</c->
+sensor<c- p>.</c->start<c- p>();</c->
 </pre>
    </div>
    <h3 class="heading settled" data-level="5.4" id="concepts-reading-change-threshold"><span class="secno">5.4. </span><span class="content">Reading change threshold</span><a class="self-link" href="#concepts-reading-change-threshold"></a></h3>
    <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑥">platform sensor</a> reports <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading②⑨">readings</a> to the user agent considering
 the <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold">reading change threshold</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reading-change-threshold">reading change threshold</dfn> refers to a value which indicates whether or
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="reading-change-threshold">reading change threshold</dfn> refers to a value which indicates whether or
 not the changes in the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②③">device sensor</a>'s measurements were significant enough to
 update the corresponding <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⓪">sensor readings</a>.</p>
    <p>The <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold①">threshold</a> value depends on the surrounding software and hardware
 environment constraints, e.g., software power consumption optimizations or the underlying <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②④">device sensor</a>'s accuracy.</p>
    <h3 class="heading settled" data-level="5.5" id="concepts-sampling-and-reporting-frequencies"><span class="secno">5.5. </span><span class="content">Sampling Frequency and Reporting Frequency</span><a class="self-link" href="#concepts-sampling-and-reporting-frequencies"></a></h3>
-   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑦">platform sensor</a> is
+   <p>For the purpose of this specification, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sampling-frequency">sampling frequency</dfn> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑦">platform sensor</a> is
 defined as a frequency at which the user agent obtains <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③①">sensor readings</a> from the underlying
 platform.</p>
    <p>The user agent can request the underlying platform to deliver <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③②">readings</a> at a certain
-rate which is called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="requested-sampling-frequency">requested sampling frequency</dfn>.</p>
+rate which is called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="requested-sampling-frequency">requested sampling frequency</dfn>.</p>
    <p>The <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency③">sampling frequency</a> is equal to the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency">requested sampling frequency</a> if the underlying platform
 can support it.</p>
    <p>The <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency④">sampling frequency</a> differs from the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency①">requested sampling frequency</a> in the following cases:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p>the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency②">requested sampling frequency</a> exceeds upper or lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑤">sampling frequency</a> bounds
  supported by the underlying platform.</p>
-    <li data-md="">
+    <li data-md>
      <p>the <a data-link-type="dfn" href="#reading-change-threshold" id="ref-for-reading-change-threshold②">threshold</a> value is significant so that some of the <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑤">device sensor</a>'s measurements are skipped and the <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③③">sensor readings</a> are not updated.</p>
    </ul>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reporting-frequency">reporting frequency</dfn> for a concrete <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②">Sensor</a></code> object is defined as a frequency at which
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="reporting-frequency">reporting frequency</dfn> for a concrete <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②">Sensor</a></code> object is defined as a frequency at which
 the "reading" event is <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">fired</a> at this object.</p>
    <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③">Sensor</a></code> object cannot access new <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③④">readings</a> at a higher rate than the
 user agent obtains them from the underlying platform, therefore the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency">reporting frequency</a> can
 never exceed the <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑥">sampling frequency</a> for the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type①⑨">sensor type</a>.</p>
    <h3 class="heading settled" data-level="5.6" id="concepts-can-expose-sensor-readings"><span class="secno">5.6. </span><span class="content">Conditions to expose sensor readings</span><a class="self-link" href="#concepts-can-expose-sensor-readings"></a></h3>
-   <p>The user agent must verify that all <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions">mandatory conditions</a> are satisfied to ensure it <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="can-expose-sensor-readings">can expose sensor readings</dfn> to the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④">Sensor</a></code> objects of a certain <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">type</a> that belong to a certain <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mandatory-conditions">mandatory conditions</dfn> are the following:</p>
+   <p>The user agent must verify that all <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions">mandatory conditions</a> are satisfied to ensure it <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="can-expose-sensor-readings">can expose sensor readings</dfn> to the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④">Sensor</a></code> objects of a certain <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⓪">type</a> that belong to a certain <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mandatory-conditions">mandatory conditions</dfn> are the following:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p>The given document is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document">responsible document</a> of a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts①">secure context</a>.</p>
-    <li data-md="">
+    <li data-md>
      <p>For each <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname">permission name</a> from the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②①">sensor type</a>'s associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a>, the corresponding permission’s <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#permission-state" id="ref-for-permission-state">state</a> is "granted".</p>
-    <li data-md="">
+    <li data-md>
      <p><a data-link-type="dfn" href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate" id="ref-for-dom-visibilitystate">Visibility state</a> of the document is "visible".</p>
-    <li data-md="">
+    <li data-md>
      <p>The document is <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> all the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature①">policy-controlled features</a> associated
  with the given <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②②">sensor type</a>.</p>
-    <li data-md="">
+    <li data-md>
      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context" id="ref-for-currently-focused-area-of-a-top-level-browsing-context①">Currently focused area</a> belongs to a document whose origin is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain①">same origin-domain</a> with the origin of the given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document③">active document</a>.</p>
-    <li data-md="">
-     <p><dfn data-dfn-type="dfn" data-noexport="" id="specific-conditions">Specific conditions<a class="self-link" href="#specific-conditions"></a></dfn>: The <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification②">extension specifications</a> that add new <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions①">conditions</a> hook into this specification at this point.</p>
+    <li data-md>
+     <p><dfn data-dfn-type="dfn" data-noexport id="specific-conditions">Specific conditions<a class="self-link" href="#specific-conditions"></a></dfn>: The <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification②">extension specifications</a> that add new <a data-link-type="dfn" href="#mandatory-conditions" id="ref-for-mandatory-conditions①">conditions</a> hook into this specification at this point.</p>
    </ul>
    <p class="note" role="note"><span>Note:</span> In order to release hardware resources, the user agent can request underlying <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑧">platform sensor</a> to suspend notifications about newly available readings until it <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings">can expose sensor readings</a>.</p>
    <h2 class="heading settled" data-level="6" id="model"><span class="secno">6. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="model-sensor-type"><span class="secno">6.1. </span><span class="content">Sensor Type</span><a class="self-link" href="#model-sensor-type"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-type">sensor type</dfn> has one or more associated <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface">extension sensor interfaces</a>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="associated-sensors">associated sensors</dfn>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sensor-type">sensor type</dfn> has one or more associated <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface">extension sensor interfaces</a>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②③">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="associated-sensors">associated sensors</dfn>.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②④">sensor type</a> may have a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor③">default sensor</a>.</p>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of associated <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">permission names</a> referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-permission-names">sensor permission names</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑤">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of associated <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname①">permission names</a> referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="sensor-permission-names">sensor permission names</dfn>.</p>
    <p class="note" role="note"><span>Note:</span> multiple <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑥">sensor types</a> may share the same <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname②">permission name</a>.</p>
    <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑦">sensor type</a> has a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#permission-revocation-algorithm" id="ref-for-permission-revocation-algorithm">permission revocation algorithm</a>.</p>
    <div class="algorithm" data-algorithm="generic sensor permission revocation algorithm">
-    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport="" id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
+    <p>To invoke the <dfn data-dfn-type="dfn" data-lt="generic sensor permission revocation algorithm" data-noexport id="generic-sensor-permission-revocation-algorithm">permission revocation algorithm<a class="self-link" href="#generic-sensor-permission-revocation-algorithm"></a></dfn> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname③">PermissionName</a></code> <var>permission_name</var>, run the following steps:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>sensor_type</var> whose <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names①">permission names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>permission_name</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>sensor</var> in <var>sensor_type</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">set</a> of <a data-link-type="dfn" href="#associated-sensors" id="ref-for-associated-sensors">associated sensors</a>,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Invoke <a data-link-type="dfn" href="#revoke-sensor-permission" id="ref-for-revoke-sensor-permission">revoke sensor permission</a> with <var>sensor</var> as argument.</p>
         </ol>
       </ol>
     </ol>
    </div>
-   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">set</a> of associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> tokens referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sensor-feature-names">sensor feature names</dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type②⑧">sensor type</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty①">nonempty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">set</a> of associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> tokens referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="sensor-feature-names">sensor feature names</dfn>.</p>
    <h3 class="heading settled" data-level="6.2" id="model-sensor"><span class="secno">6.2. </span><span class="content">Sensor</span><a class="self-link" href="#model-sensor"></a></h3>
-   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activated-sensor-objects">activated sensor objects</dfn>, which is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty②">empty</a> and an
-associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>, which holds the latest available <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⑤">sensor readings</a>.</p>
+   <p>The current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor⑨">platform sensor</a> has an associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="activated-sensor-objects">activated sensor objects</dfn>, which is initially <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty②">empty</a> and an
+associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="latest-reading">latest reading</dfn> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>, which holds the latest available <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⑤">sensor readings</a>.</p>
    <p class="note" role="note"><span>Note:</span> User agents can share the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a> and
 the <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑥">set</a> between different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">contexts</a> only if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#origin-2" id="ref-for-origin-2">origins</a> of these contexts' <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active documents</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain②">same origin-domain</a>.</p>
    <p>Any time a new <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⑥">sensor reading</a> for a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⓪">platform sensor</a> is obtained and if the user agent <a data-link-type="dfn" href="#can-expose-sensor-readings" id="ref-for-can-expose-sensor-readings①">can expose sensor readings</a> to the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document⑤">active document</a>,
@@ -2127,14 +2174,14 @@ The return value of the <a data-link-type="dfn" href="https://heycam.github.io/w
 easily obtained by invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with the object implementing the <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface②">extension sensor interface</a> and the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute②">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier①">identifier</a> as arguments.</p>
    <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a> of all <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑤">latest reading</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry③">entries</a> is initially set to null.</p>
    <p>A <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①③">platform sensor</a> has an associated <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency③">requested sampling frequency</a> which is initially null.</p>
-   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty③">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑦">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
+   <p>For a non<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty③">empty</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑦">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①">activated sensor objects</a> the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency④">requested sampling frequency</a> is equal to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="optimal-sampling-frequency">optimal sampling frequency</dfn>, which is estimated
 by the user agent taking into account <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot">provided frequencies</a></code> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects②">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤">Sensors</a></code> and <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑦">sampling frequency</a> bounds
 defined by the underlying platform.</p>
    <p class="note" role="note"><span>Note:</span> For example, the user agent may estimate <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency">optimal sampling frequency</a> as a Least Common
 Denominator (LCD) for a set of <code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot①">provided frequencies</a></code> capped
 by <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑧">sampling frequency</a> bounds defined by the underlying platform.</p>
-   <div class="example" id="example-509cb3c1">
-    <a class="self-link" href="#example-509cb3c1"></a> 
+   <div class="example" id="example-c4bd9af5">
+    <a class="self-link" href="#example-c4bd9af5"></a> 
     <p>This example illustrates a possible implementation of the described <a href="#model">Model</a>.</p>
     <p>In the diagram below several <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects③">activated</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑥">Sensor</a></code> objects from two
 different <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing contexts</a> interact with a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑥">device sensor</a>.</p>
@@ -2146,48 +2193,48 @@ same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browse
    </div>
    <h2 class="heading settled" data-level="7" id="api"><span class="secno">7. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="the-sensor-interface"><span class="secno">7.1. </span><span class="content">The Sensor Interface</span><a class="self-link" href="#the-sensor-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensor"><code>Sensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-sensor-activated"><code>activated</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-sensor-hasreading"><code>hasReading</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp">DOMHighResTimeStamp</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMHighResTimeStamp?" id="dom-sensor-timestamp"><code>timestamp</code></dfn>;
-  <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="start()" id="dom-sensor-start"><code>start</code></dfn>();
-  <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export="" data-lt="stop()" id="dom-sensor-stop"><code>stop</code></dfn>();
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onreading"><code>onreading</code></dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onactivate"><code>onactivate</code></dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler②">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-sensor-onerror"><code>onerror</code></dfn>;
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="sensor"><code><c- g>Sensor</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget"><c- n>EventTarget</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-sensor-activated"><code><c- g>activated</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-sensor-hasreading"><code><c- g>hasReading</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-readonly data-type="DOMHighResTimeStamp?" id="dom-sensor-timestamp"><code><c- g>timestamp</c-></code></dfn>;
+  <c- b>void</c-> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export data-lt="start()" id="dom-sensor-start"><code><c- g>start</c-></code></dfn>();
+  <c- b>void</c-> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="method" data-export data-lt="stop()" id="dom-sensor-stop"><code><c- g>stop</c-></code></dfn>();
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler"><c- n>EventHandler</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-sensor-onreading"><code><c- g>onreading</c-></code></dfn>;
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①"><c- n>EventHandler</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-sensor-onactivate"><code><c- g>onactivate</c-></code></dfn>;
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler②"><c- n>EventHandler</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-sensor-onerror"><code><c- g>onerror</c-></code></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensoroptions"><code>SensorOptions</code></dfn> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-sensoroptions-frequency"><code>frequency</code></dfn>;
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sensoroptions"><code><c- g>SensorOptions</c-></code></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SensorOptions" data-dfn-type="dict-member" data-export data-type="double " id="dom-sensoroptions-frequency"><code><c- g>frequency</c-></code></dfn>;
 };
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑨">Sensor</a></code> object has an associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑦">platform sensor</a>.</p>
-   <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sensor-task-source">sensor task source</dfn>.</p>
-   <div class="example" id="example-f144a057">
-    <a class="self-link" href="#example-f144a057"></a> In the following example, firstly, we check whether the user agent has permission to access <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⑨">sensor readings</a>, then we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> activation,
+   <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source">task source</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task">tasks</a> mentioned in this specification is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sensor-task-source">sensor task source</dfn>.</p>
+   <div class="example" id="example-c4eab8e2">
+    <a class="self-link" href="#example-c4eab8e2"></a> In the following example, firstly, we check whether the user agent has permission to access <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading③⑨">sensor readings</a>, then we construct accelerometer sensor and add <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event-listener" id="ref-for-concept-event-listener">event listeners</a> to get <a data-link-type="dfn" href="https://dom.spec.whatwg.org#concept-event" id="ref-for-concept-event">events</a> for <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑧">platform sensor</a> activation,
     error conditions and notifications about newly available <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⓪">sensor readings</a>. The example
     measures and logs maximum total acceleration of a device hosting the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor①⑨">platform sensor</a>. 
     <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event types</a> for the corresponding <a href="#the-sensor-interface"> Sensor Interface</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> attributes are defined in <a href="#event-handlers">Event handlers</a> section.</p>
-<pre class="highlight">navigator<span class="p">.</span>permissions<span class="p">.</span>query<span class="p">({</span> name<span class="o">:</span> <span class="s1">'accelerometer'</span> <span class="p">}).</span>then<span class="p">(</span>result <span class="p">=></span> <span class="p">{</span>
-    <span class="k">if</span> <span class="p">(</span>result<span class="p">.</span>state <span class="o">===</span> <span class="s1">'denied'</span><span class="p">)</span> <span class="p">{</span>
-        console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Permission to use accelerometer sensor is denied.'</span><span class="p">);</span>
-        <span class="k">return</span><span class="p">;</span>
-    <span class="p">}</span>
+<pre class="highlight">navigator<c- p>.</c->permissions<c- p>.</c->query<c- p>({</c-> name<c- o>:</c-> <c- t>'accelerometer'</c-> <c- p>}).</c->then<c- p>(</c->result <c- p>=></c-> <c- p>{</c->
+    <c- k>if</c-> <c- p>(</c->result<c- p>.</c->state <c- o>===</c-> <c- t>'denied'</c-><c- p>)</c-> <c- p>{</c->
+        console<c- p>.</c->log<c- p>(</c-><c- t>'Permission to use accelerometer sensor is denied.'</c-><c- p>);</c->
+        <c- k>return</c-><c- p>;</c->
+    <c- p>}</c->
 
-    <span class="kd">let</span> acl <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">30</span><span class="p">});</span>
-    <span class="kd">let</span> max_magnitude <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
-    acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'activate'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="s1">'Ready to measure.'</span><span class="p">));</span>
-    acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'error'</span><span class="p">,</span> error <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span><span class="sb">`Error: </span><span class="si">${</span>error<span class="p">.</span>name<span class="si">}</span><span class="sb">`</span><span class="p">));</span>
-    acl<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'reading'</span><span class="p">,</span> <span class="p">()</span> <span class="p">=></span> <span class="p">{</span>
-        <span class="kd">let</span> magnitude <span class="o">=</span> Math<span class="p">.</span>hypot<span class="p">(</span>acl<span class="p">.</span>x<span class="p">,</span> acl<span class="p">.</span>y<span class="p">,</span> acl<span class="p">.</span>z<span class="p">);</span>
-        <span class="k">if</span> <span class="p">(</span>magnitude <span class="o">></span> max_magnitude<span class="p">)</span> <span class="p">{</span>
-            max_magnitude <span class="o">=</span> magnitude<span class="p">;</span>
-            console<span class="p">.</span>log<span class="p">(</span><span class="sb">`Max magnitude: </span><span class="si">${</span>max_magnitude<span class="si">}</span><span class="sb"> m/s2`</span><span class="p">);</span>
-        <span class="p">}</span>
-    <span class="p">});</span>
-    acl<span class="p">.</span>start<span class="p">();</span>
-<span class="p">});</span>
+    <c- a>let</c-> acl <c- o>=</c-> <c- k>new</c-> Accelerometer<c- p>({</c->frequency<c- o>:</c-> <c- mi>30</c-><c- p>});</c->
+    <c- a>let</c-> max_magnitude <c- o>=</c-> <c- mi>0</c-><c- p>;</c->
+    acl<c- p>.</c->addEventListener<c- p>(</c-><c- t>'activate'</c-><c- p>,</c-> <c- p>()</c-> <c- p>=></c-> console<c- p>.</c->log<c- p>(</c-><c- t>'Ready to measure.'</c-><c- p>));</c->
+    acl<c- p>.</c->addEventListener<c- p>(</c-><c- t>'error'</c-><c- p>,</c-> error <c- p>=></c-> console<c- p>.</c->log<c- p>(</c-><c- sb>`Error: </c-><c- si>${</c->error<c- p>.</c->name<c- si>}</c-><c- sb>`</c-><c- p>));</c->
+    acl<c- p>.</c->addEventListener<c- p>(</c-><c- t>'reading'</c-><c- p>,</c-> <c- p>()</c-> <c- p>=></c-> <c- p>{</c->
+        <c- a>let</c-> magnitude <c- o>=</c-> Math<c- p>.</c->hypot<c- p>(</c->acl<c- p>.</c->x<c- p>,</c-> acl<c- p>.</c->y<c- p>,</c-> acl<c- p>.</c->z<c- p>);</c->
+        <c- k>if</c-> <c- p>(</c->magnitude <c- o>></c-> max_magnitude<c- p>)</c-> <c- p>{</c->
+            max_magnitude <c- o>=</c-> magnitude<c- p>;</c->
+            console<c- p>.</c->log<c- p>(</c-><c- sb>`Max magnitude: </c-><c- si>${</c->max_magnitude<c- si>}</c-><c- sb> m/s2`</c-><c- p>);</c->
+        <c- p>}</c->
+    <c- p>});</c->
+    acl<c- p>.</c->start<c- p>();</c->
+<c- p>});</c->
 </pre>
    </div>
    <h4 class="heading settled" data-level="7.1.1" id="sensor-lifecycle"><span class="secno">7.1.1. </span><span class="content">Sensor lifecycle</span><a class="self-link" href="#sensor-lifecycle"></a></h4>
@@ -2270,8 +2317,7 @@ or "error" events.</p>
    <p>A <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①②">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①">[[state]]</a></code> is "activated" must not be garbage collected
 if there are any event listeners registered for "reading" events, or "error" events.</p>
    <p>When a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①③">Sensor</a></code> object whose <code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot②">[[state]]</a></code> is "activated" or "activating" is
-eligible for garbage collection, the user agent must invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor
-object</a> with this object as argument.</p>
+garbage collected, the user agent must invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object">deactivate a sensor object</a> with this object as argument.</p>
    <h4 class="heading settled" data-level="7.1.3" id="sensor-internal-slots"><span class="secno">7.1.3. </span><span class="content">Sensor internal slots</span><a class="self-link" href="#sensor-internal-slots"></a></h4>
    <p>Instances of <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①④">Sensor</a></code> are created
 with the internal slots described in the following table:</p>
@@ -2283,26 +2329,26 @@ with the internal slots described in the following table:</p>
       <th>Description (non-normative)
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export id="dom-sensor-state-slot"><code>[[state]]</code></dfn>
       <td>The current state of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑤">Sensor</a></code> object which is one of
                 "idle",
                 "activating", or
                 "activated".
                 It is initially "idle". 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export id="dom-sensor-frequency-slot"><code>[[frequency]]</code></dfn>
       <td>
        A double representing frequency in Hz that is used to calculate
                 the <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑥">requested sampling frequency</a> for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②①">platform sensor</a> and to define the upper bound of the <a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency①">reporting frequency</a> for this <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑥">Sensor</a></code> object. 
        <p>This slot holds the provided <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency">frequency</a></code> value.
                 It is initially unset.</p>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export id="dom-sensor-lasteventfiredat-slot"><code>[[lastEventFiredAt]]</code></dfn>
       <td>The high resolution timestamp of the latest <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④①">sensor reading</a> that was sent to observers of the <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑦">Sensor</a></code> object,
                 expressed in milliseconds that passed since the <a data-link-type="dfn" href="https://www.w3.org/TR/hr-time-2/#dfn-time-origin" id="ref-for-dfn-time-origin①">time origin</a>.
                 It is initially null. 
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export="" id="dom-sensor-pendingreadingnotification-slot"><code>[[pendingReadingNotification]]</code></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Sensor" data-dfn-type="attribute" data-export id="dom-sensor-pendingreadingnotification-slot"><code>[[pendingReadingNotification]]</code></dfn>
       <td>A boolean which indicates whether the observers need to be
                 notified after a new <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④②">sensor reading</a> was reported.
                 It is initially false.
@@ -2311,10 +2357,10 @@ with the internal slots described in the following table:</p>
    <div class="algorithm" data-algorithm="is sensor activated">
     <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-activated" id="ref-for-dom-sensor-activated">activated</a></code> attribute must run these steps:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <strong>this</strong>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot③">[[state]]</a></code> is "activated",
   return true.</p>
-     <li data-md="">
+     <li data-md>
       <p>Otherwise, return false.</p>
     </ol>
    </div>
@@ -2322,11 +2368,11 @@ with the internal slots described in the following table:</p>
    <div class="algorithm" data-algorithm="sensor has reading">
     <p>The getter of the <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-hasreading" id="ref-for-dom-sensor-hasreading">hasReading</a></code> attribute must run these steps:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>timestamp</var> be the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading①">get value from latest reading</a> with <strong>this</strong> and "timestamp" as arguments.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>timestamp</var> is not null, return true.</p>
-     <li data-md="">
+     <li data-md>
       <p>Otherwise, return false.</p>
     </ol>
    </div>
@@ -2337,43 +2383,43 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
    <div class="algorithm" data-algorithm="to start a sensor">
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-start" id="ref-for-dom-sensor-start">start()</a></code> method must run these steps:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor_state</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot④">[[state]]</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor_state</var> is either "activating"
   or "activated", then return.</p>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑤">[[state]]</a></code> to "activating".</p>
-     <li data-md="">
+     <li data-md>
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>let <var>connected</var> be the result of invoking <a data-link-type="dfn" href="#connect-to-sensor" id="ref-for-connect-to-sensor">connect to sensor</a> with <var>sensor_instance</var> as argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>connected</var> is false, then</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception">creating</a> a
   "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notreadableerror" id="ref-for-notreadableerror">NotReadableError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
-         <li data-md="">
+         <li data-md>
           <p>Return.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>permission_state</var> be the result of invoking <a data-link-type="dfn" href="#request-sensor-access" id="ref-for-request-sensor-access①">request sensor access</a> with <var>sensor_instance</var> as argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>permission_state</var> is "granted",</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Invoke <a data-link-type="dfn" href="#activate-a-sensor-object" id="ref-for-activate-a-sensor-object">activate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Otherwise, if <var>permission_state</var> is "denied",</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception①">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error①">notify error</a> with <var>e</var> and <var>sensor_instance</var> as arguments.</p>
         </ol>
       </ol>
@@ -2383,14 +2429,14 @@ the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-read
    <div class="algorithm" data-algorithm="to stop a sensor">
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-sensor-stop" id="ref-for-dom-sensor-stop">stop()</a></code> method must run these steps:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑥">[[state]]</a></code> is "idle", then return.</p>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑦">[[state]]</a></code> to "idle".</p>
-     <li data-md="">
+     <li data-md>
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object①">deactivate a sensor object</a> with <var>sensor_instance</var> as argument.</p>
       </ol>
     </ol>
@@ -2423,481 +2469,481 @@ that must be supported as attributes by the objects implementing the <code class
       <td><code>error</code>
    </table>
    <h3 class="heading settled" data-level="7.2" id="the-sensor-error-event-interface"><span class="secno">7.2. </span><span class="content">The SensorErrorEvent Interface</span><a class="self-link" href="#the-sensor-error-event-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="constructor" data-export="" data-lt="SensorErrorEvent(type, errorEventInitDict)" id="dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit">SensorErrorEventInit</a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export="" id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"></a></dfn>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="sensorerrorevent"><code>SensorErrorEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMException" id="dom-sensorerrorevent-error"><code>error</code></dfn>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="constructor" data-export data-lt="SensorErrorEvent(type, errorEventInitDict)" id="dom-sensorerrorevent-sensorerrorevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit"><c- n>SensorErrorEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SensorErrorEvent/SensorErrorEvent(type, errorEventInitDict)" data-dfn-type="argument" data-export id="dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code><c- g>errorEventInitDict</c-></code><a class="self-link" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"></a></dfn>),
+ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="sensorerrorevent"><code><c- g>SensorErrorEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event"><c- n>Event</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②"><c- n>DOMException</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SensorErrorEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMException" id="dom-sensorerrorevent-error"><code><c- g>error</c-></code></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit">EventInit</a> {
-  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a> <dfn class="nv idl-code" data-dfn-for="SensorErrorEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMException " id="dom-sensorerroreventinit-error"><code>error</code><a class="self-link" href="#dom-sensorerroreventinit-error"></a></dfn>;
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sensorerroreventinit"><code><c- g>SensorErrorEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit"><c- n>EventInit</c-></a> {
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException③"><c- n>DOMException</c-></a> <dfn class="idl-code" data-dfn-for="SensorErrorEventInit" data-dfn-type="dict-member" data-export data-type="DOMException " id="dom-sensorerroreventinit-error"><code><c- g>error</c-></code><a class="self-link" href="#dom-sensorerroreventinit-error"></a></dfn>;
 };
 </pre>
    <h4 class="heading settled" data-level="7.2.1" id="sensor-error-event-error"><span class="secno">7.2.1. </span><span class="content">SensorErrorEvent.error</span><a class="self-link" href="#sensor-error-event-error"></a></h4>
    <p>Gets the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException④">DOMException</a></code> object passed to <code class="idl"><a data-link-type="idl" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit①">SensorErrorEventInit</a></code>.</p>
    <h2 class="heading settled" data-level="8" id="abstract-operations"><span class="secno">8. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
-   <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.1" data-lt="Initialize a sensor object" id="initialize-a-sensor-object"><span class="secno">8.1. </span><span class="content">Initialize a sensor object</span><a class="self-link" href="#initialize-a-sensor-object"></a></h3>
+   <h3 class="heading settled" data-dfn-type="dfn" data-export data-level="8.1" data-lt="Initialize a sensor object" id="initialize-a-sensor-object"><span class="secno">8.1. </span><span class="content">Initialize a sensor object</span><a class="self-link" href="#initialize-a-sensor-object"></a></h3>
    <div class="algorithm" data-algorithm="initialize a sensor object">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor①⑨">Sensor</a></code> object.</p>
-     <dd data-md="">
+     <dd data-md>
       <p><var>options</var>, a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate">For each</a> <var>key</var> → <var>value</var> of <var>options</var></p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If the associated <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options">supported sensor options</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">does not contain</a> <var>key</var></p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">Throw</a> "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notsupportederror" id="ref-for-notsupportederror">NotSupportedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑤">DOMException</a></code>.</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency①">frequency</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present" id="ref-for-dfn-present">present</a>, then</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot②">[[frequency]]</a></code> to <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency②">frequency</a></code>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> there is not guarantee that the requested <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-sensoroptions-frequency" id="ref-for-dom-sensoroptions-frequency③">frequency</a></code> can be respected. The actual <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency⑨">sampling frequency</a> can be calculated using <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⓪">Sensor</a></code> <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensor-timestamp" id="ref-for-dom-sensor-timestamp①">timestamp</a></code> attributes.</p>
     </ol>
    </div>
-   <h3 class="heading settled" data-dfn-type="dfn" data-export="" data-level="8.2" data-lt="Check sensor policy-controlled features" id="check-sensor-policy-controlled-features"><span class="secno">8.2. </span><span class="content">Check sensor policy-controlled features</span><a class="self-link" href="#check-sensor-policy-controlled-features"></a></h3>
+   <h3 class="heading settled" data-dfn-type="dfn" data-export data-level="8.2" data-lt="Check sensor policy-controlled features" id="check-sensor-policy-controlled-features"><span class="secno">8.2. </span><span class="content">Check sensor policy-controlled features</span><a class="self-link" href="#check-sensor-policy-controlled-features"></a></h3>
    <div class="algorithm" data-algorithm="check sensor policy-controlled features">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_type</var>, a <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⓪">sensor type</a>.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>True if all of the associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names">sensor feature names</a> are <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a>,
  false otherwise.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>feature_names</var> be the <var>sensor_type</var>’s associated <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names①">sensor feature names</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>feature_name</var> of <var>feature_names</var>,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document⑥">active document</a> is not <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#allowed-to-use" id="ref-for-allowed-to-use③">allowed to use</a> the <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature③">policy-controlled feature</a> named <var>feature_name</var>, then:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return false.</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return true.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="8.3" data-lt="Connect to sensor" id="connect-to-sensor"><span class="secno">8.3. </span><span class="content">Connect to sensor</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export data-level="8.3" data-lt="Connect to sensor" id="connect-to-sensor"><span class="secno">8.3. </span><span class="content">Connect to sensor</span></h3>
    <div class="algorithm" data-algorithm="connect to sensor">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②①">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>True if sensor instance was associated with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②②">platform sensor</a>,
  false otherwise.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>type</var> be the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③①">sensor type</a> of <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the device has a single <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor②⑨">device sensor</a> which can provide <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④④">readings</a> for <var>type</var>, then</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②③">platform sensor</a> corresponding
   to this <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③⓪">device sensor</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Return true.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If the device has multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③①">device sensors</a> which can provide <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⑤">readings</a> for <var>type</var>, then</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>type</var> has an associated <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor④">default sensor</a>, then</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Associate <var>sensor_instance</var> with a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②④">platform sensor</a> corresponding
   to <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑤">default sensor</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Return true.</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return false.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.4" data-lt="Activate a sensor object" data-noexport="" id="activate-a-sensor-object"><span class="secno">8.4. </span><span class="content">Activate a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.4" data-lt="Activate a sensor object" data-noexport id="activate-a-sensor-object"><span class="secno">8.4. </span><span class="content">Activate a sensor object</span></h3>
    <div class="algorithm" data-algorithm="activate a sensor object">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②②">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑤">platform sensor</a> associated with <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>sensor_instance</var> to <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑤">activated sensor objects</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings">set sensor settings</a> with <var>sensor</var> as argument.</p>
-     <li data-md="">
+     <li data-md>
       <p>Queue a task to run <a data-link-type="dfn" href="#notify-activated-state" id="ref-for-notify-activated-state">notify activated state</a> with <var>sensor_instance</var> as an argument.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.5" data-lt="Deactivate a sensor object" data-noexport="" id="deactivate-a-sensor-object"><span class="secno">8.5. </span><span class="content">Deactivate a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.5" data-lt="Deactivate a sensor object" data-noexport id="deactivate-a-sensor-object"><span class="secno">8.5. </span><span class="content">Deactivate a sensor object</span></h3>
    <div class="algorithm" data-algorithm="deactivate a sensor object">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②③">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Remove all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task①">tasks</a> associated with <var>sensor_instance</var> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue">task queue</a> associated
   with <a data-link-type="dfn" href="#sensor-task-source" id="ref-for-sensor-task-source">sensor task source</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑥">platform sensor</a> associated with <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑥">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contains</a> <var>sensor_instance</var>,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> <var>sensor_instance</var> from <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑦">activated sensor objects</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Invoke <a data-link-type="dfn" href="#set-sensor-settings" id="ref-for-set-sensor-settings①">set sensor settings</a> with <var>sensor</var> as argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a></code> to false.</p>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a></code> to null.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.6" data-lt="Revoke sensor permission" data-noexport="" id="revoke-sensor-permission"><span class="secno">8.6. </span><span class="content">Revoke sensor permission</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.6" data-lt="Revoke sensor permission" data-noexport id="revoke-sensor-permission"><span class="secno">8.6. </span><span class="content">Revoke sensor permission</span></h3>
    <div class="algorithm" data-algorithm="revoke sensor permission">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑦">platform sensor</a>.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑧">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑧">activated sensor objects</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">For each</a> <var>s</var> of <var>activated_sensors</var>,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Invoke <a data-link-type="dfn" href="#deactivate-a-sensor-object" id="ref-for-deactivate-a-sensor-object②">deactivate a sensor object</a> with <var>s</var> as argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception" id="ref-for-dfn-create-exception②">creating</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror①">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑥">DOMException</a></code>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-error" id="ref-for-notify-error②">notify error</a> with <var>e</var> and <var>s</var> as arguments.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.7" data-lt="Set sensor settings" data-noexport="" id="set-sensor-settings"><span class="secno">8.7. </span><span class="content">Set sensor settings</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.7" data-lt="Set sensor settings" data-noexport id="set-sensor-settings"><span class="secno">8.7. </span><span class="content">Set sensor settings</span></h3>
    <div class="algorithm" data-algorithm="set sensor settings">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑧">platform sensor</a>.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor</var>’s set of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects⑨">activated sensor objects</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty④">is empty</a>,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑦">requested sampling frequency</a> to null.</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate①">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑦">latest reading</a>.</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑧">latest reading</a>[<var>key</var>] to null.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Update the user-agent-specific way in which <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⑥">sensor readings</a> are obtained from <var>sensor</var> to no longer provide <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⑦">readings</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Return.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Set <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency⑧">requested sampling frequency</a> to <a data-link-type="dfn" href="#optimal-sampling-frequency" id="ref-for-optimal-sampling-frequency①">optimal sampling frequency</a>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.8" data-lt="Update latest reading" data-noexport="" id="update-latest-reading"><span class="secno">8.8. </span><span class="content">Update latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.8" data-lt="Update latest reading" data-noexport id="update-latest-reading"><span class="secno">8.8. </span><span class="content">Update latest reading</span></h3>
    <div class="algorithm" data-algorithm="update latest reading">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor</var>, a <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor②⑨">platform sensor</a>.</p>
-     <dd data-md="">
+     <dd data-md>
       <p><var>reading</var>, a <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⑧">sensor reading</a>.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate②">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading⑨">latest reading</a>.</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①⓪">latest reading</a>[<var>key</var>] to the corresponding
   value of <var>reading</var>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>activated_sensors</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑨">set</a> of <a data-link-type="dfn" href="#activated-sensor-objects" id="ref-for-activated-sensor-objects①⓪">activated sensor objects</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate③">For each</a> <var>s</var> in <var>activated_sensors</var>,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Invoke <a data-link-type="dfn" href="#report-latest-reading-updated" id="ref-for-report-latest-reading-updated">report latest reading updated</a> with <var>s</var> as an argument.</p>
         </ol>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.9" data-lt="Find the reporting frequency of a sensor object" data-noexport="" id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.9. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.9" data-lt="Find the reporting frequency of a sensor object" data-noexport id="find-the-reporting-frequency-of-a-sensor-object"><span class="secno">8.9. </span><span class="content">Find the reporting frequency of a sensor object</span></h3>
    <div class="algorithm" data-algorithm="find the reporting frequency of a sensor object">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②④">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p><a data-link-type="dfn" href="#reporting-frequency" id="ref-for-reporting-frequency②">reporting frequency</a> in Hz.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>frequency</var> be null.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>f</var> be <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-frequency-slot" id="ref-for-dom-sensor-frequency-slot③">[[frequency]]</a></code>.</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>if <var>f</var> is set,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>set <var>frequency</var> to <var>f</var> capped by the upper and lower <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①⓪">sampling frequency</a> bounds for the associated <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⓪">platform sensor</a>.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Otherwise,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>user agent can assign <var>frequency</var> to an appropriate value.</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>return <var>frequency</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.10" data-lt="Report latest reading updated" data-noexport="" id="report-latest-reading-updated"><span class="secno">8.10. </span><span class="content">Report latest reading updated</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.10" data-lt="Report latest reading updated" data-noexport id="report-latest-reading-updated"><span class="secno">8.10. </span><span class="content">Report latest reading updated</span></h3>
    <div class="algorithm" data-algorithm="report latest reading updated">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑤">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot①">[[pendingReadingNotification]]</a></code> is true,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Return.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot②">[[pendingReadingNotification]]</a></code> to true.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>lastReportedTimestamp</var> be the value of <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot①">[[lastEventFiredAt]]</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>lastReportedTimestamp</var> is not set</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>Return.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>reportingFrequency</var> be result of invoking <a data-link-type="dfn" href="#find-the-reporting-frequency-of-a-sensor-object" id="ref-for-find-the-reporting-frequency-of-a-sensor-object">Find the reporting frequency of a sensor object</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>reportingFrequency</var> is null</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading①">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>Return.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>reportingInterval</var> be the result of 1 / <var>reportingFrequency</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>timestampDelta</var> be the result of <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①①">latest reading</a>["timestamp"] - <var>lastReportedTimestamp</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>timestampDelta</var> is greater than or equal to <var>reportingInterval</var></p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading②">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
-       <li data-md="">
+       <li data-md>
         <p>Return.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>deferUpdateTime</var> be the result of <var>reportingInterval</var> - <var>timestampDelta</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop" id="ref-for-spin-the-event-loop">Spin the event loop</a> for a period of time equal to <var>deferUpdateTime</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot③">[[pendingReadingNotification]]</a></code> is true,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading③">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.11" data-lt="Notify new reading" data-noexport="" id="notify-new-reading"><span class="secno">8.11. </span><span class="content">Notify new reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.11" data-lt="Notify new reading" data-noexport id="notify-new-reading"><span class="secno">8.11. </span><span class="content">Notify new reading</span></h3>
    <div class="algorithm" data-algorithm="notify new reading">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑥">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-pendingreadingnotification-slot" id="ref-for-dom-sensor-pendingreadingnotification-slot④">[[pendingReadingNotification]]</a></code> to false.</p>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-lasteventfiredat-slot" id="ref-for-dom-sensor-lasteventfiredat-slot②">[[lastEventFiredAt]]</a></code> to <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①②">latest reading</a>["timestamp"].</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire①">Fire an event</a> named "reading" at <var>sensor_instance</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.12" data-lt="Notify activated state" data-noexport="" id="notify-activated-state"><span class="secno">8.12. </span><span class="content">Notify activated state</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.12" data-lt="Notify activated state" data-noexport id="notify-activated-state"><span class="secno">8.12. </span><span class="content">Notify activated state</span></h3>
    <div class="algorithm" data-algorithm="notify activated state">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑦">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot⑨">[[state]]</a></code> to "activated".</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">Fire an event</a> named "activate" at <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③①">platform sensor</a> associated with <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor</var>’s <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①③">latest reading</a>["timestamp"] is not null,</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Queue a task to run <a data-link-type="dfn" href="#notify-new-reading" id="ref-for-notify-new-reading④">notify new reading</a> with <var>sensor_instance</var> as an argument.</p>
       </ol>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.13" data-lt="Notify error" data-noexport="" id="notify-error"><span class="secno">8.13. </span><span class="content">Notify error</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.13" data-lt="Notify error" data-noexport id="notify-error"><span class="secno">8.13. </span><span class="content">Notify error</span></h3>
    <div class="algorithm" data-algorithm="notify error">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑧">Sensor</a></code> object.</p>
-     <dd data-md="">
+     <dd data-md>
       <p><var>error</var>, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>None</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①⓪">[[state]]</a></code> to "idle".</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire③">Fire an event</a> named "error" at <var>sensor_instance</var> using <code class="idl"><a data-link-type="idl" href="#sensorerrorevent" id="ref-for-sensorerrorevent">SensorErrorEvent</a></code> with its <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-sensorerrorevent-error" id="ref-for-dom-sensorerrorevent-error">error</a></code> attribute initialized to <var>error</var>.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.14" data-lt="Get value from latest reading" data-noexport="" id="get-value-from-latest-reading"><span class="secno">8.14. </span><span class="content">Get value from latest reading</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.14" data-lt="Get value from latest reading" data-noexport id="get-value-from-latest-reading"><span class="secno">8.14. </span><span class="content">Get value from latest reading</span></h3>
    <div class="algorithm" data-algorithm="get value from latest reading">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor②⑨">Sensor</a></code> object.</p>
-     <dd data-md="">
+     <dd data-md>
       <p><var>key</var>, a string representing the name of the value.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>A <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading④⑨">sensor reading</a> value or null.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>sensor_instance</var>.<code class="idl"><a data-link-type="idl" href="#dom-sensor-state-slot" id="ref-for-dom-sensor-state-slot①①">[[state]]</a></code> is "activated",</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>readings</var> be the <a data-link-type="dfn" href="#latest-reading" id="ref-for-latest-reading①④">latest reading</a> of <var>sensor_instance</var>’s related <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③②">platform sensor</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification③">extension specification</a> defines a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> for <var>sensor_instance</var>,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Remap (see <a data-link-type="biblio" href="#biblio-coordinates-transformation">[COORDINATES-TRANSFORMATION]</a>) <var>readings</var> values to the <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a>.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Return <var>readings</var>[<var>key</var>].</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Otherwise, return null.</p>
     </ol>
    </div>
-   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.15" data-lt="Request sensor access" data-noexport="" id="request-sensor-access"><span class="secno">8.15. </span><span class="content">Request sensor access</span></h3>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="8.15" data-lt="Request sensor access" data-noexport id="request-sensor-access"><span class="secno">8.15. </span><span class="content">Request sensor access</span></h3>
    <div class="algorithm" data-algorithm="request sensor access">
     <dl>
-     <dt data-md="">input
-     <dd data-md="">
+     <dt data-md>input
+     <dd data-md>
       <p><var>sensor_instance</var>, a <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⓪">Sensor</a></code> object.</p>
-     <dt data-md="">output
-     <dd data-md="">
+     <dt data-md>output
+     <dd data-md>
       <p>A <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#permission-state" id="ref-for-permission-state①">permission state</a>.</p>
     </dl>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor</var> be the <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③③">platform sensor</a> associated with <var>sensor_instance</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>sensor_permissions</var> be <var>sensor</var>’s associated <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①⓪">set</a> of <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names②">permission names</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Run these sub-steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate④">For each</a> <var>permission_name</var> in <var>sensor_permissions</var>,</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>state</var> be the result of <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use">requesting permission to use</a> <var>permission_name</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>state</var> is "denied"</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Return "denied".</p>
           </ol>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Otherwise, return "granted".</p>
       </ol>
     </ol>
@@ -2905,7 +2951,7 @@ that must be supported as attributes by the objects implementing the <code class
    <h2 class="heading settled" data-level="9" id="extensibility"><span class="secno">9. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
    <p><em>This section is non-normative.</em></p>
    <p>This section describes how this specification can be extended to specify APIs for different <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③②">sensor types</a>.</p>
-   <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport="" id="extension-specification">extension specifications</dfn> are encouraged to focus on a
+   <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport id="extension-specification">extension specifications</dfn> are encouraged to focus on a
 single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
    <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification④">Extension specifications</a> are encouraged to define whether a <a data-link-type="dfn" href="#calibration" id="ref-for-calibration①">calibration</a> process applies to <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⓪">sensor readings</a>.</p>
@@ -2914,14 +2960,14 @@ as appropriate.</p>
    <h3 class="heading settled" data-level="9.1" id="extension-security-and-privacy"><span class="secno">9.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
    <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">Extension specifications</a> are expected to:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p>conform with the generic <a href="#mitigation-strategies">mitigation strategies</a>,</p>
-    <li data-md="">
+    <li data-md>
      <p>consider <a href="#mitigation-strategies-case-by-case">mitigation strategies applied
 on a case by case basis</a>,</p>
-    <li data-md="">
+    <li data-md>
      <p>be evaluated against the Self-Review Questionnaire on Security and Privacy <a data-link-type="biblio" href="#biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]</a>,</p>
-    <li data-md="">
+    <li data-md>
      <p>and in particular, be evaluated against the <a class="non-normative" data-link-type="dfn" href="https://w3ctag.github.io/security-questionnaire/#sop-violations" id="ref-for-sop-violations">same-origin policy violations</a> that can arise if sensors expose a new communication channel not governed
 by the same-origin policy.</p>
    </ul>
@@ -2960,16 +3006,16 @@ have focused on <a data-link-type="dfn" href="#high-level" id="ref-for-high-leve
    <p>This was a reasonable approach for a number of reasons.
 Indeed, <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①⓪">high-level</a> sensors:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p>convey developer intent clearly,</p>
-    <li data-md="">
+    <li data-md>
      <p>do not require intimate knowledge of how the underlying hardware sensors functions,</p>
-    <li data-md="">
+    <li data-md>
      <p>are easy to use,</p>
-    <li data-md="">
+    <li data-md>
      <p>may enable the User Agent to make significant
   performance and battery life improvements,</p>
-    <li data-md="">
+    <li data-md>
      <p>help avoid certain privacy and security issues by
   decreasing the amount and type of information exposed.</p>
    </ul>
@@ -2995,26 +3041,26 @@ accuracy or other settings defined in <a data-link-type="dfn" href="#extension-s
    <p>The following definitions must be specified for
 each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑧">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a>:</p>
    <ul>
-    <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="extension-sensor-interface">extension sensor interface</dfn>, which is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
+    <li data-md>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="extension-sensor-interface">extension sensor interface</dfn>, which is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code>.
   The <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface③">extension sensor interface</a> must be constructible.
   Its [<code class="idl"><a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Constructor" id="ref-for-Constructor">Constructor</a></code>] must take, as an argument,
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code>.</p>
      <p>The <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface④">extension sensor interface</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①①">set</a> of supported options
-  referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="supported-sensor-options">supported sensor options</dfn>.
+  referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="supported-sensor-options">supported sensor options</dfn>.
   Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specification</a> defines otherwise, <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options①">supported sensor options</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain③">contain</a> a single item which is "frequency".</p>
      <p>The user agent must remove items from <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options②">supported sensor options</a> for a given <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface⑤">extension sensor interface</a> if it cannot support the corresponding sensor
   options.</p>
      <p>The <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface⑥">extension sensor interface</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attributes</a> which expose <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⑤">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier②">identifier</a> as arguments.</p>
-    <li data-md="">
+    <li data-md>
      <p>A <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">permission name</a>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑧">sensor fusion</a> (otherwise, <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">permission names</a> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor types</a> must be used).</p>
    </ul>
    <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①③">extension specification</a> may specify the following definitions
 for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor types</a>:</p>
    <ul>
-    <li data-md="">
+    <li data-md>
      <p>A <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary②">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries①">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a></code>.</p>
-    <li data-md="">
+    <li data-md>
      <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑦">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑦">default sensor</a> should be straightforward.
   For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③②">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①④">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
@@ -3025,7 +3071,7 @@ for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④�
 A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①②">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⓪">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑦">permission name</a>,
 for instance, "gyroscope" or "accelerometer". <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑨">Fusion sensors</a> must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use①">request permission to access</a> each of the sensors that are
 used as a source of fusion.</p>
-   <p>Even though, it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⑦">sensor readings</a> from
+   <p>Even though it might be difficult to reconstruct <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①③">low-level</a> <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⑦">sensor readings</a> from
 fused data, some of the original information might be inferred. For example, it is easy to
 deduce user’s orientation in space if absolute or geomagnetic orientation sensors are used,
 therefore, these sensors must <a data-link-type="dfn" href="https://w3c.github.io/permissions/#request-permission-to-use" id="ref-for-request-permission-to-use②">request permission to use</a> magnetometer as it provides information about orientation of device in relation to Earth’s
@@ -3034,7 +3080,7 @@ it does not need to <a data-link-type="dfn" href="https://w3c.github.io/permissi
    <p><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor①">Permission descriptors</a></code> can also be used to set maximum allowed limits
 for accuracy or <a data-link-type="dfn" href="#sampling-frequency" id="ref-for-sampling-frequency①①">sampling frequency</a>. An example for a possible extension of the Permission API
 for accelerometer sensor is given below.</p>
-<pre class="example" id="example-6d08453b"><a class="self-link" href="#example-6d08453b"></a>dictionary AccelerometerPermissionDescriptor : PermissionDescriptor {
+<pre class="example" id="example-88a9149d"><a class="self-link" href="#example-88a9149d"></a>dictionary AccelerometerPermissionDescriptor : PermissionDescriptor {
     boolean highAccuracy = false;
     boolean highFrequency = false;
 };
@@ -3050,29 +3096,29 @@ from <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading�
    <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④③">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a> token,
 for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑤">extension specification</a> defines
 otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑥">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names③">sensor permission names</a>.</p>
-   <div class="example html" id="example-924ff346">
-    <a class="self-link" href="#example-924ff346"></a> The accelerometer feature is selectively enabled for third-party origin by adding <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#iframe-allow-attribute" id="ref-for-iframe-allow-attribute">allow attribute</a> to the frame container element: 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://third-party.com"</span> <span class="na">allow</span><span class="o">=</span><span class="s">"accelerometer"</span><span class="p">/>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+   <div class="example html" id="example-07bc76ef">
+    <a class="self-link" href="#example-07bc76ef"></a> The accelerometer feature is selectively enabled for third-party origin by adding <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#iframe-allow-attribute" id="ref-for-iframe-allow-attribute">allow attribute</a> to the frame container element: 
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://third-party.com"</c-> <c- e>allow</c-><c- o>=</c-><c- s>"accelerometer"</c-><c- p>/>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
    </div>
-   <div class="example html" id="example-f5158b02">
-    <a class="self-link" href="#example-f5158b02"></a> A sensor usage is disabled completely by specifying the feature policy in a HTTP
+   <div class="example html" id="example-c8a0fab8">
+    <a class="self-link" href="#example-c8a0fab8"></a> A sensor usage is disabled completely by specifying the feature policy in a HTTP
 response header: 
-<pre class="highlight">Feature<span class="o">-</span>Policy<span class="o">:</span> <span class="p">{</span><span class="s2">"accelerometer"</span><span class="o">:</span> <span class="p">[]}</span>
+<pre class="highlight">Feature<c- o>-</c->Policy<c- o>:</c-> <c- p>{</c-><c- u>"accelerometer"</c-><c- o>:</c-> <c- p>[]}</c->
 </pre>
    </div>
    <p><a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion①①">Fusion sensors</a> must use <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names④">sensor feature names</a> of the sensors
 that are used as a source of fusion.</p>
-   <div class="example html" id="example-33abe2f9">
-    <a class="self-link" href="#example-33abe2f9"></a> Allow third-party origin to use accelerometer, magnetometer and gyroscope features
+   <div class="example html" id="example-dcbd0b33">
+    <a class="self-link" href="#example-dcbd0b33"></a> Allow third-party origin to use accelerometer, magnetometer and gyroscope features
 that are required by the absolute orientation sensor. 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://third-party.com"</span> <span class="na">allow</span><span class="o">=</span><span class="s">"accelerometer; magnetometer; gyroscope"</span><span class="p">/></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://third-party.com"</c-> <c- e>allow</c-><c- o>=</c-><c- s>"accelerometer; magnetometer; gyroscope"</c-><c- p>/></c->
 </pre>
    </div>
    <h3 class="heading settled" data-level="9.9" id="example-webidl"><span class="secno">9.9. </span><span class="content">Example WebIDL</span><a class="self-link" href="#example-webidl"></a></h3>
-   <p>Here’s example WebIDL for a possible extension of this specification
+   <p>Here’s an example WebIDL for a possible extension of this specification
 for proximity <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③③">sensors</a>.</p>
-<pre class="example" id="example-29041274"><a class="self-link" href="#example-29041274"></a>[Constructor(optional ProximitySensorOptions proximitySensorOptions),
+<pre class="example" id="example-457db57a"><a class="self-link" href="#example-457db57a"></a>[Constructor(optional ProximitySensorOptions proximitySensorOptions),
  SecureContext, Exposed=Window]
 interface ProximitySensor : Sensor {
     readonly attribute double? distance;
@@ -3181,8 +3227,8 @@ for their editorial input.</p>
    <p>Examples in this specification are introduced with the words "for example"
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
-   <div class="example" id="example-f839f6c8">
-    <a class="self-link" href="#example-f839f6c8"></a> 
+   <div class="example" id="example-ae2b6bc0">
+    <a class="self-link" href="#example-ae2b6bc0"></a> 
     <p>This is an example of an informative example.</p>
    </div>
    <p>Because this document doesn’t itself define APIs for specific <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑦">sensor types</a>—<wbr>that is the role of extensions to this specification—<wbr>all examples are inevitably (wishful) fabrications.
@@ -3199,12 +3245,12 @@ for their editorial input.</p>
     are to be interpreted with the meaning of the key word ("must",
     "should", "may", etc) used in introducing the algorithm.</p>
    <p>Conformance requirements phrased as algorithms or specific steps can be
-    implemented in any manner, so long as the end result is <dfn data-dfn-type="dfn" data-noexport="" id="equivalent">equivalent<a class="self-link" href="#equivalent"></a></dfn>. In
+    implemented in any manner, so long as the end result is <dfn data-dfn-type="dfn" data-noexport id="equivalent">equivalent<a class="self-link" href="#equivalent"></a></dfn>. In
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
    <h3 class="no-ref no-num heading settled" id="conformance-classes"><span class="content">Conformance Classes</span><a class="self-link" href="#conformance-classes"></a></h3>
-   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
+   <p>A <dfn data-dfn-type="dfn" data-noexport id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
     listed in this specification that are applicable to user agents.</p>
 <script>
     // Scrollspy
@@ -3424,119 +3470,606 @@ for their editorial input.</p>
    <li><a href="#uniaxial">uniaxial</a><span>, in §5.1</span>
    <li><a href="#update-latest-reading">Update latest reading</a><span>, in §8.7</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-event">
+   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event">7.2. The SensorErrorEvent Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
+   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-eventinit">7.2. The SensorErrorEvent Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-eventtarget">
+   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventtarget">7.1. The Sensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document">
+   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document">4.2.2. Feature Policy</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-event">
+   <a href="https://dom.spec.whatwg.org#concept-event">https://dom.spec.whatwg.org#concept-event</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-event">7.1. The Sensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
+   <a href="https://dom.spec.whatwg.org#concept-event-listener">https://dom.spec.whatwg.org#concept-event-listener</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-event-listener">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-concept-event-listener①">9.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
+   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-event-fire">5.5. Sampling Frequency and Reporting Frequency</a>
+    <li><a href="#ref-for-concept-event-fire①">8.11. Notify new reading</a>
+    <li><a href="#ref-for-concept-event-fire②">8.12. Notify activated state</a>
+    <li><a href="#ref-for-concept-event-fire③">8.13. Notify error</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-iframe-allow-attribute">
+   <a href="https://wicg.github.io/feature-policy/#iframe-allow-attribute">https://wicg.github.io/feature-policy/#iframe-allow-attribute</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-iframe-allow-attribute">9.8. Extending the Feature Policy API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
+   <a href="https://wicg.github.io/feature-policy/#allowed-to-use">https://wicg.github.io/feature-policy/#allowed-to-use</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-allowed-to-use">4.2.2. Feature Policy</a>
+    <li><a href="#ref-for-allowed-to-use①">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-allowed-to-use②">8.2. Check sensor policy-controlled features</a> <a href="#ref-for-allowed-to-use③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-default-allowlist">
+   <a href="https://wicg.github.io/feature-policy/#default-allowlist">https://wicg.github.io/feature-policy/#default-allowlist</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-default-allowlist">9.8. Extending the Feature Policy API</a> <a href="#ref-for-default-allowlist①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
+   <a href="https://wicg.github.io/feature-policy/#policy-controlled-feature">https://wicg.github.io/feature-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-policy-controlled-feature">4.2.2. Feature Policy</a>
+    <li><a href="#ref-for-policy-controlled-feature①">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-policy-controlled-feature②">6.1. Sensor Type</a>
+    <li><a href="#ref-for-policy-controlled-feature③">8.2. Check sensor policy-controlled features</a>
+    <li><a href="#ref-for-policy-controlled-feature④">9.8. Extending the Feature Policy API</a> <a href="#ref-for-policy-controlled-feature⑤">(2)</a> <a href="#ref-for-policy-controlled-feature⑥">(3)</a> <a href="#ref-for-policy-controlled-feature⑦">(4)</a> <a href="#ref-for-policy-controlled-feature⑧">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
+   <a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-domhighrestimestamp">7.1. The Sensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-time-origin">
+   <a href="https://www.w3.org/TR/hr-time-2/#dfn-time-origin">https://www.w3.org/TR/hr-time-2/#dfn-time-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-time-origin">6.2. Sensor</a>
+    <li><a href="#ref-for-dfn-time-origin①">7.1.3. Sensor internal slots</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-eventhandler">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventhandler">7.1. The Sensor Interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a>
+    <li><a href="#ref-for-eventhandler③">7.1.9. Sensor.onreading</a>
+    <li><a href="#ref-for-eventhandler④">7.1.10. Sensor.onactivate</a>
+    <li><a href="#ref-for-eventhandler⑤">7.1.11. Sensor.onerror</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-active-document">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-active-document">4.2.3. Focused Area</a>
+    <li><a href="#ref-for-active-document①">4.2.4. Visibility State</a>
+    <li><a href="#ref-for-active-document②">5.6. Conditions to expose sensor readings</a> <a href="#ref-for-active-document③">(2)</a>
+    <li><a href="#ref-for-active-document④">6.2. Sensor</a> <a href="#ref-for-active-document⑤">(2)</a>
+    <li><a href="#ref-for-active-document⑥">8.2. Check sensor policy-controlled features</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context">4.2.3. Focused Area</a>
+    <li><a href="#ref-for-browsing-context①">6.2. Sensor</a> <a href="#ref-for-browsing-context②">(2)</a> <a href="#ref-for-browsing-context③">(3)</a> <a href="#ref-for-browsing-context④">(4)</a> <a href="#ref-for-browsing-context⑤">(5)</a> <a href="#ref-for-browsing-context⑥">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context">4.2.3. Focused Area</a>
+    <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context①">5.6. Conditions to expose sensor readings</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-event-handlers">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-handlers">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-event-handlers①">7.1.12. Event handlers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-handler-event-type">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-event-handler-event-type①">7.1.12. Event handlers</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-gains-focus">
+   <a href="https://html.spec.whatwg.org/multipage/interaction.html#gains-focus">https://html.spec.whatwg.org/multipage/interaction.html#gains-focus</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-gains-focus">4.2.3. Focused Area</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-in-parallel">
+   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-in-parallel">7.1.7. Sensor.start()</a>
+    <li><a href="#ref-for-in-parallel①">7.1.8. Sensor.stop()</a>
+    <li><a href="#ref-for-in-parallel②">8.8. Update latest reading</a>
+    <li><a href="#ref-for-in-parallel③">8.15. Request sensor access</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-origin-2">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#origin-2">https://html.spec.whatwg.org/multipage/origin.html#origin-2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-origin-2">6.2. Sensor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-responsible-document">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-responsible-document">5.6. Conditions to expose sensor readings</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-same-origin-domain">4.2.3. Focused Area</a>
+    <li><a href="#ref-for-same-origin-domain①">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-same-origin-domain②">6.2. Sensor</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-spin-the-event-loop">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-spin-the-event-loop">8.10. Report latest reading updated</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-task">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-task">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-concept-task①">8.5. Deactivate a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-task-queue">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-task-queue">8.5. Deactivate a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-task-source">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-task-source">7.1. The Sensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-set-append">
+   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-set-append">8.4. Activate a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-contain">
+   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-contain">6.1. Sensor Type</a>
+    <li><a href="#ref-for-list-contain①">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-list-contain②">8.5. Deactivate a sensor object</a>
+    <li><a href="#ref-for-list-contain③">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-entry">
+   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-entry">6.2. Sensor</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a> <a href="#ref-for-map-entry③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-iterate">
+   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-iterate">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-map-iterate①">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-map-iterate②">8.8. Update latest reading</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-is-empty">
+   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-is-empty">6.1. Sensor Type</a> <a href="#ref-for-list-is-empty①">(2)</a>
+    <li><a href="#ref-for-list-is-empty②">6.2. Sensor</a> <a href="#ref-for-list-is-empty③">(2)</a>
+    <li><a href="#ref-for-list-is-empty④">8.7. Set sensor settings</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-key">
+   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-key">6.2. Sensor</a> <a href="#ref-for-map-key①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ordered-map">
+   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ordered-map">6.2. Sensor</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a> <a href="#ref-for-ordered-map③">(4)</a> <a href="#ref-for-ordered-map④">(5)</a> <a href="#ref-for-ordered-map⑤">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ordered-set">
+   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ordered-set">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-ordered-set①">6.1. Sensor Type</a> <a href="#ref-for-ordered-set②">(2)</a> <a href="#ref-for-ordered-set③">(3)</a> <a href="#ref-for-ordered-set④">(4)</a>
+    <li><a href="#ref-for-ordered-set⑤">6.2. Sensor</a> <a href="#ref-for-ordered-set⑥">(2)</a> <a href="#ref-for-ordered-set⑦">(3)</a>
+    <li><a href="#ref-for-ordered-set⑧">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-ordered-set⑨">8.8. Update latest reading</a>
+    <li><a href="#ref-for-ordered-set①⓪">8.15. Request sensor access</a>
+    <li><a href="#ref-for-ordered-set①①">9.6. Definition Requirements</a>
+    <li><a href="#ref-for-ordered-set①②">9.8. Extending the Feature Policy API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-remove">
+   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-remove">8.5. Deactivate a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-set">
+   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-set">8.7. Set sensor settings</a>
+    <li><a href="#ref-for-map-set①">8.8. Update latest reading</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-map-value">
+   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-map-value">6.2. Sensor</a> <a href="#ref-for-map-value①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
+   <a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-visibilitystate">5.6. Conditions to expose sensor readings</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-steps-to-determine-the-visibility-state">
+   <a href="https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state">https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-steps-to-determine-the-visibility-state">4.2.4. Visibility State</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dictdef-permissiondescriptor">
+   <a href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor">https://w3c.github.io/permissions/#dictdef-permissiondescriptor</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-permissiondescriptor">9.7. Extending the Permission API</a> <a href="#ref-for-dictdef-permissiondescriptor①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-enumdef-permissionname">
+   <a href="https://w3c.github.io/permissions/#enumdef-permissionname">https://w3c.github.io/permissions/#enumdef-permissionname</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-permissionname③">6.1. Sensor Type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-new-information-about-the-users-intent">
+   <a href="https://w3c.github.io/permissions/#new-information-about-the-users-intent">https://w3c.github.io/permissions/#new-information-about-the-users-intent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-new-information-about-the-users-intent">4. Security and privacy considerations</a>
+    <li><a href="#ref-for-new-information-about-the-users-intent①">4.2.5. Permissions API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-enumdef-permissionname">
+   <a href="https://www.w3.org/TR/permissions/#enumdef-permissionname">https://www.w3.org/TR/permissions/#enumdef-permissionname</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-permissionname">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-enumdef-permissionname①">6.1. Sensor Type</a> <a href="#ref-for-enumdef-permissionname②">(2)</a>
+    <li><a href="#ref-for-enumdef-permissionname④">9.6. Definition Requirements</a> <a href="#ref-for-enumdef-permissionname⑤">(2)</a>
+    <li><a href="#ref-for-enumdef-permissionname⑥">9.7. Extending the Permission API</a> <a href="#ref-for-enumdef-permissionname⑦">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-permission-revocation-algorithm">
+   <a href="https://w3c.github.io/permissions/#permission-revocation-algorithm">https://w3c.github.io/permissions/#permission-revocation-algorithm</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-permission-revocation-algorithm">6.1. Sensor Type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-permission-state">
+   <a href="https://www.w3.org/TR/permissions/#permission-state">https://www.w3.org/TR/permissions/#permission-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-permission-state">5.6. Conditions to expose sensor readings</a>
+    <li><a href="#ref-for-permission-state①">8.15. Request sensor access</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-request-permission-to-use">
+   <a href="https://w3c.github.io/permissions/#request-permission-to-use">https://w3c.github.io/permissions/#request-permission-to-use</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-request-permission-to-use">8.15. Request sensor access</a>
+    <li><a href="#ref-for-request-permission-to-use①">9.7. Extending the Permission API</a> <a href="#ref-for-request-permission-to-use②">(2)</a> <a href="#ref-for-request-permission-to-use③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-secure-contexts">
+   <a href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts">https://w3c.github.io/webappsec-secure-contexts/#secure-contexts</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-secure-contexts">4.2.1. Secure Context</a>
+    <li><a href="#ref-for-secure-contexts①">5.6. Conditions to expose sensor readings</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-sop-violations">
+   <a href="https://w3ctag.github.io/security-questionnaire/#sop-violations">https://w3ctag.github.io/security-questionnaire/#sop-violations</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sop-violations">9.1. Security and Privacy</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Constructor">
+   <a href="https://heycam.github.io/webidl/#Constructor">https://heycam.github.io/webidl/#Constructor</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Constructor">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
+   <a href="https://heycam.github.io/webidl/#idl-DOMException">https://heycam.github.io/webidl/#idl-DOMException</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMException">7.1.7. Sensor.start()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
+    <li><a href="#ref-for-idl-DOMException②">7.2. The SensorErrorEvent Interface</a> <a href="#ref-for-idl-DOMException③">(2)</a>
+    <li><a href="#ref-for-idl-DOMException④">7.2.1. SensorErrorEvent.error</a>
+    <li><a href="#ref-for-idl-DOMException⑤">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-idl-DOMException⑥">8.6. Revoke sensor permission</a>
+    <li><a href="#ref-for-idl-DOMException⑦">8.13. Notify error</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
+   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMString">7.2. The SensorErrorEvent Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-Exposed①">7.2. The SensorErrorEvent Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-notallowederror">
+   <a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notallowederror">7.1.7. Sensor.start()</a>
+    <li><a href="#ref-for-notallowederror①">8.6. Revoke sensor permission</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-notreadableerror">
+   <a href="https://heycam.github.io/webidl/#notreadableerror">https://heycam.github.io/webidl/#notreadableerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notreadableerror">7.1.7. Sensor.start()</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-notsupportederror">
+   <a href="https://heycam.github.io/webidl/#notsupportederror">https://heycam.github.io/webidl/#notsupportederror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-notsupportederror">8.1. Initialize a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-SecureContext">
+   <a href="https://heycam.github.io/webidl/#SecureContext">https://heycam.github.io/webidl/#SecureContext</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-SecureContext">7.1. The Sensor Interface</a>
+    <li><a href="#ref-for-SecureContext①">7.2. The SensorErrorEvent Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-attribute">
+   <a href="https://heycam.github.io/webidl/#dfn-attribute">https://heycam.github.io/webidl/#dfn-attribute</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-attribute">6.2. Sensor</a> <a href="#ref-for-dfn-attribute①">(2)</a> <a href="#ref-for-dfn-attribute②">(3)</a>
+    <li><a href="#ref-for-dfn-attribute③">9.6. Definition Requirements</a> <a href="#ref-for-dfn-attribute④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-boolean">
+   <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-boolean">7.1. The Sensor Interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
+   <a href="https://heycam.github.io/webidl/#dfn-create-exception">https://heycam.github.io/webidl/#dfn-create-exception</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-create-exception">7.1.7. Sensor.start()</a> <a href="#ref-for-dfn-create-exception①">(2)</a>
+    <li><a href="#ref-for-dfn-create-exception②">8.6. Revoke sensor permission</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-dictionary">
+   <a href="https://heycam.github.io/webidl/#dfn-dictionary">https://heycam.github.io/webidl/#dfn-dictionary</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-dictionary">8.1. Initialize a sensor object</a>
+    <li><a href="#ref-for-dfn-dictionary①">9.6. Definition Requirements</a> <a href="#ref-for-dfn-dictionary②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-double">
+   <a href="https://heycam.github.io/webidl/#idl-double">https://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-double">7.1. The Sensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-exception-type">
+   <a href="https://heycam.github.io/webidl/#dfn-exception-type">https://heycam.github.io/webidl/#dfn-exception-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-exception-type">7.1.11. Sensor.onerror</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
+   <a href="https://heycam.github.io/webidl/#dfn-identifier">https://heycam.github.io/webidl/#dfn-identifier</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-identifier">6.2. Sensor</a> <a href="#ref-for-dfn-identifier①">(2)</a>
+    <li><a href="#ref-for-dfn-identifier②">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-inherited-dictionaries">
+   <a href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">https://heycam.github.io/webidl/#dfn-inherited-dictionaries</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-inherited-dictionaries">9.6. Definition Requirements</a> <a href="#ref-for-dfn-inherited-dictionaries①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-inherited-interfaces">
+   <a href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">https://heycam.github.io/webidl/#dfn-inherited-interfaces</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-inherited-interfaces">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-interface">
+   <a href="https://heycam.github.io/webidl/#dfn-interface">https://heycam.github.io/webidl/#dfn-interface</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-interface">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-present">
+   <a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-present">8.1. Initialize a sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-read-only">
+   <a href="https://heycam.github.io/webidl/#dfn-read-only">https://heycam.github.io/webidl/#dfn-read-only</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-read-only">9.6. Definition Requirements</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-throw">
+   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-throw">8.1. Initialize a sensor object</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
-     <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
-     <li><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a>
-     <li><a href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-document">document</a>
-     <li><a href="https://dom.spec.whatwg.org#concept-event">event</a>
-     <li><a href="https://dom.spec.whatwg.org#concept-event-listener">event listener</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a>
+     <li><span class="dfn-paneled" id="term-for-event" style="color:initial">Event</span>
+     <li><span class="dfn-paneled" id="term-for-dictdef-eventinit" style="color:initial">EventInit</span>
+     <li><span class="dfn-paneled" id="term-for-eventtarget" style="color:initial">EventTarget</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
+     <li><span class="dfn-paneled" id="term-for-concept-event" style="color:initial">event</span>
+     <li><span class="dfn-paneled" id="term-for-concept-event-listener" style="color:initial">event listener</span>
+     <li><span class="dfn-paneled" id="term-for-concept-event-fire" style="color:initial">fire an event</span>
     </ul>
    <li>
     <a data-link-type="biblio">[FEATURE-POLICY]</a> defines the following terms:
     <ul>
-     <li><a href="https://wicg.github.io/feature-policy/#iframe-allow-attribute">allow attribute</a>
-     <li><a href="https://wicg.github.io/feature-policy/#allowed-to-use">allowed to use</a>
-     <li><a href="https://wicg.github.io/feature-policy/#default-allowlist">default allowlist</a>
-     <li><a href="https://wicg.github.io/feature-policy/#policy-controlled-feature">policy-controlled feature</a>
+     <li><span class="dfn-paneled" id="term-for-iframe-allow-attribute" style="color:initial">allow attribute</span>
+     <li><span class="dfn-paneled" id="term-for-allowed-to-use" style="color:initial">allowed to use</span>
+     <li><span class="dfn-paneled" id="term-for-default-allowlist" style="color:initial">default allowlist</span>
+     <li><span class="dfn-paneled" id="term-for-policy-controlled-feature" style="color:initial">policy-controlled feature</span>
     </ul>
    <li>
     <a data-link-type="biblio">[hr-time-2]</a> defines the following terms:
     <ul>
-     <li><a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">DOMHighResTimeStamp</a>
-     <li><a href="https://www.w3.org/TR/hr-time-2/#dfn-time-origin">time origin</a>
+     <li><span class="dfn-paneled" id="term-for-dom-domhighrestimestamp" style="color:initial">DOMHighResTimeStamp</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-time-origin" style="color:initial">time origin</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">currently focused area</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#gains-focus">gains focus</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#origin-2">origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">same origin-domain</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">spin the event loop</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queue</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>
+     <li><span class="dfn-paneled" id="term-for-eventhandler" style="color:initial">EventHandler</span>
+     <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-currently-focused-area-of-a-top-level-browsing-context" style="color:initial">currently focused area</span>
+     <li><span class="dfn-paneled" id="term-for-event-handlers" style="color:initial">event handler</span>
+     <li><span class="dfn-paneled" id="term-for-event-handler-event-type" style="color:initial">event handler event type</span>
+     <li><span class="dfn-paneled" id="term-for-gains-focus" style="color:initial">gains focus</span>
+     <li><span class="dfn-paneled" id="term-for-in-parallel" style="color:initial">in parallel</span>
+     <li><span class="dfn-paneled" id="term-for-origin-2" style="color:initial">origin</span>
+     <li><span class="dfn-paneled" id="term-for-responsible-document" style="color:initial">responsible document</span>
+     <li><span class="dfn-paneled" id="term-for-same-origin-domain" style="color:initial">same origin-domain</span>
+     <li><span class="dfn-paneled" id="term-for-spin-the-event-loop" style="color:initial">spin the event loop</span>
+     <li><span class="dfn-paneled" id="term-for-concept-task" style="color:initial">task</span>
+     <li><span class="dfn-paneled" id="term-for-task-queue" style="color:initial">task queue</span>
+     <li><span class="dfn-paneled" id="term-for-task-source" style="color:initial">task source</span>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
-     <li><a href="https://infra.spec.whatwg.org/#set-append">append</a>
-     <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-entry">entry</a>
-     <li><a href="https://infra.spec.whatwg.org/#list-iterate">for each <small>(for list)</small></a>
-     <li><a href="https://infra.spec.whatwg.org/#map-iterate">for each <small>(for map)</small></a>
-     <li><a href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
-     <li><a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>
-     <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
-     <li><a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-set">set</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
+     <li><span class="dfn-paneled" id="term-for-set-append" style="color:initial">append</span>
+     <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
+     <li><span class="dfn-paneled" id="term-for-map-entry" style="color:initial">entry</span>
+     <li><span class="dfn-paneled" id="term-for-map-iterate" style="color:initial">for each <small>(for map)</small></span>
+     <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
+     <li><span class="dfn-paneled" id="term-for-map-key" style="color:initial">key</span>
+     <li><span class="dfn-paneled" id="term-for-ordered-map" style="color:initial">ordered map</span>
+     <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
+     <li><span class="dfn-paneled" id="term-for-list-remove" style="color:initial">remove</span>
+     <li><span class="dfn-paneled" id="term-for-map-set" style="color:initial">set</span>
+     <li><span class="dfn-paneled" id="term-for-map-value" style="color:initial">value</span>
     </ul>
    <li>
     <a data-link-type="biblio">[page-visibility]</a> defines the following terms:
     <ul>
-     <li><a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">document visibility state</a>
-     <li><a href="https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state">steps to determine the visibility state</a>
+     <li><span class="dfn-paneled" id="term-for-dom-visibilitystate" style="color:initial">document visibility state</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-steps-to-determine-the-visibility-state" style="color:initial">steps to determine the visibility state</span>
     </ul>
    <li>
     <a data-link-type="biblio">[PERMISSIONS]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor">PermissionDescriptor</a>
-     <li><a href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a>
-     <li><a href="https://w3c.github.io/permissions/#new-information-about-the-users-intent">new information about the user's intent</a>
-     <li><a href="https://www.w3.org/TR/permissions/#enumdef-permissionname">permission name</a>
-     <li><a href="https://w3c.github.io/permissions/#permission-revocation-algorithm">permission revocation algorithm</a>
-     <li><a href="https://www.w3.org/TR/permissions/#permission-state">permission state</a>
-     <li><a href="https://w3c.github.io/permissions/#request-permission-to-use">request permission to use</a>
+     <li><span class="dfn-paneled" id="term-for-dictdef-permissiondescriptor" style="color:initial">PermissionDescriptor</span>
+     <li><span class="dfn-paneled" id="term-for-enumdef-permissionname" style="color:initial">PermissionName</span>
+     <li><span class="dfn-paneled" id="term-for-new-information-about-the-users-intent" style="color:initial">new information about the user's intent</span>
+     <li><span class="dfn-paneled" id="term-for-enumdef-permissionname①" style="color:initial">permission name</span>
+     <li><span class="dfn-paneled" id="term-for-permission-revocation-algorithm" style="color:initial">permission revocation algorithm</span>
+     <li><span class="dfn-paneled" id="term-for-permission-state" style="color:initial">permission state</span>
+     <li><span class="dfn-paneled" id="term-for-request-permission-to-use" style="color:initial">request permission to use</span>
     </ul>
    <li>
     <a data-link-type="biblio">[POWERFUL-FEATURES]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts">secure contexts</a>
+     <li><span class="dfn-paneled" id="term-for-secure-contexts" style="color:initial">secure contexts</span>
     </ul>
    <li>
     <a data-link-type="biblio">[SECURITY-PRIVACY-QUESTIONNAIRE]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3ctag.github.io/security-questionnaire/#sop-violations">same-origin policy violations</a>
+     <li><span class="dfn-paneled" id="term-for-sop-violations" style="color:initial">same-origin policy violations</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#Constructor">Constructor</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
-     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
-     <li><a href="https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a>
-     <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
-     <li><a href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a>
-     <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-attribute">attribute</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-dictionary">dictionary</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-exception-type">exception types</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-identifier">identifier</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries">inherited dictionaries</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-interface">interface</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-read-only">read only</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
+     <li><span class="dfn-paneled" id="term-for-Constructor" style="color:initial">Constructor</span>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMException" style="color:initial">DOMException</span>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMString" style="color:initial">DOMString</span>
+     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-notallowederror" style="color:initial">NotAllowedError</span>
+     <li><span class="dfn-paneled" id="term-for-notreadableerror" style="color:initial">NotReadableError</span>
+     <li><span class="dfn-paneled" id="term-for-notsupportederror" style="color:initial">NotSupportedError</span>
+     <li><span class="dfn-paneled" id="term-for-SecureContext" style="color:initial">SecureContext</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-attribute" style="color:initial">attribute</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-create-exception" style="color:initial">created</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-dictionary" style="color:initial">dictionary</span>
+     <li><span class="dfn-paneled" id="term-for-idl-double" style="color:initial">double</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-exception-type" style="color:initial">exception types</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-identifier" style="color:initial">identifier</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-inherited-dictionaries" style="color:initial">inherited dictionaries</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-inherited-interfaces" style="color:initial">inherited interfaces</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-interface" style="color:initial">interface</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-present" style="color:initial">present</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-read-only" style="color:initial">read only</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-throw" style="color:initial">throw</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -3597,30 +4130,30 @@ for their editorial input.</p>
    <dd>Maryam Mehrnezhad, Ehsan Toreini, Siamak F. Shahandashti, Feng Hao. <a href="https://rd.springer.com/article/10.1007/s10207-017-0369-x?wt_mc=Internal.Event.1.SEM.ArticleAuthorOnlineFirst">Stealing PINs via mobile sensors: actual risk versus user perception</a>. 2017. Informational. URL: <a href="https://rd.springer.com/article/10.1007/s10207-017-0369-x?wt_mc=Internal.Event.1.SEM.ArticleAuthorOnlineFirst">https://rd.springer.com/article/10.1007/s10207-017-0369-x?wt_mc=Internal.Event.1.SEM.ArticleAuthorOnlineFirst</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#sensor"><code>Sensor</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><span class="kt">boolean</span></a> <a class="nv" data-readonly="" data-type="boolean" href="#dom-sensor-activated"><code>activated</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><span class="kt">boolean</span></a> <a class="nv" data-readonly="" data-type="boolean" href="#dom-sensor-hasreading"><code>hasReading</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①">DOMHighResTimeStamp</a>? <a class="nv" data-readonly="" data-type="DOMHighResTimeStamp?" href="#dom-sensor-timestamp"><code>timestamp</code></a>;
-  <span class="kt">void</span> <a class="nv" href="#dom-sensor-start"><code>start</code></a>();
-  <span class="kt">void</span> <a class="nv" href="#dom-sensor-stop"><code>stop</code></a>();
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler⑥">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onreading"><code>onreading</code></a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①①">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onactivate"><code>onactivate</code></a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler②①">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-sensor-onerror"><code>onerror</code></a>;
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#sensor"><code><c- g>Sensor</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①"><c- n>EventTarget</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-sensor-activated"><code><c- g>activated</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-sensor-hasreading"><code><c- g>hasReading</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a>? <a data-readonly data-type="DOMHighResTimeStamp?" href="#dom-sensor-timestamp"><code><c- g>timestamp</c-></code></a>;
+  <c- b>void</c-> <a href="#dom-sensor-start"><code><c- g>start</c-></code></a>();
+  <c- b>void</c-> <a href="#dom-sensor-stop"><code><c- g>stop</c-></code></a>();
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler⑥"><c- n>EventHandler</c-></a> <a data-type="EventHandler" href="#dom-sensor-onreading"><code><c- g>onreading</c-></code></a>;
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①①"><c- n>EventHandler</c-></a> <a data-type="EventHandler" href="#dom-sensor-onactivate"><code><c- g>onactivate</c-></code></a>;
+  <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler②①"><c- n>EventHandler</c-></a> <a data-type="EventHandler" href="#dom-sensor-onerror"><code><c- g>onerror</c-></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensoroptions"><code>SensorOptions</code></a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a> <a class="nv" data-type="double " href="#dom-sensoroptions-frequency"><code>frequency</code></a>;
+<c- b>dictionary</c-> <a href="#dictdef-sensoroptions"><code><c- g>SensorOptions</c-></code></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a data-type="double " href="#dom-sensoroptions-frequency"><code><c- g>frequency</c-></code></a>;
 };
 
-[<a class="nv" href="#dom-sensorerrorevent-sensorerrorevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit②">SensorErrorEventInit</a> <a class="nv" href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code>errorEventInitDict</code></a>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#sensorerrorevent"><code>SensorErrorEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②①">DOMException</a> <a class="nv" data-readonly="" data-type="DOMException" href="#dom-sensorerrorevent-error"><code>error</code></a>;
+[<a href="#dom-sensorerrorevent-sensorerrorevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <a href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit②"><c- n>SensorErrorEventInit</c-></a> <a href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code><c- g>errorEventInitDict</c-></code></a>),
+ <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#sensorerrorevent"><code><c- g>SensorErrorEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①"><c- n>Event</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②①"><c- n>DOMException</c-></a> <a data-readonly data-type="DOMException" href="#dom-sensorerrorevent-error"><code><c- g>error</c-></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-sensorerroreventinit"><code>SensorErrorEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①">EventInit</a> {
-  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException③①">DOMException</a> <a class="nv" data-type="DOMException " href="#dom-sensorerroreventinit-error"><code>error</code></a>;
+<c- b>dictionary</c-> <a href="#dictdef-sensorerroreventinit"><code><c- g>SensorErrorEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①"><c- n>EventInit</c-></a> {
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException③①"><c- n>DOMException</c-></a> <a data-type="DOMException " href="#dom-sensorerroreventinit-error"><code><c- g>error</c-></code></a>;
 };
 
 </pre>
@@ -4186,60 +4719,143 @@ for their editorial input.</p>
     <li><a href="#ref-for-supported-sensor-options①">9.6. Definition Requirements</a> <a href="#ref-for-supported-sensor-options②">(2)</a>
    </ul>
   </aside>
+<script>/* script-var-click-highlighting */
+
+    document.addEventListener("click", e=>{
+        if(e.target.nodeName == "VAR") {
+            highlightSameAlgoVars(e.target);
+        }
+    });
+    {
+        const indexCounts = new Map();
+        const indexNames = new Map();
+        function highlightSameAlgoVars(v) {
+            // Find the algorithm container.
+            let algoContainer = null;
+            let searchEl = v;
+            while(algoContainer == null && searchEl != document.body) {
+                searchEl = searchEl.parentNode;
+                if(searchEl.hasAttribute("data-algorithm")) {
+                    algoContainer = searchEl;
+                }
+            }
+
+            // Not highlighting document-global vars,
+            // too likely to be unrelated.
+            if(algoContainer == null) return;
+
+            const algoName = algoContainer.getAttribute("data-algorithm");
+            const varName = getVarName(v);
+            const addClass = !v.classList.contains("selected");
+            let highlightClass = null;
+            if(addClass) {
+                const index = chooseHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] += 1;
+                indexNames.set(algoName+"///"+varName, index);
+                highlightClass = nameFromIndex(index);
+            } else {
+                const index = previousHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] -= 1;
+                highlightClass = nameFromIndex(index);
+            }
+
+            // Find all same-name vars, and toggle their class appropriately.
+            for(const el of algoContainer.querySelectorAll("var")) {
+                if(getVarName(el) == varName) {
+                    el.classList.toggle("selected", addClass);
+                    el.classList.toggle(highlightClass, addClass);
+                }
+            }
+        }
+        function getVarName(el) {
+            return el.textContent.replace(/(\s| )+/, " ").trim();
+        }
+        function chooseHighlightIndex(algoName, varName) {
+            let indexes = null;
+            if(indexCounts.has(algoName)) {
+                indexes = indexCounts.get(algoName);
+            } else {
+                // 7 classes right now
+                indexes = [0,0,0,0,0,0,0];
+                indexCounts.set(algoName, indexes);
+            }
+
+            // If the element was recently unclicked,
+            // *and* that color is still unclaimed,
+            // give it back the same color.
+            const lastIndex = previousHighlightIndex(algoName, varName);
+            if(indexes[lastIndex] === 0) return lastIndex;
+
+            // Find the earliest index with the lowest count.
+            const minCount = Math.min.apply(null, indexes);
+            let index = null;
+            for(var i = 0; i < indexes.length; i++) {
+                if(indexes[i] == minCount) {
+                    return i;
+                }
+            }
+        }
+        function previousHighlightIndex(algoName, varName) {
+            return indexNames.get(algoName+"///"+varName);
+        }
+        function nameFromIndex(index) {
+            return "selected" + index;
+        }
+    }
+    </script>
 <script>/* script-dfn-panel */
 
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    console.log(dfnPanel);
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
         });
-        </script>
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>


### PR DESCRIPTION
"Eligible for garbage collection" can sound ambiguous and lead to
implementers thinking this is a step that happens prior to garbage
collection itself, whereas the original intent of the text added in pull
request #248 ("Be explicit about steps taken when a Sensor instance is
GCed") was that a sensor that _is being GCed_ must be deactivated if
necessary.

Fixes #372.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/373.html" title="Last updated on Sep 25, 2018, 11:16 AM GMT (d603fa6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/373/231ea4f...rakuco:d603fa6.html" title="Last updated on Sep 25, 2018, 11:16 AM GMT (d603fa6)">Diff</a>