### PR TITLE
Add syntax highlighting to Web IDL examples.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2092,7 +2092,7 @@ it does not need to [=request permission to use|request permission to use=] magn
 for accuracy or [=sampling frequency=]. An example for a possible extension of the Permission API
 for accelerometer sensor is given below.
 
-<pre class=example>
+<pre class="example" highlight="idl">
     dictionary AccelerometerPermissionDescriptor : PermissionDescriptor {
         boolean highAccuracy = false;
         boolean highFrequency = false;
@@ -2153,7 +2153,7 @@ that are required by the absolute orientation sensor.
 Here's an example WebIDL for a possible extension of this specification
 for proximity [=device sensor|sensors=].
 
-<pre class=example>
+<pre class="example" highlight="idl">
     [SecureContext, Exposed=Window]
     interface ProximitySensor : Sensor {
         constructor(optional ProximitySensorOptions proximitySensorOptions = {});


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/428.html" title="Last updated on Dec 14, 2021, 4:31 PM UTC (ec27b1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/428/f9caadf...rakuco:ec27b1f.html" title="Last updated on Dec 14, 2021, 4:31 PM UTC (ec27b1f)">Diff</a>