### PR TITLE
Remove concrete MockSensorReadingValues dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1690,6 +1690,40 @@ enum <dfn enum>MockSensorType</dfn> {
 </pre>
 
 Each enumeration value in the {{MockSensorType}} enum identifies a [=mock sensor type=].
+
+: <dfn for="MockSensorType" enum-value>"ambient-light"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=AmbientLightSensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"accelerometer"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=Accelerometer=] interface.
+
+: <dfn for="MockSensorType" enum-value>"linear-acceleration"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=LinearAccelerationSensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"gravity"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=GravitySensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"gyroscope"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=Gyroscope=] interface.
+
+: <dfn for="MockSensorType" enum-value>"magnetometer"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=Magnetometer=] interface.
+
+: <dfn for="MockSensorType" enum-value>"uncalibrated-magnetometer"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=UncalibratedMagnetometer=] interface.
+
+: <dfn for="MockSensorType" enum-value>"absolute-orientation"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=AbsoluteOrientationSensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"relative-orientation"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=RelativeOrientationSensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"geolocation"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=GeolocationSensor=] interface.
+
+: <dfn for="MockSensorType" enum-value>"proximity"</dfn>
+:: A [=mock sensor type=] associated with the usage of the [=ProximitySensor=] interface.
+
 Each [=mock sensor type=] has a [=mock sensor reading values=] dictionary:
 
 : <dfn export>Mock Sensor Reading Values</dfn> dictionary
