### PR TITLE
Rename Feature Policy to Permissions Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -77,12 +77,6 @@ urlPrefix: https://www.w3.org/TR/page-visibility-2/; spec: PAGE-VISIBILITY
 urlPrefix: https://w3ctag.github.io/security-questionnaire/; spec: SECURITY-PRIVACY-QUESTIONNAIRE
   type: dfn
     text: same-origin policy violations; url: sop-violations
-urlPrefix: https://w3c.github.io/webappsec-feature-policy/; spec: FEATURE-POLICY
-  type: dfn
-    text: allow attribute; url: iframe-allow-attribute
-    text: default allowlist
-    text: policy-controlled feature
-    text: allowed to use; url: should-request-be-allowed-to-use-feature
 urlPrefix: https://www.w3.org/TR/permissions/; spec: PERMISSIONS
   type: dfn
     text: permission name; url: enumdef-permissionname
@@ -342,7 +336,7 @@ and defensive programming which includes:
         } catch (error) {
             // Handle construction errors.
             if (error.name === 'SecurityError') {
-                console.log('Sensor construction was blocked by the Feature Policy.');
+                console.log('Sensor construction was blocked by the Permissions Policy.');
             } else if (error.name === 'ReferenceError') {
                 console.log('Sensor is not supported by the User Agent.');
             } else {
@@ -466,12 +460,12 @@ or [=extension specifications=]
 are only available within a [=secure context=].
 
 
-<h4 id="feature-policy" oldids="browsing-context">Feature Policy</h4>
+<h4 id="permissions-policy" oldids="browsing-context,feature-policy">Permissions Policy</h4>
 
 To avoid the privacy risk of sharing [=sensor readings=] with contexts unfamiliar
 to the user, [=sensor readings=] are only available for the
 [=documents=] which are [=allowed to use=] the [=policy-controlled features=] for
-the given [=sensor type=]. See [[FEATURE-POLICY]] for more details.
+the given [=sensor type=]. See [[PERMISSIONS-POLICY]] for more details.
 
 <h4 id="focused-area" oldids="losing-focus">Focused Area</h4>
 
@@ -2124,7 +2118,7 @@ for accelerometer sensor is given below.
     };
 </pre>
 
-<h3 id="feature-policy-api">Extending the Feature Policy API</h3>
+<h3 id="permissions-policy-api" oldids="feature-policy-api">Extending the Permissions Policy API</h3>
 
 An implementation of the {{Sensor}} interface for each [=sensor type=] has one
 (if [=sensor fusion=] is not performed) or several [=policy-controlled features=]
@@ -2146,18 +2140,18 @@ otherwise, the [=sensor feature names=] matches the same [=sensor type|type=]-as
 [=sensor permission names=].
 
 <div class="example html">
-The accelerometer feature is selectively enabled for third-party origin by adding
-[=allow attribute=] to the frame container element:
+The accelerometer feature is selectively enabled for third-party origin by adding an
+<{iframe/allow}> attribute to the frame container element:
 <pre highlight="html">
   &lt;iframe src="https://third-party.com" allow="accelerometer"/&gt;&lt;/iframe&gt;
 </pre>
 </div>
 
 <div class="example html">
-A sensor usage is disabled completely by specifying the feature policy in a HTTP
+A sensor usage is disabled completely by specifying the permissions policy in an HTTP
 response header:
 <pre highlight="js">
- Feature-Policy: accelerometer 'none'
+ Permissions-Policy: accelerometer=()
 </pre>
 </div>
 


### PR DESCRIPTION
Feature Policy has been renamed, and the spec has moved. This change
updates the integration to point to the new locations, and to use the
new name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/sensors/pull/407.html" title="Last updated on Oct 20, 2020, 5:03 PM UTC (185db8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/407/6eb608d...clelland:185db8a.html" title="Last updated on Oct 20, 2020, 5:03 PM UTC (185db8a)">Diff</a>