### PR TITLE
Adjust references to terms defined in the Permissions spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -79,10 +79,6 @@ urlPrefix: https://www.w3.org/TR/page-visibility-2/; spec: PAGE-VISIBILITY
 urlPrefix: https://w3ctag.github.io/security-questionnaire/; spec: SECURITY-PRIVACY-QUESTIONNAIRE
   type: dfn
     text: same-origin policy violations; url: sop-violations
-urlPrefix: https://www.w3.org/TR/permissions/; spec: PERMISSIONS
-  type: dfn
-    text: name; url: dfn-name
-    text: permission state
 urlPrefix: https://w3c.github.io/webdriver/; spec: WebDriver
   type: dfn
     text: current browsing context; url: dfn-current-browsing-context
@@ -792,7 +788,7 @@ The user agent must verify that all [=mandatory conditions=] are satisfied to en
 
 The <dfn>mandatory conditions</dfn> are the following:
  - The given document is a [=responsible document=] of a [=secure context=].
- - For each [=name=] from the [=sensor type=]'s associated
+ - For each [=powerful feature/name=] from the [=sensor type=]'s associated
    [=sensor permission names=] [=ordered set|set=], the corresponding permission's
    [=permission state|state=] is "granted".
  - [=document visibility state|Visibility state=] of the document is "visible".
@@ -819,9 +815,9 @@ A [=sensor type=] has a [=ordered set|set=] of <dfn export>associated sensors</d
 A [=sensor type=] may have a [=default sensor=].
 
 A [=sensor type=] has a [=set/is empty|nonempty=] [=ordered set|set=] of associated
-[=names=] referred to as <dfn export>sensor permission names</dfn>.
+[=powerful feature/names=] referred to as <dfn export>sensor permission names</dfn>.
 
-Note: multiple [=sensor types=] may share the same [=name=].
+Note: multiple [=sensor types=] may share the same [=powerful feature/name=].
 
 A [=sensor type=] has a [=permission revocation algorithm=].
 
@@ -829,7 +825,7 @@ A [=sensor type=] has a [=permission revocation algorithm=].
 
     To invoke the <dfn local-lt="permission revocation algorithm" export>
     generic sensor permission revocation algorithm</dfn>
-    with [=name=] |permission_name|, run the following steps:
+    with [=powerful feature/name=] |permission_name|, run the following steps:
 
     1.  For each |sensor_type| whose [=sensor permission names|permission names=] [=set/contains=] |permission_name|:
         1.  [=set/For each=] |sensor| in |sensor_type|'s [=ordered set|set=] of [=associated sensors=],
@@ -2068,8 +2064,8 @@ each [=sensor type=] in [=extension specifications=]:
     [=get value from latest reading=] with <strong>this</strong> and
     [=attribute=] [=identifier=] as arguments.
 
--   A [=name=], if the [=sensor type=] is not representing
-    [=sensor fusion=] (otherwise, [=names=]
+-   A [=powerful feature/name=], if the [=sensor type=] is not representing
+    [=sensor fusion=] (otherwise, [=powerful feature/names=]
     associated with the fusion source [=sensor types=] must be used).
 
 An [=extension specification=] may specify the following definitions
@@ -2096,8 +2092,8 @@ In order to enable user-agent automation and application testing,
 <h3 id="permission-api">Extending the Permission API</h3>
 
 An implementation of the {{Sensor}} interface for each [=sensor type=] must protect its
-[=sensor reading|reading=] by associated [=name=] or {{PermissionDescriptor}}.
-A [=Low-level=] {{Sensor|sensor}} may use its interface name as a [=name=],
+[=sensor reading|reading=] by associated [=powerful feature/name=] or {{PermissionDescriptor}}.
+A [=Low-level=] {{Sensor|sensor}} may use its interface name as a [=powerful feature/name=],
 for instance, "gyroscope" or "accelerometer". [=sensor fusion|Fusion sensors=] must
 [=request permission to use|request permission to access=] each of the sensors that are
 used as a source of fusion.


### PR DESCRIPTION
- Use [=powerful feature/name=] dfn instead of a custom one, as it is now
  Bikeshed's spec-data.
- Similarly, [=permission status=] is also defined in spec-data, so
  reference it from there (this also fixes the reference, which was pointing
  to an invalid anchor in the Permissions spec).
