### PR TITLE
Make the permission request algorithm normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,6 +27,8 @@ Boilerplate: omit issues-index, omit conformance, omit feedback-header
 Ignored Vars: activated_sensors
 Inline GitHub Issues: yes
 Default Biblio Status: current
+Status Text: Further implementation experience is being gathered for the [=permission request algorithm=] and specification clarifications informed by this experience are being discussed in <a href="https://github.com/w3c/sensors/issues/397">GitHub issue #397</a>.
+At Risk: [[PERMISSIONS-REQUEST]]
 </pre>
 <pre class="anchors">
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM
@@ -831,6 +833,8 @@ A [=sensor type=] has a [=permission revocation algorithm=].
         1.  [=set/For each=] |sensor| in |sensor_type|'s [=ordered set|set=] of [=associated sensors=],
             1.  Invoke [=revoke sensor permission=] with |sensor| as argument.
 </div>
+
+A [=sensor type=] has a [=permission request algorithm=].
 
 A [=sensor type=] has a [=set/is empty|nonempty=] [=ordered set|set=] of associated
 [=policy-controlled feature=] tokens referred to as <dfn export>sensor feature names</dfn>.


### PR DESCRIPTION
Note in SOTD [PERMISSIONS-REQUEST] is "at-risk".

Related: #397


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/401.html" title="Last updated on Dec 3, 2019, 6:44 PM UTC (7f05923)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/401/747a95f...7f05923.html" title="Last updated on Dec 3, 2019, 6:44 PM UTC (7f05923)">Diff</a>