### PR TITLE
Initialize a sensor object: Improve notation and terms being referenced.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1275,10 +1275,10 @@ to {{SensorErrorEventInit}}.
     1.  [=map/For each=] |key| → <var ignore>value</var> of |options|
         1.  If the associated [=supported sensor options=] [=set/contains|does not contain=] |key|
             1. [=Throw=] "{{NotSupportedError!!exception}}" {{DOMException}}.
-    1.  If |options|.{{frequency!!dict-member}} is [=present=], then
-        1.  Set |sensor_instance|.{{[[frequency]]}} to |options|.{{frequency!!dict-member}}.
+    1.  If |options|["{{frequency!!dict-member}}"] [=map/exists=], then
+        1.  Set |sensor_instance|.{{[[frequency]]}} to |options|["{{frequency!!dict-member}}"].
 
-        Note: there is not guarantee that the requested |options|.{{frequency!!dict-member}}
+        Note: there is not guarantee that the requested |options|["{{frequency!!dict-member}}"]
         can be respected. The actual [=sampling frequency=] can be calculated using
         {{Sensor}} {{Sensor/timestamp!!attribute}} attributes.
 </div>


### PR DESCRIPTION
* Instead of checking if a dictionary member is present, use the more
  standard "exists" reference instead.
* Use the standard foo["bar"] notation to access a dictionary member rather
  than foo.bar.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/440.html" title="Last updated on Sep 26, 2022, 10:48 AM UTC (6cb0ad1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/440/60756e1...rakuco:6cb0ad1.html" title="Last updated on Sep 26, 2022, 10:48 AM UTC (6cb0ad1)">Diff</a>