### PR TITLE
Use right notation for default allowlist value.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2128,9 +2128,9 @@ An implementation of the {{Sensor}} interface for each [=sensor type=] has one
 that control whether or not this implementation can be used in a document.
 
 The [=policy-controlled feature|features=]' [=default allowlist=] is
-<code>["self"]</code>.
+`'self'`.
 
-Note: The [=default allowlist=] of <code>["self"]</code> allows {{Sensor}} interface
+Note: The [=default allowlist=] of `'self'` allows {{Sensor}} interface
 implementation usage in same-origin nested frames but prevents third-party content
 from [=sensor readings=] access.
 


### PR DESCRIPTION
w3c/webappsec-permissions-policy#123 clarified the notation and types used by allowlists and default allowlists.

Default allowlists are not allowlists themselves, so we need to use `"self"` rather than `["self"]`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/442.html" title="Last updated on Nov 23, 2022, 11:06 AM UTC (2527a1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/442/b574bb9...rakuco:2527a1c.html" title="Last updated on Nov 23, 2022, 11:06 AM UTC (2527a1c)">Diff</a>