### PR TITLE
Improve SensorErrorEvent description.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1239,12 +1239,12 @@ dictionary SensorErrorEventInit : EventInit {
 };
 </pre>
 
+{{SensorErrorEvent}} instances are constructed by following the steps described
+in {{Event}}'s <a for="Event">constructor</a>.
 
-### SensorErrorEvent.error ### {#sensor-error-event-error}
-
-The {{SensorErrorEvent/error!!attribute}} getter steps are to return the value it was initialized to.
-
-It represents the {{DOMException}} object passed to {{SensorErrorEventInit}}.
+The <dfn attribute for="SensorErrorEvent">error</dfn> attribute must return the
+value it was initialized to. It represents the {{DOMException}} object passed
+to {{SensorErrorEventInit}}.
 
 <h2 id="abstract-operations">Abstract Operations</h2>
 


### PR DESCRIPTION
Related to #426.

- Refer to Event's constructor steps to describe how SensorErrorEvent is
  initialized and avoid confusion in the future.
- Instead of having a separate session for SensorErrorEvent.error, just have
  a paragraph with the kind of boilerplate description that specs like DOM,
  WebSockets and App History.
