### PR TITLE
Fix up the focused area restrictions.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -475,9 +475,9 @@ the given [=sensor type=]. See [[FEATURE-POLICY]] for more details.
 
 <h4 id="focused-area" oldids="losing-focus">Focused Area</h4>
 
-[=Sensor readings=] are only available for [=active documents=] whose
-origin is [=same origin-domain=] with the [=currently focused area=]
-document.
+[=Sensor readings=] are only available for [=active documents=] whose origin is
+[=same origin-domain=] with the document of the [=currently focused area=] of
+the [=top-level browsing context=] of the specified [=active document=].
 
 This is done in order to mitigate the risk of a skimming attack against the
 [=browsing context=] containing an element which has [=gains focus|gained focus=],
@@ -802,8 +802,10 @@ The <dfn>mandatory conditions</dfn> are the following:
  - [=document visibility state|Visibility state=] of the document is "visible".
  - The document is [=allowed to use=] all the [=policy-controlled features=] associated
    with the given [=sensor type=].
- - [=Currently focused area=] belongs to a document whose origin is [=same origin-domain=]
-   with the origin of the given [=active document=].
+ - The [=currently focused area=] of the [=top-level browsing context=] of the
+   [=Document/browsing context=] of the given [=active document=] belongs to a
+   document whose origin is [=same origin-domain=] with the origin of the given
+   [=active document=].
  - <dfn>Specific conditions</dfn>: The [=extension specifications=] that add new
    [=mandatory conditions|conditions=] hook into this specification at this point.
 


### PR DESCRIPTION
I think this is what you meant. The old text in Mitigations, "the currently focused area document", doesn't have a meaning. The text in "mandatory conditions" was better, but isn't clear about which currently focused area to use, since every top-level browsing context has one.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/sensors/pull/403.html" title="Last updated on Feb 23, 2021, 3:22 AM UTC (9ad2556)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/403/7c43c34...jyasskin:9ad2556.html" title="Last updated on Feb 23, 2021, 3:22 AM UTC (9ad2556)">Diff</a>