### PR TITLE
Export MockSensorType enum

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1671,19 +1671,21 @@ using the <i>JSON Key</i> and the associated field's value from the available [=
 
 A <dfn>mock sensor type</dfn> is equivalent to a [=sensor type=]'s associated {{Sensor}} subclass.
 
-<pre class="idl">
-enum MockSensorType {
-  "ambient-light",
-  "accelerometer",
-  "linear-acceleration",
-  "gravity",
-  "gyroscope",
-  "magnetometer",
-  "uncalibrated-magnetometer",
-  "absolute-orientation",
-  "relative-orientation",
-  "geolocation",
-  "proximity",
+<!-- IDL blocks can't be linked outside the current spec, but these enum-values are
+     supposed to be defined in concrete sensor specs. -->
+<pre class="idl" link-for="MockSensorType">
+enum <dfn enum>MockSensorType</dfn> {
+  <a enum-value>"ambient-light"</a>,
+  <a enum-value>"accelerometer"</a>,
+  <a enum-value>"linear-acceleration"</a>,
+  <a enum-value>"gravity"</a>,
+  <a enum-value>"gyroscope"</a>,
+  <a enum-value>"magnetometer"</a>,
+  <a enum-value>"uncalibrated-magnetometer"</a>,
+  <a enum-value>"absolute-orientation"</a>,
+  <a enum-value>"relative-orientation"</a>,
+  <a enum-value>"geolocation"</a>,
+  <a enum-value>"proximity"</a>,
 };
 </pre>
 

--- a/index.html
+++ b/index.html
@@ -1221,7 +1221,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
-  <meta content="c64af879882536df35c11bbe417567bbd6256bb0" name="document-revision">
+  <meta content="feebed0ad60dde50934e07bb3d09d7244f449f17" name="document-revision">
 <style>
     svg g.edge text {
         font-size: 8px;
@@ -1501,7 +1501,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-18">18 January 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-25">25 January 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
IDL blocks can't be linked outside the current spec, but the "MockSensorType" enum are supposed to be
defined in concrete sensor specs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/sensors/pull/379.html" title="Last updated on Jan 25, 2019, 6:11 AM UTC (f1af137)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/379/34e081c...Honry:f1af137.html" title="Last updated on Jan 25, 2019, 6:11 AM UTC (f1af137)">Diff</a>