### PR TITLE
Revert "Temporarily disable links inside embedded SVG to allow CI to work."

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -966,49 +966,46 @@ The [=task source=] for the [=tasks=] mentioned in this specification is the <df
             }
         }
     </style>
-    <!-- Links have been temporarily disabled to allow CI to work. See w3c/spec-prod#139 for more information. -->
     <g class="graph" transform="scale(1 1) rotate(0) translate(4 74.5122)">
         <title>Sensor lifecycle</title>
-        <!-- <a xlink:href="#dom-sensor-state-slot"> -->
+        <a xlink:href="#dom-sensor-state-slot">
             <g class="node">
                 <title>idle</title>
                 <path d="M96.997,-64C96.997,-64 66.997,-64 66.997,-64 60.997,-64 54.997,-58 54.997,-52 54.997,-52 54.997,-36 54.997,-36 54.997,-30 60.997,-24 66.997,-24 66.997,-24 96.997,-24 96.997,-24 102.997,-24 108.997,-30 108.997,-36 108.997,-36 108.997,-52 108.997,-52 108.997,-58 102.997,-64 96.997,-64" fill="white" stroke="black"/>
                 <text text-anchor="middle" transform="translate(0,-2)" x="81.997" y="-41.2">idle</text>
             </g>
-        <!-- </a> -->
-        <!-- <a xlink:href="#dom-sensor-state-slot"> -->
+        </a>
+        <a xlink:href="#dom-sensor-state-slot">
             <g class="node">
                 <title>activating</title>
                 <path d="M214.997,-64C214.997,-64 156.997,-64 156.997,-64 150.997,-64 144.997,-58 144.997,-52 144.997,-52 144.997,-36 144.997,-36 144.997,-30 150.997,-24 156.997,-24 156.997,-24 214.997,-24 214.997,-24 220.997,-24 226.997,-30 226.997,-36 226.997,-36 226.997,-52 226.997,-52 226.997,-58 220.997,-64 214.997,-64" fill="white" stroke="black"/>
                 <text text-anchor="middle" transform="translate(0,-2)" x="185.997" y="-41.2">activating</text>
             </g>
-        <!-- </a> -->
+        </a>
         <g class="edge">
             <title>idle-&gt;activating</title>
             <path d="M109,-38.0296C116.891,-37.4946 125.842,-37.2349 134.762,-37.2507" fill="none" stroke="black"/>
             <polygon fill="black" points="144.762,-37.3855 134.702,-41.7502 139.762,-37.318 134.763,-37.2506 134.763,-37.2506 134.763,-37.2506 139.762,-37.318 134.823,-32.751 144.762,-37.3855 144.762,-37.3855" stroke="black"/>
             <text text-anchor="middle" transform="translate(0,-4)" x="133.576" y="-20.9121">start()</text>
-            <!-- <a xlink:href="#sensor-start"> -->
+            <a xlink:href="#sensor-start">
                 <text text-anchor="middle" transform="translate(0,-4)" x="133.576" y="-20.9121">start()</text>
-            <!-- </a> -->
+            </a>
         </g>
         <g class="edge">
             <title>activating-&gt;idle</title>
             <path d="M144.762,-50.6145C136.302,-50.8304 127.428,-50.7883 119.129,-50.4883" fill="none" stroke="black"/>
             <polygon fill="black" points="109,-49.9704 119.217,-45.987 113.993,-50.2258 118.987,-50.4811 118.987,-50.4811 118.987,-50.4811 113.993,-50.2258 118.757,-54.9753 109,-49.9704 109,-49.9704" stroke="black"/>
             <text text-anchor="middle" transform="translate(0,-4)" x="119.656" y="-59.3122">
-                <!-- <a xlink:href="#sensor-onerror"> -->
-                    onerror
-                <!-- </a> -->
+                <a xlink:href="#sensor-onerror">onerror</a>
             </text>
         </g>
-        <!-- <a xlink:href="#dom-sensor-state-slot"> -->
+        <a xlink:href="#dom-sensor-state-slot">
             <g class="node">
                 <title>activated</title>
                 <path d="M330.997,-40C330.997,-40 274.997,-40 274.997,-40 268.997,-40 262.997,-34 262.997,-28 262.997,-28 262.997,-12 262.997,-12 262.997,-6 268.997,-0 274.997,-0 274.997,-0 330.997,-0 330.997,-0 336.997,-0 342.997,-6 342.997,-12 342.997,-12 342.997,-28 342.997,-28 342.997,-34 336.997,-40 330.997,-40" fill="white" stroke="black"/>
                 <text text-anchor="middle" transform="translate(0,-2)" x="302.997" y="-17.2">activated</text>
             </g>
-        <!-- </a> -->
+        </a>
         <g class="edge">
             <title>activating-&gt;activated</title>
             <path d="M227.218,-35.606C235.505,-33.8766 244.319,-32.037 252.881,-30.2504" fill="none" stroke="black"/>
@@ -1018,15 +1015,7 @@ The [=task source=] for the [=tasks=] mentioned in this specification is the <df
             <title>activated-&gt;idle</title>
             <path d="M262.74,-17.3829C244.593,-16.1731 226.997,-15 226.997,-15 226.997,-15 144.997,-15 144.997,-15 144.997,-15 132.341,-20.9199 118.465,-27.4103" fill="none" stroke="black"/>
             <polygon fill="black" points="109.291,-31.7014 116.442,-23.3883 113.82,-29.5829 118.349,-27.4645 118.349,-27.4645 118.349,-27.4645 113.82,-29.5829 120.255,-31.5406 109.291,-31.7014 109.291,-31.7014" stroke="black"/>
-            <text text-anchor="middle" transform="translate(0,-4)" x="200" y="5">
-                <!-- <a xlink:href="#sensor-stop"> -->
-                    stop()
-                <!-- </a> -->
-                /
-                <!-- <a xlink:href="#sensor-onerror"> -->
-                    onerror
-                <!-- </a> -->
-            </text>
+            <text text-anchor="middle" transform="translate(0,-4)" x="200" y="5"><a xlink:href="#sensor-stop">stop()</a> / <a xlink:href="#sensor-onerror">onerror</a></text>
         </g>
         <g class="node">
             <title>start</title>
@@ -1036,9 +1025,9 @@ The [=task source=] for the [=tasks=] mentioned in this specification is the <df
             <title>start-&gt;idle</title>
             <path d="M19.2724,-44C25.2754,-44 34.8461,-44 44.6767,-44" fill="none" stroke="black"/>
             <polygon fill="black" points="54.8766,-44 44.8767,-48.5001 49.8766,-44 44.8766,-44.0001 44.8766,-44.0001 44.8766,-44.0001 49.8766,-44 44.8766,-39.5001 54.8766,-44 54.8766,-44" stroke="black"/>
-            <!-- <a xlink:href="#extension-sensor-interface"> -->
+            <a xlink:href="#extension-sensor-interface">
                 <text text-anchor="middle" transform="translate(0,-4)" x="29.5" y="-52.1333">construct</text>
-            <!-- </a> -->
+            </a>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
This reverts commit fd2a4560b6ab5611be315653f707bd7aef28d740.

w3c/spec-prod#139 has been fixed, so we can enable the links in the SVG
diagram again.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/438.html" title="Last updated on Jun 7, 2022, 8:43 AM UTC (933268f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/438/8781e48...rakuco:933268f.html" title="Last updated on Jun 7, 2022, 8:43 AM UTC (933268f)">Diff</a>