@@ -1697,204 +1731,12 @@ Each [=mock sensor type=] has a [=mock sensor reading values=] dictionary:
    [[#update-mock-sensor-reading-command|updating a mock sensor reading]]. Its members must match the
    [=attribute=] [=identifier=] defined by the [=sensor type=]'s
    associated [=extension sensor interface=]. Each [=mock sensor type=]
-   has a specific {{MockSensorReadingValues}}, which is defined in each section of [[#section-mock-sensor-type|mock sensor type]].
+   has a specific {{MockSensorReadingValues}}, which is defined in each [=extension specifications=].
 
    <pre class="idl">
    dictionary MockSensorReadingValues {
    };
    </pre>
-
-#### Ambient Light Sensor #### {#mock-ambient-light-sensor}
-
-The <dfn for="MockSensorType" enum-value>"ambient-light"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=AmbientLightSensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary AmbientLightReadingValues {
-      required double? illuminance;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Accelerometer #### {#mock-accelerometer}
-
-The <dfn for="MockSensorType" enum-value>"accelerometer"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=Accelerometer=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary AccelerometerReadingValues {
-      required double? x;
-      required double? y;
-      required double? z;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Linear Acceleration Sensor #### {#mock-linear-acceleration-sensor}
-
-The <dfn for="MockSensorType" enum-value>"linear-acceleration"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=LinearAccelerationSensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary LinearAccelerationReadingValues : AccelerometerReadingValues {
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Gravity Sensor #### {#mock-gravity}
-
-The <dfn for="MockSensorType" enum-value>"gravity"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=GravitySensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary GravityReadingValues : AccelerometerReadingValues {
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Gyroscope #### {#mock-gyroscope}
-
-The <dfn for="MockSensorType" enum-value>"gyroscope"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=Gyroscope=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary GyroscopeReadingValues {
-      required double? x;
-      required double? y;
-      required double? z;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Magnetometer #### {#mock-magnetometer}
-
-The <dfn for="MockSensorType" enum-value>"magnetometer"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=Magnetometer=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary MagnetometerReadingValues {
-      required double? x;
-      required double? y;
-      required double? z;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Uncalibrated Magnetometer #### {#mock-uncalibrated-magnetometer}
-
-The <dfn for="MockSensorType" enum-value>"uncalibrated-magnetometer"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=UncalibratedMagnetometer=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary UncalibratedMagnetometerReadingValues {
-      required double? x;
-      required double? y;
-      required double? z;
-      required double? xBias;
-      required double? yBias;
-      required double? zBias;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Absolute Orientation Sensor #### {#mock-absolute-orientation-sensor}
-
-The <dfn for="MockSensorType" enum-value>"absolute-orientation"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=AbsoluteOrientationSensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary AbsoluteOrientationReadingValues {
-      required FrozenArray&lt;double>? quaternion;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Relative Orientation Sensor #### {#mock-relative-orientation-sensor}
-
-The <dfn for="MockSensorType" enum-value>"relative-orientation"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=RelativeOrientationSensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary RelativeOrientationReadingValues : AbsoluteOrientationReadingValues {
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Geolocation Sensor #### {#mock-geolocation-sensor}
-
-The <dfn for="MockSensorType" enum-value>"geolocation"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=GeolocationSensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary GeolocationReadingValues {
-      required double? latitude;
-      required double? longitude;
-      required double? altitude;
-      required double? accuracy;
-      required double? altitudeAccuracy;
-      required double? heading;
-      required double? speed;
-    };
-    </pre>
-  </dd>
-</dl>
-
-#### Proximity Sensor #### {#mock-proximity-sensor}
-
-The <dfn for="MockSensorType" enum-value>"proximity"</dfn> type is the [=mock sensor type=]
-associated with the usage of the [=ProximitySensor=] interface.
-
-<dl>
-  <dt>[=Mock Sensor Reading Values=]</dt>
-  <dd>
-    <pre class="idl">
-    dictionary ProximityReadingValues {
-      required double? distance;
-      required double? max;
-      required boolean? near;
-    };
-    </pre>
-  </dd>
-</dl>
 
 <h3 id="section-extension-commands">Extension Commands</h3>
 

--- a/index.html
+++ b/index.html
@@ -1219,9 +1219,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
+  <meta content="Bikeshed version eee3e9e7543e2188fb60d183a6cf3fe3a7d971c1" name="generator">
   <link href="https://www.w3.org/TR/generic-sensor/" rel="canonical">
-  <meta content="feebed0ad60dde50934e07bb3d09d7244f449f17" name="document-revision">
+  <meta content="e6f63e21f86ad83047a68dcc26b7162e64dc5683" name="document-revision">
 <style>
     svg g.edge text {
         font-size: 8px;
@@ -1501,7 +1501,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Generic Sensor API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-25">25 January 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-29">29 January 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1665,21 +1665,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <ol class="toc">
         <li><a href="#dictionary-mocksensorconfiguration"><span class="secno">9.1.1</span> <span class="content">MockSensorConfiguration dictionary</span></a>
         <li><a href="#dictionary-mocksensor"><span class="secno">9.1.2</span> <span class="content">MockSensor dictionary</span></a>
-        <li>
-         <a href="#section-mock-sensor-type"><span class="secno">9.1.3</span> <span class="content">Mock sensor type</span></a>
-         <ol class="toc">
-          <li><a href="#mock-ambient-light-sensor"><span class="secno">9.1.3.1</span> <span class="content">Ambient Light Sensor</span></a>
-          <li><a href="#mock-accelerometer"><span class="secno">9.1.3.2</span> <span class="content">Accelerometer</span></a>
-          <li><a href="#mock-linear-acceleration-sensor"><span class="secno">9.1.3.3</span> <span class="content">Linear Acceleration Sensor</span></a>
-          <li><a href="#mock-gravity"><span class="secno">9.1.3.4</span> <span class="content">Gravity Sensor</span></a>
-          <li><a href="#mock-gyroscope"><span class="secno">9.1.3.5</span> <span class="content">Gyroscope</span></a>
-          <li><a href="#mock-magnetometer"><span class="secno">9.1.3.6</span> <span class="content">Magnetometer</span></a>
-          <li><a href="#mock-uncalibrated-magnetometer"><span class="secno">9.1.3.7</span> <span class="content">Uncalibrated Magnetometer</span></a>
-          <li><a href="#mock-absolute-orientation-sensor"><span class="secno">9.1.3.8</span> <span class="content">Absolute Orientation Sensor</span></a>
-          <li><a href="#mock-relative-orientation-sensor"><span class="secno">9.1.3.9</span> <span class="content">Relative Orientation Sensor</span></a>
-          <li><a href="#mock-geolocation-sensor"><span class="secno">9.1.3.10</span> <span class="content">Geolocation Sensor</span></a>
-          <li><a href="#mock-proximity-sensor"><span class="secno">9.1.3.11</span> <span class="content">Proximity Sensor</span></a>
-         </ol>
+        <li><a href="#section-mock-sensor-type"><span class="secno">9.1.3</span> <span class="content">Mock sensor type</span></a>
        </ol>
       <li>
        <a href="#section-extension-commands"><span class="secno">9.2</span> <span class="content">Extension Commands</span></a>
@@ -3070,140 +3056,49 @@ using the <i>JSON Key</i> and the associated field’s value from the available 
   <a class="idl-code" data-link-type="enum-value" href="#dom-mocksensortype-proximity" id="ref-for-dom-mocksensortype-proximity"><c- s>"proximity"</c-></a>,
 };
 </pre>
-   <p>Each enumeration value in the <code class="idl"><a data-link-type="idl" href="#enumdef-mocksensortype" id="ref-for-enumdef-mocksensortype②">MockSensorType</a></code> enum identifies a <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type②">mock sensor type</a>.
-Each <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type③">mock sensor type</a> has a <a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values">mock sensor reading values</a> dictionary:</p>
+   <p>Each enumeration value in the <code class="idl"><a data-link-type="idl" href="#enumdef-mocksensortype" id="ref-for-enumdef-mocksensortype②">MockSensorType</a></code> enum identifies a <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type②">mock sensor type</a>.</p>
+   <dl>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-ambient-light"><code>"ambient-light"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type③">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/ambient-light#ambient-light-sensor-interface" id="ref-for-ambient-light-sensor-interface">AmbientLightSensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-accelerometer"><code>"accelerometer"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type④">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#accelerometer-interface" id="ref-for-accelerometer-interface">Accelerometer</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-linear-acceleration"><code>"linear-acceleration"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑤">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface" id="ref-for-linearaccelerationsensor-interface">LinearAccelerationSensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-gravity"><code>"gravity"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑥">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#gravitysensor-interface" id="ref-for-gravitysensor-interface">GravitySensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-gyroscope"><code>"gyroscope"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑦">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#gyroscope-interface" id="ref-for-gyroscope-interface">Gyroscope</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-magnetometer"><code>"magnetometer"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑧">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetometer-interface" id="ref-for-magnetometer-interface">Magnetometer</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-uncalibrated-magnetometer"><code>"uncalibrated-magnetometer"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑨">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface" id="ref-for-uncalibrated-magnetometer-interface">UncalibratedMagnetometer</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-absolute-orientation"><code>"absolute-orientation"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①⓪">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface" id="ref-for-absoluteorientationsensor-interface">AbsoluteOrientationSensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-relative-orientation"><code>"relative-orientation"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①①">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface" id="ref-for-relativeorientationsensor-interface">RelativeOrientationSensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-geolocation"><code>"geolocation"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①②">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://wicg.github.io/geolocation-sensor/#geolocationsensor-interface" id="ref-for-geolocationsensor-interface">GeolocationSensor</a> interface.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-proximity"><code>"proximity"</code></dfn>
+    <dd data-md>
+     <p>A <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①③">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/proximity#proximity-sensor-interface" id="ref-for-proximity-sensor-interface">ProximitySensor</a> interface.</p>
+   </dl>
+   <p>Each <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①④">mock sensor type</a> has a <a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values">mock sensor reading values</a> dictionary:</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="mock-sensor-reading-values">Mock Sensor Reading Values</dfn> dictionary
     <dd data-md>
      <p><code class="idl"><a data-link-type="idl" href="#dictdef-mocksensorreadingvalues" id="ref-for-dictdef-mocksensorreadingvalues①">MockSensorReadingValues</a></code> dictionary represents a user-specified <a data-link-type="dfn" href="#mock-sensor-reading" id="ref-for-mock-sensor-reading⑥">mock sensor reading</a> used for <a href="#update-mock-sensor-reading-command">updating a mock sensor reading</a>. Its members must match the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier③">identifier</a> defined by the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③③">sensor type</a>'s
- associated <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface③">extension sensor interface</a>. Each <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type④">mock sensor type</a> has a specific <code class="idl"><a data-link-type="idl" href="#dictdef-mocksensorreadingvalues" id="ref-for-dictdef-mocksensorreadingvalues②">MockSensorReadingValues</a></code>, which is defined in each section of <a href="#section-mock-sensor-type">mock sensor type</a>.</p>
+ associated <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface③">extension sensor interface</a>. Each <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①⑤">mock sensor type</a> has a specific <code class="idl"><a data-link-type="idl" href="#dictdef-mocksensorreadingvalues" id="ref-for-dictdef-mocksensorreadingvalues②">MockSensorReadingValues</a></code>, which is defined in each <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑤">extension specifications</a>.</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-mocksensorreadingvalues"><code><c- g>MockSensorReadingValues</c-></code></dfn> {
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.1" id="mock-ambient-light-sensor"><span class="secno">9.1.3.1. </span><span class="content">Ambient Light Sensor</span><a class="self-link" href="#mock-ambient-light-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-ambient-light"><code>"ambient-light"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑤">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/ambient-light#ambient-light-sensor-interface" id="ref-for-ambient-light-sensor-interface">AmbientLightSensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values①">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-ambientlightreadingvalues"><code><c- g>AmbientLightReadingValues</c-></code><a class="self-link" href="#dictdef-ambientlightreadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="AmbientLightReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-ambientlightreadingvalues-illuminance"><code><c- g>illuminance</c-></code><a class="self-link" href="#dom-ambientlightreadingvalues-illuminance"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.2" id="mock-accelerometer"><span class="secno">9.1.3.2. </span><span class="content">Accelerometer</span><a class="self-link" href="#mock-accelerometer"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-accelerometer"><code>"accelerometer"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑥">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#accelerometer-interface" id="ref-for-accelerometer-interface">Accelerometer</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values②">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-accelerometerreadingvalues"><code><c- g>AccelerometerReadingValues</c-></code></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="AccelerometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-accelerometerreadingvalues-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-accelerometerreadingvalues-x"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="AccelerometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-accelerometerreadingvalues-y"><code><c- g>y</c-></code><a class="self-link" href="#dom-accelerometerreadingvalues-y"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="AccelerometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-accelerometerreadingvalues-z"><code><c- g>z</c-></code><a class="self-link" href="#dom-accelerometerreadingvalues-z"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.3" id="mock-linear-acceleration-sensor"><span class="secno">9.1.3.3. </span><span class="content">Linear Acceleration Sensor</span><a class="self-link" href="#mock-linear-acceleration-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-linear-acceleration"><code>"linear-acceleration"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑦">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface" id="ref-for-linearaccelerationsensor-interface">LinearAccelerationSensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values③">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-linearaccelerationreadingvalues"><code><c- g>LinearAccelerationReadingValues</c-></code><a class="self-link" href="#dictdef-linearaccelerationreadingvalues"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadingvalues" id="ref-for-dictdef-accelerometerreadingvalues"><c- n>AccelerometerReadingValues</c-></a> {
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.4" id="mock-gravity"><span class="secno">9.1.3.4. </span><span class="content">Gravity Sensor</span><a class="self-link" href="#mock-gravity"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-gravity"><code>"gravity"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑧">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#gravitysensor-interface" id="ref-for-gravitysensor-interface">GravitySensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values④">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-gravityreadingvalues"><code><c- g>GravityReadingValues</c-></code><a class="self-link" href="#dictdef-gravityreadingvalues"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadingvalues" id="ref-for-dictdef-accelerometerreadingvalues①"><c- n>AccelerometerReadingValues</c-></a> {
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.5" id="mock-gyroscope"><span class="secno">9.1.3.5. </span><span class="content">Gyroscope</span><a class="self-link" href="#mock-gyroscope"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-gyroscope"><code>"gyroscope"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type⑨">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#gyroscope-interface" id="ref-for-gyroscope-interface">Gyroscope</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values⑤">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-gyroscopereadingvalues"><code><c- g>GyroscopeReadingValues</c-></code><a class="self-link" href="#dictdef-gyroscopereadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⓪"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GyroscopeReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-gyroscopereadingvalues-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-gyroscopereadingvalues-x"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GyroscopeReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-gyroscopereadingvalues-y"><code><c- g>y</c-></code><a class="self-link" href="#dom-gyroscopereadingvalues-y"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①②"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GyroscopeReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-gyroscopereadingvalues-z"><code><c- g>z</c-></code><a class="self-link" href="#dom-gyroscopereadingvalues-z"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.6" id="mock-magnetometer"><span class="secno">9.1.3.6. </span><span class="content">Magnetometer</span><a class="self-link" href="#mock-magnetometer"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-magnetometer"><code>"magnetometer"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①⓪">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetometer-interface" id="ref-for-magnetometer-interface">Magnetometer</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values⑥">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-magnetometerreadingvalues"><code><c- g>MagnetometerReadingValues</c-></code><a class="self-link" href="#dictdef-magnetometerreadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①③"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="MagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-magnetometerreadingvalues-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-magnetometerreadingvalues-x"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①④"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="MagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-magnetometerreadingvalues-y"><code><c- g>y</c-></code><a class="self-link" href="#dom-magnetometerreadingvalues-y"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑤"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="MagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-magnetometerreadingvalues-z"><code><c- g>z</c-></code><a class="self-link" href="#dom-magnetometerreadingvalues-z"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.7" id="mock-uncalibrated-magnetometer"><span class="secno">9.1.3.7. </span><span class="content">Uncalibrated Magnetometer</span><a class="self-link" href="#mock-uncalibrated-magnetometer"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-uncalibrated-magnetometer"><code>"uncalibrated-magnetometer"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①①">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface" id="ref-for-uncalibrated-magnetometer-interface">UncalibratedMagnetometer</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values⑦">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-uncalibratedmagnetometerreadingvalues"><code><c- g>UncalibratedMagnetometerReadingValues</c-></code><a class="self-link" href="#dictdef-uncalibratedmagnetometerreadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑥"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-x"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑦"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-y"><code><c- g>y</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-y"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑧"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-z"><code><c- g>z</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-z"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑨"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-xbias"><code><c- g>xBias</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-xbias"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⓪"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-ybias"><code><c- g>yBias</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-ybias"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="UncalibratedMagnetometerReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-uncalibratedmagnetometerreadingvalues-zbias"><code><c- g>zBias</c-></code><a class="self-link" href="#dom-uncalibratedmagnetometerreadingvalues-zbias"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.8" id="mock-absolute-orientation-sensor"><span class="secno">9.1.3.8. </span><span class="content">Absolute Orientation Sensor</span><a class="self-link" href="#mock-absolute-orientation-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-absolute-orientation"><code>"absolute-orientation"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①②">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface" id="ref-for-absoluteorientationsensor-interface">AbsoluteOrientationSensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values⑧">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-absoluteorientationreadingvalues"><code><c- g>AbsoluteOrientationReadingValues</c-></code></dfn> {
-  <c- b>required</c-> <c- b>FrozenArray</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②②"><c- b>double</c-></a>>? <dfn class="idl-code" data-dfn-for="AbsoluteOrientationReadingValues" data-dfn-type="dict-member" data-export data-type="FrozenArray<double>? " id="dom-absoluteorientationreadingvalues-quaternion"><code><c- g>quaternion</c-></code><a class="self-link" href="#dom-absoluteorientationreadingvalues-quaternion"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.9" id="mock-relative-orientation-sensor"><span class="secno">9.1.3.9. </span><span class="content">Relative Orientation Sensor</span><a class="self-link" href="#mock-relative-orientation-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-relative-orientation"><code>"relative-orientation"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①③">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface" id="ref-for-relativeorientationsensor-interface">RelativeOrientationSensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values⑨">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-relativeorientationreadingvalues"><code><c- g>RelativeOrientationReadingValues</c-></code><a class="self-link" href="#dictdef-relativeorientationreadingvalues"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-absoluteorientationreadingvalues" id="ref-for-dictdef-absoluteorientationreadingvalues"><c- n>AbsoluteOrientationReadingValues</c-></a> {
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.10" id="mock-geolocation-sensor"><span class="secno">9.1.3.10. </span><span class="content">Geolocation Sensor</span><a class="self-link" href="#mock-geolocation-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-geolocation"><code>"geolocation"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①④">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://wicg.github.io/geolocation-sensor/#geolocationsensor-interface" id="ref-for-geolocationsensor-interface">GeolocationSensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values①⓪">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-geolocationreadingvalues"><code><c- g>GeolocationReadingValues</c-></code><a class="self-link" href="#dictdef-geolocationreadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②③"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-latitude"><code><c- g>latitude</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-latitude"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②④"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-longitude"><code><c- g>longitude</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-longitude"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑤"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-altitude"><code><c- g>altitude</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-altitude"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑥"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-accuracy"><code><c- g>accuracy</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-accuracy"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑦"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-altitudeaccuracy"><code><c- g>altitudeAccuracy</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-altitudeaccuracy"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑧"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-heading"><code><c- g>heading</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-heading"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑨"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="GeolocationReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-geolocationreadingvalues-speed"><code><c- g>speed</c-></code><a class="self-link" href="#dom-geolocationreadingvalues-speed"></a></dfn>;
-};
-</pre>
-   </dl>
-   <h5 class="heading settled" data-level="9.1.3.11" id="mock-proximity-sensor"><span class="secno">9.1.3.11. </span><span class="content">Proximity Sensor</span><a class="self-link" href="#mock-proximity-sensor"></a></h5>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="MockSensorType" data-dfn-type="enum-value" data-export id="dom-mocksensortype-proximity"><code>"proximity"</code></dfn> type is the <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-type①⑤">mock sensor type</a> associated with the usage of the <a data-link-type="dfn" href="https://w3c.github.io/proximity#proximity-sensor-interface" id="ref-for-proximity-sensor-interface">ProximitySensor</a> interface.</p>
-   <dl>
-    <dt><a data-link-type="dfn" href="#mock-sensor-reading-values" id="ref-for-mock-sensor-reading-values①①">Mock Sensor Reading Values</a>
-    <dd>
-<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="idl-code" data-dfn-type="dictionary" data-export id="dictdef-proximityreadingvalues"><code><c- g>ProximityReadingValues</c-></code><a class="self-link" href="#dictdef-proximityreadingvalues"></a></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③⓪"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-distance"><code><c- g>distance</c-></code><a class="self-link" href="#dom-proximityreadingvalues-distance"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①"><c- b>double</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="double? " id="dom-proximityreadingvalues-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-proximityreadingvalues-max"></a></dfn>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a>? <dfn class="idl-code" data-dfn-for="ProximityReadingValues" data-dfn-type="dict-member" data-export data-type="boolean? " id="dom-proximityreadingvalues-near"><code><c- g>near</c-></code><a class="self-link" href="#dom-proximityreadingvalues-near"></a></dfn>;
 };
 </pre>
    </dl>
@@ -3395,11 +3290,11 @@ Each <a data-link-type="dfn" href="#mock-sensor-type" id="ref-for-mock-sensor-ty
    <p>Such <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="extension specification" data-noexport id="extension-specification">extension specifications</dfn> are encouraged to focus on a
 single <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑤">sensor type</a>, exposing both <a data-link-type="dfn" href="#high-level" id="ref-for-high-level⑦">high</a> and <a data-link-type="dfn" href="#low-level" id="ref-for-low-level⑦">low</a> level
 as appropriate.</p>
-   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑤">Extension specifications</a> are encouraged to define whether a <a data-link-type="dfn" href="#calibration" id="ref-for-calibration①">calibration</a> process applies to <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤①">sensor readings</a>.</p>
-   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑥">Extension specifications</a> may explicitly define the <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for the associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> or make it configurable per <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code> object.</p>
-   <p>For an up-to-date list of <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">extension specifications</a>, please refer to <a data-link-type="biblio" href="#biblio-generic-sensor-usecases">[GENERIC-SENSOR-USECASES]</a> and <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> documents.</p>
+   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑥">Extension specifications</a> are encouraged to define whether a <a data-link-type="dfn" href="#calibration" id="ref-for-calibration①">calibration</a> process applies to <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤①">sensor readings</a>.</p>
+   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑦">Extension specifications</a> may explicitly define the <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for the associated <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑥">sensor type</a> or make it configurable per <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor③⑧">Sensor</a></code> object.</p>
+   <p>For an up-to-date list of <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">extension specifications</a>, please refer to <a data-link-type="biblio" href="#biblio-generic-sensor-usecases">[GENERIC-SENSOR-USECASES]</a> and <a data-link-type="biblio" href="#biblio-motion-sensors">[MOTION-SENSORS]</a> documents.</p>
    <h3 class="heading settled" data-level="10.1" id="extension-security-and-privacy"><span class="secno">10.1. </span><span class="content">Security and Privacy</span><a class="self-link" href="#extension-security-and-privacy"></a></h3>
-   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑧">Extension specifications</a> are expected to:</p>
+   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">Extension specifications</a> are expected to:</p>
    <ul>
     <li data-md>
      <p>conform with the generic <a href="#mitigation-strategies">mitigation strategies</a>,</p>
@@ -3431,7 +3326,7 @@ a <code>temperature</code> attribute (and not a <code>value</code> or <code>temp
 A good starting point for naming are the
 Quantities, Units, Dimensions and Data Types Ontologies <a data-link-type="biblio" href="#biblio-qudt">[QUDT]</a>.</p>
    <h3 class="heading settled" data-level="10.3" id="unit"><span class="secno">10.3. </span><span class="content">Unit</span><a class="self-link" href="#unit"></a></h3>
-   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification⑨">Extension specifications</a> must specify the unit of <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤④">sensor readings</a>.</p>
+   <p><a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⓪">Extension specifications</a> must specify the unit of <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤④">sensor readings</a>.</p>
    <p>As per the Technical Architecture Group’s (TAG) API Design Principles <a data-link-type="biblio" href="#biblio-api-design-principles">[API-DESIGN-PRINCIPLES]</a>,
 all time measurement should be in milliseconds.
 All other units should be specified using,
@@ -3467,7 +3362,7 @@ most notably for performance reasons.</p>
    <p>Providing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①⓪">low-level</a> access
 enables Web application developers to leverage domain-specific constraints
 and design more performant systems.</p>
-   <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⓪">extension specifications</a> should focus primarily on
+   <p>Following the precepts of the Extensible Web Manifesto <a data-link-type="biblio" href="#biblio-extennnnsible">[EXTENNNNSIBLE]</a>, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a> should focus primarily on
 exposing <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①①">low-level</a> sensor APIs, but should also expose <a data-link-type="dfn" href="#high-level" id="ref-for-high-level①①">high-level</a> APIs when they are clear benefits in doing so.</p>
    <h3 class="heading settled" data-level="10.5" id="multiple-sensors"><span class="secno">10.5. </span><span class="content">When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</span><a class="self-link" href="#multiple-sensors"></a></h3>
    <p>It is not advisable to construct multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④②">Sensor</a></code> instances of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑦">sensor type</a> with
@@ -3477,10 +3372,10 @@ creating multiple instances of the same <a data-link-type="dfn" href="#sensor-ty
 handler.</p>
    <p>Conversely, multiple <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④④">Sensors</a></code> of the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type③⑨">sensor type</a> can be created when they
 are intended to be used with different settings, such as: <a data-link-type="dfn" href="#requested-sampling-frequency" id="ref-for-requested-sampling-frequency①②">requested sampling frequency</a>,
-accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①①">extension specifications</a>.</p>
+accuracy or other settings defined in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specifications</a>.</p>
    <h3 class="heading settled" data-level="10.6" id="definition-reqs"><span class="secno">10.6. </span><span class="content">Definition Requirements</span><a class="self-link" href="#definition-reqs"></a></h3>
    <p>The following definitions must be specified for
-each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①②">extension specifications</a>:</p>
+each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">sensor type</a> in <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①③">extension specifications</a>:</p>
    <ul>
     <li data-md>
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="extension-sensor-interface">extension sensor interface</dfn>, which is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interface</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> contains <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor④⑤">Sensor</a></code>.
@@ -3489,14 +3384,14 @@ each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⓪">
   an optional <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> whose <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-dictionaries" id="ref-for-dfn-inherited-dictionaries">inherited dictionaries</a> contains <code class="idl"><a data-link-type="idl" href="#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a></code>.</p>
      <p>The <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface⑤">extension sensor interface</a> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①①">set</a> of supported options
   referred to as <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="supported-sensor-options">supported sensor options</dfn>.
-  Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①③">extension specification</a> defines otherwise, <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options①">supported sensor options</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain④">contain</a> a single item which is "frequency".</p>
+  Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①④">extension specification</a> defines otherwise, <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options①">supported sensor options</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain④">contain</a> a single item which is "frequency".</p>
      <p>The user agent must remove items from <a data-link-type="dfn" href="#supported-sensor-options" id="ref-for-supported-sensor-options②">supported sensor options</a> for a given <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface⑥">extension sensor interface</a> if it cannot support the corresponding sensor
   options.</p>
      <p>The <a data-link-type="dfn" href="#extension-sensor-interface" id="ref-for-extension-sensor-interface⑦">extension sensor interface</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attributes</a> which expose <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⑥">sensor readings</a> are <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> and their getters must return the result of invoking <a data-link-type="dfn" href="#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <strong>this</strong> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute⑤">attribute</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-identifier" id="ref-for-dfn-identifier④">identifier</a> as arguments.</p>
     <li data-md>
      <p>A <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname④">permission name</a>, if the <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④①">sensor type</a> is not representing <a data-link-type="dfn" href="#sensor-fusion" id="ref-for-sensor-fusion⑧">sensor fusion</a> (otherwise, <a data-link-type="dfn" href="https://www.w3.org/TR/permissions/#enumdef-permissionname" id="ref-for-enumdef-permissionname⑤">permission names</a> associated with the fusion source <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④②">sensor types</a> must be used).</p>
    </ul>
-   <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①④">extension specification</a> may specify the following definitions
+   <p>An <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑤">extension specification</a> may specify the following definitions
 for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④③">sensor types</a>:</p>
    <ul>
     <li data-md>
@@ -3504,7 +3399,7 @@ for each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④�
     <li data-md>
      <p>A <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑥">default sensor</a>. Generally, devices are equipped with a single <a data-link-type="dfn" href="#concept-platform-sensor" id="ref-for-concept-platform-sensor③⑨">platform sensor</a> of each <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④④">type</a>,
   so defining a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑦">default sensor</a> should be straightforward.
-  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③②">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑤">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
+  For <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑤">sensor types</a> where multiple <a data-link-type="dfn" href="#concept-device-sensor" id="ref-for-concept-device-sensor③②">sensors</a> are common, <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑥">extension specifications</a> may choose not to define a <a data-link-type="dfn" href="#default-sensor" id="ref-for-default-sensor⑧">default sensor</a>,
   especially when doing so would not make sense.</p>
    </ul>
    <h3 class="heading settled" data-level="10.7" id="permission-api"><span class="secno">10.7. </span><span class="content">Extending the Permission API</span><a class="self-link" href="#permission-api"></a></h3>
@@ -3535,7 +3430,7 @@ implementation usage in same-origin nested frames but prevents third-party conte
 from <a data-link-type="dfn" href="#sensor-reading" id="ref-for-sensor-reading⑤⑨">sensor readings</a> access.</p>
    <p>The <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names②">sensor feature names</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①②">set</a> must contain <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑥">policy-controlled feature</a> tokens of every associated <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">feature</a>.</p>
    <p>A <a data-link-type="dfn" href="#low-level" id="ref-for-low-level①④">Low-level</a> <code class="idl"><a data-link-type="idl" href="#sensor" id="ref-for-sensor⑤⓪">sensor</a></code> may use its interface name as a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a> token,
-for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑥">extension specification</a> defines
+for instance, "gyroscope" or "accelerometer". Unless the <a data-link-type="dfn" href="#extension-specification" id="ref-for-extension-specification①⑦">extension specification</a> defines
 otherwise, the <a data-link-type="dfn" href="#sensor-feature-names" id="ref-for-sensor-feature-names③">sensor feature names</a> matches the same <a data-link-type="dfn" href="#sensor-type" id="ref-for-sensor-type④⑧">type</a>-associated <a data-link-type="dfn" href="#sensor-permission-names" id="ref-for-sensor-permission-names③">sensor permission names</a>.</p>
    <div class="example html" id="example-07bc76ef">
     <a class="self-link" href="#example-07bc76ef"></a> The accelerometer feature is selectively enabled for third-party origin by adding <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#iframe-allow-attribute" id="ref-for-iframe-allow-attribute">allow attribute</a> to the frame container element: 
@@ -3829,18 +3724,12 @@ for their editorial input.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-mocksensortype-absolute-orientation">"absolute-orientation"</a><span>, in §9.1.3.8</span>
-   <li><a href="#dictdef-absoluteorientationreadingvalues">AbsoluteOrientationReadingValues</a><span>, in §9.1.3.8</span>
-   <li><a href="#dom-mocksensortype-accelerometer">"accelerometer"</a><span>, in §9.1.3.2</span>
-   <li><a href="#dictdef-accelerometerreadingvalues">AccelerometerReadingValues</a><span>, in §9.1.3.2</span>
-   <li><a href="#dom-geolocationreadingvalues-accuracy">accuracy</a><span>, in §9.1.3.10</span>
+   <li><a href="#dom-mocksensortype-absolute-orientation">"absolute-orientation"</a><span>, in §9.1.3</span>
+   <li><a href="#dom-mocksensortype-accelerometer">"accelerometer"</a><span>, in §9.1.3</span>
    <li><a href="#activate-a-sensor-object">Activate a sensor object</a><span>, in §8.3</span>
    <li><a href="#dom-sensor-activated">activated</a><span>, in §7.1</span>
    <li><a href="#activated-sensor-objects">activated sensor objects</a><span>, in §6.2</span>
-   <li><a href="#dom-geolocationreadingvalues-altitude">altitude</a><span>, in §9.1.3.10</span>
-   <li><a href="#dom-geolocationreadingvalues-altitudeaccuracy">altitudeAccuracy</a><span>, in §9.1.3.10</span>
-   <li><a href="#dom-mocksensortype-ambient-light">"ambient-light"</a><span>, in §9.1.3.1</span>
-   <li><a href="#dictdef-ambientlightreadingvalues">AmbientLightReadingValues</a><span>, in §9.1.3.1</span>
+   <li><a href="#dom-mocksensortype-ambient-light">"ambient-light"</a><span>, in §9.1.3</span>
    <li><a href="#associated-sensors">associated sensors</a><span>, in §6.1</span>
    <li><a href="#biaxial">biaxial</a><span>, in §5.1</span>
    <li><a href="#calibration">calibration</a><span>, in §5.1</span>
@@ -3855,7 +3744,6 @@ for their editorial input.</p>
    <li><a href="#default-sensor">default sensor</a><span>, in §5.3</span>
    <li><a href="#delete-mock-sensor">delete mock sensor</a><span>, in §9.2.4</span>
    <li><a href="#concept-device-sensor">device sensor</a><span>, in §5.1</span>
-   <li><a href="#dom-proximityreadingvalues-distance">distance</a><span>, in §9.1.3.11</span>
    <li><a href="#equivalent">equivalent</a><span>, in §Unnumbered section</span>
    <li>
     error
@@ -3869,33 +3757,23 @@ for their editorial input.</p>
    <li><a href="#dom-sensoroptions-frequency">frequency</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-frequency-slot">[[frequency]]</a><span>, in §7.1.3</span>
    <li><a href="#generic-sensor-permission-revocation-algorithm">generic sensor permission revocation algorithm</a><span>, in §6.1</span>
-   <li><a href="#dom-mocksensortype-geolocation">"geolocation"</a><span>, in §9.1.3.10</span>
-   <li><a href="#dictdef-geolocationreadingvalues">GeolocationReadingValues</a><span>, in §9.1.3.10</span>
+   <li><a href="#dom-mocksensortype-geolocation">"geolocation"</a><span>, in §9.1.3</span>
    <li><a href="#get-mock-sensor">get mock sensor</a><span>, in §9.2.2</span>
    <li><a href="#get-value-from-latest-reading">Get value from latest reading</a><span>, in §8.13</span>
-   <li><a href="#dom-mocksensortype-gravity">"gravity"</a><span>, in §9.1.3.4</span>
-   <li><a href="#dictdef-gravityreadingvalues">GravityReadingValues</a><span>, in §9.1.3.4</span>
-   <li><a href="#dom-mocksensortype-gyroscope">"gyroscope"</a><span>, in §9.1.3.5</span>
-   <li><a href="#dictdef-gyroscopereadingvalues">GyroscopeReadingValues</a><span>, in §9.1.3.5</span>
+   <li><a href="#dom-mocksensortype-gravity">"gravity"</a><span>, in §9.1.3</span>
+   <li><a href="#dom-mocksensortype-gyroscope">"gyroscope"</a><span>, in §9.1.3</span>
    <li><a href="#dom-sensor-hasreading">hasReading</a><span>, in §7.1</span>
-   <li><a href="#dom-geolocationreadingvalues-heading">heading</a><span>, in §9.1.3.10</span>
    <li><a href="#high-level">high-level</a><span>, in §5.2</span>
-   <li><a href="#dom-ambientlightreadingvalues-illuminance">illuminance</a><span>, in §9.1.3.1</span>
    <li><a href="#initialize-a-sensor-object">Initialize a sensor object</a><span>, in §8</span>
    <li><a href="#dom-sensor-lasteventfiredat-slot">[[lastEventFiredAt]]</a><span>, in §7.1.3</span>
    <li><a href="#latest-reading">latest reading</a><span>, in §6.2</span>
-   <li><a href="#dom-geolocationreadingvalues-latitude">latitude</a><span>, in §9.1.3.10</span>
    <li><a href="#limit-max-frequency">Limit maximum sampling frequency</a><span>, in §4.3</span>
    <li><a href="#limit-number-of-delivered-readings">Limit number of delivered readings</a><span>, in §4.3.2</span>
-   <li><a href="#dom-mocksensortype-linear-acceleration">"linear-acceleration"</a><span>, in §9.1.3.3</span>
-   <li><a href="#dictdef-linearaccelerationreadingvalues">LinearAccelerationReadingValues</a><span>, in §9.1.3.3</span>
+   <li><a href="#dom-mocksensortype-linear-acceleration">"linear-acceleration"</a><span>, in §9.1.3</span>
    <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §5.1</span>
-   <li><a href="#dom-geolocationreadingvalues-longitude">longitude</a><span>, in §9.1.3.10</span>
    <li><a href="#low-level">low-level</a><span>, in §5.2</span>
-   <li><a href="#dom-mocksensortype-magnetometer">"magnetometer"</a><span>, in §9.1.3.6</span>
-   <li><a href="#dictdef-magnetometerreadingvalues">MagnetometerReadingValues</a><span>, in §9.1.3.6</span>
+   <li><a href="#dom-mocksensortype-magnetometer">"magnetometer"</a><span>, in §9.1.3</span>
    <li><a href="#mandatory-conditions">mandatory conditions</a><span>, in §5.6</span>
-   <li><a href="#dom-proximityreadingvalues-max">max</a><span>, in §9.1.3.11</span>
    <li>
     maxSamplingFrequency
     <ul>
@@ -3918,7 +3796,6 @@ for their editorial input.</p>
    <li><a href="#enumdef-mocksensortype">MockSensorType</a><span>, in §9.1.3</span>
    <li><a href="#dom-mocksensorconfiguration-mocksensortype">mockSensorType</a><span>, in §9.1.1</span>
    <li><a href="#mock-sensor-type">mock sensor type</a><span>, in §9.1.3</span>
-   <li><a href="#dom-proximityreadingvalues-near">near</a><span>, in §9.1.3.11</span>
    <li><a href="#no-such-mock-sensor">no such mock sensor</a><span>, in §9.3</span>
    <li><a href="#notify-activated-state">Notify activated state</a><span>, in §8.11</span>
    <li><a href="#notify-error">Notify error</a><span>, in §8.12</span>
@@ -3929,15 +3806,12 @@ for their editorial input.</p>
    <li><a href="#optimal-sampling-frequency">optimal sampling frequency</a><span>, in §6.2</span>
    <li><a href="#dom-sensor-pendingreadingnotification-slot">[[pendingReadingNotification]]</a><span>, in §7.1.3</span>
    <li><a href="#concept-platform-sensor">platform sensor</a><span>, in §5.1</span>
-   <li><a href="#dom-mocksensortype-proximity">"proximity"</a><span>, in §9.1.3.11</span>
-   <li><a href="#dictdef-proximityreadingvalues">ProximityReadingValues</a><span>, in §9.1.3.11</span>
-   <li><a href="#dom-absoluteorientationreadingvalues-quaternion">quaternion</a><span>, in §9.1.3.8</span>
+   <li><a href="#dom-mocksensortype-proximity">"proximity"</a><span>, in §9.1.3</span>
    <li><a href="#reading-change-threshold">reading change threshold</a><span>, in §5.4</span>
    <li><a href="#reading-timestamp">reading timestamp</a><span>, in §5.1</span>
    <li><a href="#reading-value">reading value</a><span>, in §5.1</span>
    <li><a href="#reduce-accuracy">Reduce accuracy</a><span>, in §4.3.3</span>
-   <li><a href="#dom-mocksensortype-relative-orientation">"relative-orientation"</a><span>, in §9.1.3.9</span>
-   <li><a href="#dictdef-relativeorientationreadingvalues">RelativeOrientationReadingValues</a><span>, in §9.1.3.9</span>
+   <li><a href="#dom-mocksensortype-relative-orientation">"relative-orientation"</a><span>, in §9.1.3</span>
    <li><a href="#reporting-frequency">reporting frequency</a><span>, in §5.5</span>
    <li><a href="#report-latest-reading-updated">Report latest reading updated</a><span>, in §8.9</span>
    <li><a href="#dom-mocksensor-requestedsamplingfrequency">requestedSamplingFrequency</a><span>, in §9.1.2</span>
@@ -3962,7 +3836,6 @@ for their editorial input.</p>
    <li><a href="#smart-sensors">Smart sensors</a><span>, in §5.2</span>
    <li><a href="#spatial-sensor">spatial sensor</a><span>, in §5.1</span>
    <li><a href="#specific-conditions">Specific conditions</a><span>, in §5.6</span>
-   <li><a href="#dom-geolocationreadingvalues-speed">speed</a><span>, in §9.1.3.10</span>
    <li><a href="#dom-sensor-start">start()</a><span>, in §7.1</span>
    <li><a href="#dom-sensor-state-slot">[[state]]</a><span>, in §7.1.3</span>
    <li><a href="#dom-sensor-stop">stop()</a><span>, in §7.1</span>
@@ -3970,61 +3843,33 @@ for their editorial input.</p>
    <li><a href="#supported-sensor-options">supported sensor options</a><span>, in §10.6</span>
    <li><a href="#dom-sensor-timestamp">timestamp</a><span>, in §7.1</span>
    <li><a href="#triaxial">triaxial</a><span>, in §5.1</span>
-   <li><a href="#dom-mocksensortype-uncalibrated-magnetometer">"uncalibrated-magnetometer"</a><span>, in §9.1.3.7</span>
-   <li><a href="#dictdef-uncalibratedmagnetometerreadingvalues">UncalibratedMagnetometerReadingValues</a><span>, in §9.1.3.7</span>
+   <li><a href="#dom-mocksensortype-uncalibrated-magnetometer">"uncalibrated-magnetometer"</a><span>, in §9.1.3</span>
    <li><a href="#uniaxial">uniaxial</a><span>, in §5.1</span>
    <li><a href="#update-latest-reading">Update latest reading</a><span>, in §8.7</span>
    <li><a href="#update-mock-sensor-reading">update mock sensor reading</a><span>, in §9.2.3</span>
-   <li>
-    x
-    <ul>
-     <li><a href="#dom-accelerometerreadingvalues-x">dict-member for AccelerometerReadingValues</a><span>, in §9.1.3.2</span>
-     <li><a href="#dom-gyroscopereadingvalues-x">dict-member for GyroscopeReadingValues</a><span>, in §9.1.3.5</span>
-     <li><a href="#dom-magnetometerreadingvalues-x">dict-member for MagnetometerReadingValues</a><span>, in §9.1.3.6</span>
-     <li><a href="#dom-uncalibratedmagnetometerreadingvalues-x">dict-member for UncalibratedMagnetometerReadingValues</a><span>, in §9.1.3.7</span>
-    </ul>
-   <li><a href="#dom-uncalibratedmagnetometerreadingvalues-xbias">xBias</a><span>, in §9.1.3.7</span>
-   <li>
-    y
-    <ul>
-     <li><a href="#dom-accelerometerreadingvalues-y">dict-member for AccelerometerReadingValues</a><span>, in §9.1.3.2</span>
-     <li><a href="#dom-gyroscopereadingvalues-y">dict-member for GyroscopeReadingValues</a><span>, in §9.1.3.5</span>
-     <li><a href="#dom-magnetometerreadingvalues-y">dict-member for MagnetometerReadingValues</a><span>, in §9.1.3.6</span>
-     <li><a href="#dom-uncalibratedmagnetometerreadingvalues-y">dict-member for UncalibratedMagnetometerReadingValues</a><span>, in §9.1.3.7</span>
-    </ul>
-   <li><a href="#dom-uncalibratedmagnetometerreadingvalues-ybias">yBias</a><span>, in §9.1.3.7</span>
-   <li>
-    z
-    <ul>
-     <li><a href="#dom-accelerometerreadingvalues-z">dict-member for AccelerometerReadingValues</a><span>, in §9.1.3.2</span>
-     <li><a href="#dom-gyroscopereadingvalues-z">dict-member for GyroscopeReadingValues</a><span>, in §9.1.3.5</span>
-     <li><a href="#dom-magnetometerreadingvalues-z">dict-member for MagnetometerReadingValues</a><span>, in §9.1.3.6</span>
-     <li><a href="#dom-uncalibratedmagnetometerreadingvalues-z">dict-member for UncalibratedMagnetometerReadingValues</a><span>, in §9.1.3.7</span>
-    </ul>
-   <li><a href="#dom-uncalibratedmagnetometerreadingvalues-zbias">zBias</a><span>, in §9.1.3.7</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
    <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-accelerometer-interface">9.1.3.2. Accelerometer</a>
+    <li><a href="#ref-for-accelerometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
    <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-gravitysensor-interface">9.1.3.4. Gravity Sensor</a>
+    <li><a href="#ref-for-gravitysensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
    <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-linearaccelerationsensor-interface">9.1.3.3. Linear Acceleration Sensor</a>
+    <li><a href="#ref-for-linearaccelerationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ambient-light-sensor-interface">
    <a href="https://w3c.github.io/ambient-light#ambient-light-sensor-interface">https://w3c.github.io/ambient-light#ambient-light-sensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ambient-light-sensor-interface">9.1.3.1. Ambient Light Sensor</a>
+    <li><a href="#ref-for-ambient-light-sensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-event">
@@ -4106,13 +3951,13 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="term-for-geolocationsensor-interface">
    <a href="https://wicg.github.io/geolocation-sensor/#geolocationsensor-interface">https://wicg.github.io/geolocation-sensor/#geolocationsensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-geolocationsensor-interface">9.1.3.10. Geolocation Sensor</a>
+    <li><a href="#ref-for-geolocationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
    <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-gyroscope-interface">9.1.3.5. Gyroscope</a>
+    <li><a href="#ref-for-gyroscope-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
@@ -4329,25 +4174,25 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
    <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-magnetometer-interface">9.1.3.6. Magnetometer</a>
+    <li><a href="#ref-for-magnetometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-uncalibrated-magnetometer-interface">
    <a href="https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface">https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-uncalibrated-magnetometer-interface">9.1.3.7. Uncalibrated Magnetometer</a>
+    <li><a href="#ref-for-uncalibrated-magnetometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
    <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-absoluteorientationsensor-interface">9.1.3.8. Absolute Orientation Sensor</a>
+    <li><a href="#ref-for-absoluteorientationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-relativeorientationsensor-interface">
    <a href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface">https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-relativeorientationsensor-interface">9.1.3.9. Relative Orientation Sensor</a>
+    <li><a href="#ref-for-relativeorientationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
@@ -4420,7 +4265,7 @@ for their editorial input.</p>
   <aside class="dfn-panel" data-for="term-for-proximity-sensor-interface">
    <a href="https://w3c.github.io/proximity#proximity-sensor-interface">https://w3c.github.io/proximity#proximity-sensor-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-proximity-sensor-interface">9.1.3.11. Proximity Sensor</a>
+    <li><a href="#ref-for-proximity-sensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sop-violations">
@@ -4633,7 +4478,6 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.1. The Sensor Interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">9.1.1. MockSensorConfiguration dictionary</a>
-    <li><a href="#ref-for-idl-boolean③">9.1.3.11. Proximity Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
@@ -4670,14 +4514,6 @@ for their editorial input.</p>
     <li><a href="#ref-for-idl-double">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-idl-double①">9.1.1. MockSensorConfiguration dictionary</a> <a href="#ref-for-idl-double②">(2)</a>
     <li><a href="#ref-for-idl-double③">9.1.2. MockSensor dictionary</a> <a href="#ref-for-idl-double④">(2)</a> <a href="#ref-for-idl-double⑤">(3)</a>
-    <li><a href="#ref-for-idl-double⑥">9.1.3.1. Ambient Light Sensor</a>
-    <li><a href="#ref-for-idl-double⑦">9.1.3.2. Accelerometer</a> <a href="#ref-for-idl-double⑧">(2)</a> <a href="#ref-for-idl-double⑨">(3)</a>
-    <li><a href="#ref-for-idl-double①⓪">9.1.3.5. Gyroscope</a> <a href="#ref-for-idl-double①①">(2)</a> <a href="#ref-for-idl-double①②">(3)</a>
-    <li><a href="#ref-for-idl-double①③">9.1.3.6. Magnetometer</a> <a href="#ref-for-idl-double①④">(2)</a> <a href="#ref-for-idl-double①⑤">(3)</a>
-    <li><a href="#ref-for-idl-double①⑥">9.1.3.7. Uncalibrated Magnetometer</a> <a href="#ref-for-idl-double①⑦">(2)</a> <a href="#ref-for-idl-double①⑧">(3)</a> <a href="#ref-for-idl-double①⑨">(4)</a> <a href="#ref-for-idl-double②⓪">(5)</a> <a href="#ref-for-idl-double②①">(6)</a>
-    <li><a href="#ref-for-idl-double②②">9.1.3.8. Absolute Orientation Sensor</a>
-    <li><a href="#ref-for-idl-double②③">9.1.3.10. Geolocation Sensor</a> <a href="#ref-for-idl-double②④">(2)</a> <a href="#ref-for-idl-double②⑤">(3)</a> <a href="#ref-for-idl-double②⑥">(4)</a> <a href="#ref-for-idl-double②⑦">(5)</a> <a href="#ref-for-idl-double②⑧">(6)</a> <a href="#ref-for-idl-double②⑨">(7)</a>
-    <li><a href="#ref-for-idl-double③⓪">9.1.3.11. Proximity Sensor</a> <a href="#ref-for-idl-double③①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-exception-type">
@@ -4983,7 +4819,7 @@ for their editorial input.</p>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#sensor"><code><c- g>Sensor</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①"><c- n>EventTarget</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-sensor-activated"><code><c- g>activated</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-sensor-activated"><code><c- g>activated</c-></code></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-sensor-hasreading"><code><c- g>hasReading</c-></code></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a>? <a data-readonly data-type="DOMHighResTimeStamp?" href="#dom-sensor-timestamp"><code><c- g>timestamp</c-></code></a>;
   <c- b>void</c-> <a href="#dom-sensor-start"><code><c- g>start</c-></code></a>();
@@ -4994,7 +4830,7 @@ for their editorial input.</p>
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-sensoroptions"><code><c- g>SensorOptions</c-></code></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③②"><c- b>double</c-></a> <a data-type="double " href="#dom-sensoroptions-frequency"><code><c- g>frequency</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥"><c- b>double</c-></a> <a data-type="double " href="#dom-sensoroptions-frequency"><code><c- g>frequency</c-></code></a>;
 };
 
 [<a href="#dom-sensorerrorevent-sensorerrorevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <a href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-sensorerroreventinit" id="ref-for-dictdef-sensorerroreventinit②"><c- n>SensorErrorEventInit</c-></a> <a href="#dom-sensorerrorevent-sensorerrorevent-type-erroreventinitdict-erroreventinitdict"><code><c- g>errorEventInitDict</c-></code></a>),
@@ -5010,12 +4846,12 @@ for their editorial input.</p>
 <c- b>dictionary</c-> <a href="#dictdef-mocksensorconfiguration"><code><c- g>MockSensorConfiguration</c-></code></a> {
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#enumdef-mocksensortype" id="ref-for-enumdef-mocksensortype⑥"><c- n>MockSensorType</c-></a> <a data-type="MockSensorType " href="#dom-mocksensorconfiguration-mocksensortype"><code><c- g>mockSensorType</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①"><c- b>boolean</c-></a> <a data-default="true" data-type="boolean " href="#dom-mocksensorconfiguration-connected"><code><c- g>connected</c-></code></a> = <c- b>true</c->;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①⓪"><c- b>double</c-></a>? <a data-type="double? " href="#dom-mocksensorconfiguration-maxsamplingfrequency"><code><c- g>maxSamplingFrequency</c-></code></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①⓪"><c- b>double</c-></a>? <a data-type="double? " href="#dom-mocksensorconfiguration-minsamplingfrequency"><code><c- g>minSamplingFrequency</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-mocksensorconfiguration-maxsamplingfrequency"><code><c- g>maxSamplingFrequency</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-mocksensorconfiguration-minsamplingfrequency"><code><c- g>minSamplingFrequency</c-></code></a>;
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-mocksensor"><code><c- g>MockSensor</c-></code></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③③"><c- b>double</c-></a> <a data-type="double " href="#dom-mocksensor-maxsamplingfrequency"><code><c- g>maxSamplingFrequency</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①"><c- b>double</c-></a> <a data-type="double " href="#dom-mocksensor-maxsamplingfrequency"><code><c- g>maxSamplingFrequency</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④①"><c- b>double</c-></a> <a data-type="double " href="#dom-mocksensor-minsamplingfrequency"><code><c- g>minSamplingFrequency</c-></code></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑤①"><c- b>double</c-></a> <a data-type="double " href="#dom-mocksensor-requestedsamplingfrequency"><code><c- g>requestedSamplingFrequency</c-></code></a>;
 };
@@ -5035,66 +4871,6 @@ for their editorial input.</p>
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-mocksensorreadingvalues"><code><c- g>MockSensorReadingValues</c-></code></a> {
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-ambientlightreadingvalues"><code><c- g>AmbientLightReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-ambientlightreadingvalues-illuminance"><code><c- g>illuminance</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-accelerometerreadingvalues"><code><c- g>AccelerometerReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-accelerometerreadingvalues-x"><code><c- g>x</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-accelerometerreadingvalues-y"><code><c- g>y</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-accelerometerreadingvalues-z"><code><c- g>z</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-linearaccelerationreadingvalues"><code><c- g>LinearAccelerationReadingValues</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadingvalues" id="ref-for-dictdef-accelerometerreadingvalues②"><c- n>AccelerometerReadingValues</c-></a> {
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-gravityreadingvalues"><code><c- g>GravityReadingValues</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadingvalues" id="ref-for-dictdef-accelerometerreadingvalues①①"><c- n>AccelerometerReadingValues</c-></a> {
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-gyroscopereadingvalues"><code><c- g>GyroscopeReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⓪①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-gyroscopereadingvalues-x"><code><c- g>x</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-gyroscopereadingvalues-y"><code><c- g>y</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①②①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-gyroscopereadingvalues-z"><code><c- g>z</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-magnetometerreadingvalues"><code><c- g>MagnetometerReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①③①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-magnetometerreadingvalues-x"><code><c- g>x</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①④①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-magnetometerreadingvalues-y"><code><c- g>y</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑤①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-magnetometerreadingvalues-z"><code><c- g>z</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-uncalibratedmagnetometerreadingvalues"><code><c- g>UncalibratedMagnetometerReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑥①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-x"><code><c- g>x</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑦①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-y"><code><c- g>y</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑧①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-z"><code><c- g>z</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⑨①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-xbias"><code><c- g>xBias</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⓪①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-ybias"><code><c- g>yBias</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-uncalibratedmagnetometerreadingvalues-zbias"><code><c- g>zBias</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-absoluteorientationreadingvalues"><code><c- g>AbsoluteOrientationReadingValues</c-></code></a> {
-  <c- b>required</c-> <c- b>FrozenArray</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②②①"><c- b>double</c-></a>>? <a data-type="FrozenArray<double>? " href="#dom-absoluteorientationreadingvalues-quaternion"><code><c- g>quaternion</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-relativeorientationreadingvalues"><code><c- g>RelativeOrientationReadingValues</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-absoluteorientationreadingvalues" id="ref-for-dictdef-absoluteorientationreadingvalues①"><c- n>AbsoluteOrientationReadingValues</c-></a> {
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-geolocationreadingvalues"><code><c- g>GeolocationReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②③①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-latitude"><code><c- g>latitude</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②④①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-longitude"><code><c- g>longitude</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑤①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-altitude"><code><c- g>altitude</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑥①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-accuracy"><code><c- g>accuracy</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑦①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-altitudeaccuracy"><code><c- g>altitudeAccuracy</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑧①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-heading"><code><c- g>heading</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②⑨①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-geolocationreadingvalues-speed"><code><c- g>speed</c-></code></a>;
-};
-
-<c- b>dictionary</c-> <a href="#dictdef-proximityreadingvalues"><code><c- g>ProximityReadingValues</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③⓪①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-proximityreadingvalues-distance"><code><c- g>distance</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①①"><c- b>double</c-></a>? <a data-type="double? " href="#dom-proximityreadingvalues-max"><code><c- g>max</c-></code></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①"><c- b>boolean</c-></a>? <a data-type="boolean? " href="#dom-proximityreadingvalues-near"><code><c- g>near</c-></code></a>;
 };
 
 </pre>
@@ -5742,18 +5518,7 @@ for their editorial input.</p>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">9.1. Mock Sensors</a>
     <li><a href="#ref-for-mock-sensor-type①">9.1.1. MockSensorConfiguration dictionary</a>
-    <li><a href="#ref-for-mock-sensor-type②">9.1.3. Mock sensor type</a> <a href="#ref-for-mock-sensor-type③">(2)</a> <a href="#ref-for-mock-sensor-type④">(3)</a>
-    <li><a href="#ref-for-mock-sensor-type⑤">9.1.3.1. Ambient Light Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type⑥">9.1.3.2. Accelerometer</a>
-    <li><a href="#ref-for-mock-sensor-type⑦">9.1.3.3. Linear Acceleration Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type⑧">9.1.3.4. Gravity Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type⑨">9.1.3.5. Gyroscope</a>
-    <li><a href="#ref-for-mock-sensor-type①⓪">9.1.3.6. Magnetometer</a>
-    <li><a href="#ref-for-mock-sensor-type①①">9.1.3.7. Uncalibrated Magnetometer</a>
-    <li><a href="#ref-for-mock-sensor-type①②">9.1.3.8. Absolute Orientation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type①③">9.1.3.9. Relative Orientation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type①④">9.1.3.10. Geolocation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-type①⑤">9.1.3.11. Proximity Sensor</a>
+    <li><a href="#ref-for-mock-sensor-type②">9.1.3. Mock sensor type</a> <a href="#ref-for-mock-sensor-type③">(2)</a> <a href="#ref-for-mock-sensor-type④">(3)</a> <a href="#ref-for-mock-sensor-type⑤">(4)</a> <a href="#ref-for-mock-sensor-type⑥">(5)</a> <a href="#ref-for-mock-sensor-type⑦">(6)</a> <a href="#ref-for-mock-sensor-type⑧">(7)</a> <a href="#ref-for-mock-sensor-type⑨">(8)</a> <a href="#ref-for-mock-sensor-type①⓪">(9)</a> <a href="#ref-for-mock-sensor-type①①">(10)</a> <a href="#ref-for-mock-sensor-type①②">(11)</a> <a href="#ref-for-mock-sensor-type①③">(12)</a> <a href="#ref-for-mock-sensor-type①④">(13)</a> <a href="#ref-for-mock-sensor-type①⑤">(14)</a>
     <li><a href="#ref-for-mock-sensor-type①⑥">9.2.1. Create mock sensor</a> <a href="#ref-for-mock-sensor-type①⑦">(2)</a>
     <li><a href="#ref-for-mock-sensor-type①⑧">9.2.2. Get mock sensor</a>
     <li><a href="#ref-for-mock-sensor-type①⑨">9.2.3. Update mock sensor reading</a>
@@ -5770,31 +5535,6 @@ for their editorial input.</p>
     <li><a href="#ref-for-enumdef-mocksensortype⑤">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor-reading-values">
-   <b><a href="#mock-sensor-reading-values">#mock-sensor-reading-values</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-mock-sensor-reading-values">9.1.3. Mock sensor type</a>
-    <li><a href="#ref-for-mock-sensor-reading-values①">9.1.3.1. Ambient Light Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values②">9.1.3.2. Accelerometer</a>
-    <li><a href="#ref-for-mock-sensor-reading-values③">9.1.3.3. Linear Acceleration Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values④">9.1.3.4. Gravity Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values⑤">9.1.3.5. Gyroscope</a>
-    <li><a href="#ref-for-mock-sensor-reading-values⑥">9.1.3.6. Magnetometer</a>
-    <li><a href="#ref-for-mock-sensor-reading-values⑦">9.1.3.7. Uncalibrated Magnetometer</a>
-    <li><a href="#ref-for-mock-sensor-reading-values⑧">9.1.3.8. Absolute Orientation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values⑨">9.1.3.9. Relative Orientation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values①⓪">9.1.3.10. Geolocation Sensor</a>
-    <li><a href="#ref-for-mock-sensor-reading-values①①">9.1.3.11. Proximity Sensor</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dictdef-mocksensorreadingvalues">
-   <b><a href="#dictdef-mocksensorreadingvalues">#dictdef-mocksensorreadingvalues</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-mocksensorreadingvalues">9.1. Mock Sensors</a>
-    <li><a href="#ref-for-dictdef-mocksensorreadingvalues①">9.1.3. Mock sensor type</a> <a href="#ref-for-dictdef-mocksensorreadingvalues②">(2)</a>
-    <li><a href="#ref-for-dictdef-mocksensorreadingvalues③">9.2.3. Update mock sensor reading</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-mocksensortype-ambient-light">
    <b><a href="#dom-mocksensortype-ambient-light">#dom-mocksensortype-ambient-light</a></b><b>Referenced in:</b>
    <ul>
@@ -5805,13 +5545,6 @@ for their editorial input.</p>
    <b><a href="#dom-mocksensortype-accelerometer">#dom-mocksensortype-accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-accelerometer">9.1.3. Mock sensor type</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dictdef-accelerometerreadingvalues">
-   <b><a href="#dictdef-accelerometerreadingvalues">#dictdef-accelerometerreadingvalues</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-accelerometerreadingvalues">9.1.3.3. Linear Acceleration Sensor</a>
-    <li><a href="#ref-for-dictdef-accelerometerreadingvalues①">9.1.3.4. Gravity Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-mocksensortype-linear-acceleration">
@@ -5850,12 +5583,6 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-mocksensortype-absolute-orientation">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-absoluteorientationreadingvalues">
-   <b><a href="#dictdef-absoluteorientationreadingvalues">#dictdef-absoluteorientationreadingvalues</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-absoluteorientationreadingvalues">9.1.3.9. Relative Orientation Sensor</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-mocksensortype-relative-orientation">
    <b><a href="#dom-mocksensortype-relative-orientation">#dom-mocksensortype-relative-orientation</a></b><b>Referenced in:</b>
    <ul>
@@ -5872,6 +5599,20 @@ for their editorial input.</p>
    <b><a href="#dom-mocksensortype-proximity">#dom-mocksensortype-proximity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-proximity">9.1.3. Mock sensor type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mock-sensor-reading-values">
+   <b><a href="#mock-sensor-reading-values">#mock-sensor-reading-values</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mock-sensor-reading-values">9.1.3. Mock sensor type</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-mocksensorreadingvalues">
+   <b><a href="#dictdef-mocksensorreadingvalues">#dictdef-mocksensorreadingvalues</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-mocksensorreadingvalues">9.1. Mock Sensors</a>
+    <li><a href="#ref-for-dictdef-mocksensorreadingvalues①">9.1.3. Mock sensor type</a> <a href="#ref-for-dictdef-mocksensorreadingvalues②">(2)</a>
+    <li><a href="#ref-for-dictdef-mocksensorreadingvalues③">9.2.3. Update mock sensor reading</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="no-such-mock-sensor">
@@ -5896,13 +5637,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-extension-specification②">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-extension-specification③">8.14. Get value from latest reading</a>
     <li><a href="#ref-for-extension-specification④">9. Automation</a>
-    <li><a href="#ref-for-extension-specification⑤">10. Extensibility</a> <a href="#ref-for-extension-specification⑥">(2)</a> <a href="#ref-for-extension-specification⑦">(3)</a>
-    <li><a href="#ref-for-extension-specification⑧">10.1. Security and Privacy</a>
-    <li><a href="#ref-for-extension-specification⑨">10.3. Unit</a>
-    <li><a href="#ref-for-extension-specification①⓪">10.4. Exposing High-Level vs. Low-Level Sensors</a>
-    <li><a href="#ref-for-extension-specification①①">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
-    <li><a href="#ref-for-extension-specification①②">10.6. Definition Requirements</a> <a href="#ref-for-extension-specification①③">(2)</a> <a href="#ref-for-extension-specification①④">(3)</a> <a href="#ref-for-extension-specification①⑤">(4)</a>
-    <li><a href="#ref-for-extension-specification①⑥">10.8. Extending the Feature Policy API</a>
+    <li><a href="#ref-for-extension-specification⑤">9.1.3. Mock sensor type</a>
+    <li><a href="#ref-for-extension-specification⑥">10. Extensibility</a> <a href="#ref-for-extension-specification⑦">(2)</a> <a href="#ref-for-extension-specification⑧">(3)</a>
+    <li><a href="#ref-for-extension-specification⑨">10.1. Security and Privacy</a>
+    <li><a href="#ref-for-extension-specification①⓪">10.3. Unit</a>
+    <li><a href="#ref-for-extension-specification①①">10.4. Exposing High-Level vs. Low-Level Sensors</a>
+    <li><a href="#ref-for-extension-specification①②">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
+    <li><a href="#ref-for-extension-specification①③">10.6. Definition Requirements</a> <a href="#ref-for-extension-specification①④">(2)</a> <a href="#ref-for-extension-specification①⑤">(3)</a> <a href="#ref-for-extension-specification①⑥">(4)</a>
+    <li><a href="#ref-for-extension-specification①⑦">10.8. Extending the Feature Policy API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extension-sensor-interface">


### PR DESCRIPTION
Which has been upstreamed to concrete sensor specs.
Fixes #378


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/sensors/pull/380.html" title="Last updated on Jan 29, 2019, 6:09 AM UTC (a5d943b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/380/e6f63e2...Honry:a5d943b.html" title="Last updated on Jan 29, 2019, 6:09 AM UTC (a5d943b)">Diff</a>