### PR TITLE
initialize a sensor object: Explicitly require |options| to be a SensorOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1268,7 +1268,7 @@ to {{SensorErrorEventInit}}.
 
     : input
     :: |sensor_instance|, a {{Sensor}} object.
-    :: |options|, a [=dictionary=] object.
+    :: |options|, a {{SensorOptions}} dictionary instance.
     : output
     :: None
 


### PR DESCRIPTION
This algorithm, invoked by the constructor of interfaces deriving from
`Sensor`, was accepting any dictionary. This meant it was possible, for
example, for any member (including `frequency`) to actually have any type
whatsoever.

Be more strict and require `options` to be a `SensorsOptions` instance, or
an instance of a dictionary inheriting from `SensorOptions`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/439.html" title="Last updated on Sep 21, 2022, 10:53 AM UTC (fa57114)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/439/60756e1...rakuco:fa57114.html" title="Last updated on Sep 21, 2022, 10:53 AM UTC (fa57114)">Diff</a>