### PR TITLE
Capitalize "low-level" correctly in the text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2075,7 +2075,7 @@ In order to enable user-agent automation and application testing,
 
 An implementation of the {{Sensor}} interface for each [=sensor type=] must protect its
 [=sensor reading|reading=] by associated [=powerful feature/name=] or {{PermissionDescriptor}}.
-A [=Low-level=] {{Sensor|sensor}} may use its interface name as a [=powerful feature/name=],
+A [=low-level=] {{Sensor|sensor}} may use its interface name as a [=powerful feature/name=],
 for instance, "gyroscope" or "accelerometer". [=sensor fusion|Fusion sensors=] must
 [=request permission to use|request permission to access=] each of the sensors that are
 used as a source of fusion.
@@ -2115,7 +2115,7 @@ from [=sensor readings=] access.
 The [=sensor feature names=] [=ordered set|set=] must contain [=policy-controlled feature=]
 tokens of every associated [=policy-controlled feature|feature=].
 
-A [=Low-level=] {{Sensor|sensor}} may use its interface name as a [=policy-controlled feature=] token,
+A [=low-level=] {{Sensor|sensor}} may use its interface name as a [=policy-controlled feature=] token,
 for instance, "gyroscope" or "accelerometer". Unless the [=extension specification=] defines
 otherwise, the [=sensor feature names=] matches the same [=sensor type|type=]-associated
 [=sensor permission names=].


### PR DESCRIPTION
The term is mentioned in the middle of a few sentences, where it should be
written in lowercase.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/427.html" title="Last updated on Dec 14, 2021, 4:27 PM UTC (9a1d3ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/427/f9caadf...rakuco:9a1d3ae.html" title="Last updated on Dec 14, 2021, 4:27 PM UTC (9a1d3ae)">Diff</a>