### PR TITLE
Update stability status in SOTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,7 @@ Status Text:
   <a href="https://github.com/w3c/sensors/issues/397">GitHub issue #397</a>.
   The group does not expect to advance this specification beyond CR until
   [[PERMISSIONS-REQUEST]] moves beyond incubation.
+  This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM


### PR DESCRIPTION
Required to pass specberus sotd.draft-stability test and to unblock TR publication.

(spec-prod log: https://github.com/w3c/sensors/actions/runs/1534827436)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/417.html" title="Last updated on Dec 3, 2021, 11:25 AM UTC (8dc5d67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/417/bf5bdf1...8dc5d67.html" title="Last updated on Dec 3, 2021, 11:25 AM UTC (8dc5d67)">Diff</a>