### PR TITLE
Syntax correction for the Feature-Policy response header example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2162,7 +2162,7 @@ The accelerometer feature is selectively enabled for third-party origin by addin
 A sensor usage is disabled completely by specifying the feature policy in a HTTP
 response header:
 <pre highlight="js">
- Feature-Policy: {"accelerometer": []}
+ Feature-Policy: accelerometer 'self' https://third-party.com
 </pre>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2162,7 +2162,7 @@ The accelerometer feature is selectively enabled for third-party origin by addin
 A sensor usage is disabled completely by specifying the feature policy in a HTTP
 response header:
 <pre highlight="js">
- Feature-Policy: accelerometer 'self' https://third-party.com
+ Feature-Policy: accelerometer 'none'
 </pre>
 </div>
 


### PR DESCRIPTION
It looks to me, that incorrect syntax has been used for the FP header, for reference: https://w3c.github.io/webappsec-feature-policy/#examples


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Malvoz/sensors/pull/395.html" title="Last updated on Oct 21, 2019, 3:24 PM UTC (fb107d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/395/7c0b8f9...Malvoz:fb107d9.html" title="Last updated on Oct 21, 2019, 3:24 PM UTC (fb107d9)">Diff</a>