### PR TITLE
Reword the "Conditions to expose sensor readings" section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -751,22 +751,19 @@ never exceed the [=sampling frequency=] for the given [=sensor type=].
 
 ## Conditions to expose sensor readings ## {#concepts-can-expose-sensor-readings}
 
-The user agent must verify that all [=mandatory conditions=] are satisfied to ensure it
-<dfn>can expose sensor readings</dfn> to the {{Sensor}} objects of a certain
-[=sensor type|type=] that belong to a certain [=active document=].
-
-The <dfn>mandatory conditions</dfn> are the following:
- - The given document's [=relevant settings object=] is a [=secure context=].
- - For each [=powerful feature/name=] from the [=sensor type=]'s associated
-   [=sensor permission names=] [=ordered set|set=], the corresponding permission's
-   [=permission state|state=] is "granted".
- - The [=visibility state=] of the document is "visible".
- - The document is [=allowed to use=] all the [=policy-controlled features=] associated
-   with the given [=sensor type=].
- - [=Currently focused area=] belongs to a document whose origin is [=same origin-domain=]
-   with the origin of the given [=active document=].
+The user agent <dfn>can expose sensor readings</dfn> to a given |document| if and only if
+all of the following are true:
+ - |document|'s [=relevant settings object=] is a [=secure context=].
+ - |document|'s [=visibility state=] is "visible".
+ - The [=currently focused area=] belongs to a document whose origin is [=same
+   origin-domain=] with |document|'s origin.
  - <dfn>Specific conditions</dfn>: The [=extension specifications=] that add new
    [=mandatory conditions|conditions=] hook into this specification at this point.
+
+Note: In addition to the conditions above, it is important to note that {{Sensor}}
+subclasses invoke the [=check sensor policy-controlled features=] operation in their
+constructors, and [[#sensor-start]] invokes [=request sensor access=]. Together, these
+checks correspond to the mitigation strategies described in [[#mitigation-strategies]].
 
 Note: In order to release hardware resources, the user agent can request underlying
 [=platform sensor=] to suspend notifications about newly available readings until it


### PR DESCRIPTION
Follow-up to the review comments in #433.

The previous definition of "can expose sensor readings" was a bit too loose.
It relied on a `[=sensor type=]` that was not passed to the operation and
used "given document" to refer to the active document referenced in a prior
paragraph.

Instead:
- Do away with all the "mandatory conditions" bits and only define "can
  expose sensor readings".
- Make said "can expose sensor readings" check explicitly require a
  `Document`. All parts of the spec that referenced this definition were
  already invoking it together with "the current browsing context's active
  document".
- Remove the checks related to the Permissions and Permissions Policy APIs.
  They required access to a sensor type that could not be easily retrieved
  by all callers; additionally, concrete Sensor classes all perform the
  Permissions Policy API checks in their constructors and `Sensor.start()`
  ensures the required permissions have been granted. We now make this
  explicit in a new note.

One possible improvement would be to normatively require all concrete Sensor
classes to invoke "check sensor policy-controlled features" in their
constructors, as this is currently done but not mandated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/434.html" title="Last updated on Apr 14, 2022, 2:40 PM UTC (2b77580)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/434/f15c553...rakuco:2b77580.html" title="Last updated on Apr 14, 2022, 2:40 PM UTC (2b77580)">Diff</a>