### PR TITLE
Update "Security and privacy considerations" and "Permissions API"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -351,17 +351,6 @@ and defensive programming which includes:
 The judgement on how to communicate to the user the known [[#main-privacy-security-threats|threats]]
 is up to the implementer. The implementation of the [[#mitigation-strategies|mitigations]] is
 mandatory, however.
-
-The Generic Sensor API and its [=extension specifications=] are agnostic with respect to any user
-interface aspects. This specification defines an [[#request-sensor-access|integration point]] to the
-Permissions API [[PERMISSIONS]] that implementers can use for [=new information about the user's intent|
-explicit or implicit user consenting=]. In addition, implementers are encouraged to use additional
-privacy-enhancing mechanisms inline with their product requirements to provide a consistent and
-cohesive experience. Such mechanisms can include, for example, global and per-origin access controls,
-page info dialogs, location bar indicators, or other disclosure user interface elements.
-
-The Generic Sensor API provides flexibility to implementers to make user consenting and
-disclosure user interface design decisions on a concrete sensor basis as needed.
 </div>
 
 [=sensor readings|Sensor readings=] are sensitive data and could become a subject of
@@ -497,9 +486,6 @@ is "visible".
 <h4 id="permissions" oldids="permissioning">Permissions API</h4>
 
 Access to [=sensor readings=] are controlled by the Permissions API [[!PERMISSIONS]].
-User agents use a [=new information about the user's intent|number of criteria=]
-to grant access to the [=sensor readings|readings=].
-Note that access can be granted without prompting the user.
 
 <h3 id="mitigation-strategies-case-by-case">Mitigation strategies applied on a case by case basis</h3>
 


### PR DESCRIPTION
These changes address wide review feedback from PING.

Fix #396

PTAL @snyderp


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 14, 2019, 9:21 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fsensors%2Fpull%2F400%2F89c2080.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fsensors%2Fpull%2F400.html)

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
<head><title>HTML Diff service</title>
<link rel="stylesheet" href="http://www.w3.org/StyleSheets/base" />
</head>
<body>

<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C"/></a> <a href="http://www.w3.org/2003/Editors">W3C Editors homepage</a></p>

<h1>Create Diff between HTML pages</h1>

<p style='color:#FF0000'>An error (403 Forbidden) occured trying to get <a href='https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/400/89c2080.html'>https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/400/89c2080.html</a>.</p>

<form method="GET">
<p>Address of reference document: <input name="doc1" type="url" value="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/400/89c2080.html" style="width:100%"/></p>
<p>Address of new document: <input name="doc2" value="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/400.html"  style="width:100%"/></p>
<p><input type="submit" value="get Diff"/></p>
</form>

<p><strong>Tip</strong>: if the document uses the W3C convention on linking to its previous version, you can specify only the address of the new document — the previous link will be automatically detected.</p>
<h2>Diff markings</h2>
<p>This service relies on <a href="https://www.gnu.org/software/diffutils/">GNU diff</a>. The found differences are roughly marked as follow:
<ul>
<li>deleted text is shown in pink with down-arrows (as styled for a &lt;del> element)</li>
<li>where there is replacement, it’s shown in green with bi-directional arrows,</li>
<li>where there is newly inserted text, it’s yellow with up arrows (&lt;ins> element)</li>
</ul>
<address>
script $Revision$ of $Date$<br />
by <a href="http://www.w3.org/People/Dom/">Dominique Hazaël-Massieux</a><br />based on <a href="https://dev.w3.org/cvsweb/2009/htmldiff/htmldiff.pl">Shane McCarron’ Perl script</a> wrapped in a <a href="http://dev.w3.org/cvsweb/2009/htmldiff/">Python CGI</a>
</address>
</body>
</html>


```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/sensors%23400.)._
</details>
