### PR TITLE
Use "e.g." rather than "i.e." in example of non-spatial sensor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -557,7 +557,7 @@ A [=spatial sensor=] can be <dfn>uniaxial</dfn>, <dfn>biaxial</dfn>,
 or <dfn>triaxial</dfn>, depending on the number of orthogonal axes in
 which it can perform simultaneous measurements.
 
-Scalar physical quantities (i.e. temperature) do not require
+Scalar physical quantities (e.g. temperature) do not require
 a [=local coordinate system=] for resolution.
 
 The [=local coordinate system=] normally used in a mobile device is


### PR DESCRIPTION
Temperature is being mentioned as an example of a scalar physical quantity,
so it makes more sense to use "for example" rather than "that is".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/420.html" title="Last updated on Dec 13, 2021, 10:07 AM UTC (3dcf53f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/420/20b7562...rakuco:3dcf53f.html" title="Last updated on Dec 13, 2021, 10:07 AM UTC (3dcf53f)">Diff</a>