### PR TITLE
Clean up custom anchors set in the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,44 +38,14 @@ Status Text:
   This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
-urlPrefix: https://dom.spec.whatwg.org; spec: DOM
-  type: dfn
-    text: dispatch; url: concept-event-dispatch
-    text: event; url: concept-event
-    text: event listener; url: concept-event-listener
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
   type: dfn
     urlPrefix: webappapis.html
       text: task queue
-      text: task; url: concept-task
-      text: fire a simple event
-      text: trusted; url: concept-events-trusted
       text: spin the event loop; url: spin-the-event-loop
-    urlPrefix: browsers.html
-      text: navigating; url: navigate
-      text: browsing context
-      text: nested browsing context
-    urlPrefix: iframe-embed-object.html
-      text: allowed-to-use
     urlPrefix: interaction.html
-      text: focused
       text: gains focus; url: gains-focus
-      text: DOM anchor; url: dom-anchor
-      text: focusable area; url: focusable-area
       text: currently focused area; url: currently-focused-area-of-a-top-level-browsing-context
-      text: has focus steps; url: has-focus-steps
-    urlPrefix: origin.html
-      text: origin; url: origin-2
-urlPrefix: https://www.w3.org/TR/hr-time-2/; spec: HR-TIME-2
-  type: interface
-    text: DOMHighResTimeStamp; url: dom-domhighrestimestamp
-  type: dfn
-    text: time origin; url: dfn-time-origin
-urlPrefix: https://www.w3.org/TR/page-visibility-2/; spec: PAGE-VISIBILITY
-  type: dfn
-    text: document visibility state; url: dom-visibilitystate
-    text: visibility states; url: dfn-visibility-states
-    text: steps to determine the visibility state; url: dfn-determine-the-visibility-state
 urlPrefix: https://w3ctag.github.io/security-questionnaire/; spec: SECURITY-PRIVACY-QUESTIONNAIRE
   type: dfn
     text: same-origin policy violations; url: sop-violations
@@ -479,8 +449,7 @@ payment service from within an iframe.
 <h4 id="visibility-state">Visibility State</h4>
 
 [=Sensor readings=] are only available for the [=active documents=] whose
-[=steps to determine the visibility state|visibility state=]
-is "visible".
+[=visibility state=] is "visible".
 
 <h4 id="permissions" oldids="permissioning">Permissions API</h4>
 
@@ -791,7 +760,7 @@ The <dfn>mandatory conditions</dfn> are the following:
  - For each [=powerful feature/name=] from the [=sensor type=]'s associated
    [=sensor permission names=] [=ordered set|set=], the corresponding permission's
    [=permission state|state=] is "granted".
- - [=document visibility state|Visibility state=] of the document is "visible".
+ - The [=visibility state=] of the document is "visible".
  - The document is [=allowed to use=] all the [=policy-controlled features=] associated
    with the given [=sensor type=].
  - [=Currently focused area=] belongs to a document whose origin is [=same origin-domain=]
@@ -845,7 +814,7 @@ associated <dfn>latest reading</dfn> [=ordered map|map=], which holds the latest
 
 Note: User agents can share the [=latest reading=] [=ordered map|map=] and
 the [=activated sensor objects=] [=ordered set|set=] between different
-[=browsing context|contexts=] only if the [=origins=] of these contexts' [=active documents=]
+[=browsing context|contexts=] only if the [=/origins=] of these contexts' [=active documents=]
 are [=same origin-domain=].
 
 Any time a new [=sensor reading=] for a [=platform sensor=] is obtained and if the user agent


### PR DESCRIPTION
A lot of cruft has accumulated over the years, and we can get rid of a lot
of custom anchors that are actually exported by the specs referenced here.

* Page visibility: The Page Visibility spec was merged into the HTML spec
  itself. As such, remove the custom dfn for a few terms and simply refer to
  [=visibility state=], which is now defined and exported by the HTML spec.

* DOM: We were defining 3 terms and only using 1, which is actually exported
  by the DOM spec and present in Bikeshed's spec-data.

* High Resolution Time Level 2: The terms we reference are exported by the
  spec and present in Bikeshed's spec-data, so we do not need to set them
  here.

* HTML: A lot of terms are exported and present in Bikeshed's spec-data;
  keep only those definitions that really are not exported.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/419.html" title="Last updated on Dec 10, 2021, 2:07 PM UTC (9656ac7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/419/429fc2c...rakuco:9656ac7.html" title="Last updated on Dec 10, 2021, 2:07 PM UTC (9656ac7)">Diff</a>