### PR TITLE
Use "exists" rather than "is present" in dictionary checks.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1767,9 +1767,9 @@ Each [=mock sensor type=] has a [=mock sensor reading values=] dictionary:
         1.  Set |mock|'s [=mock sensor type=] to |type|.
         1.  Let |connected| be the |configuration|.{{MockSensorConfiguration/connected}}, set |mock|'s associated
             [=connection flag=] to |connected|.
-        1.  If |configuration|.{{MockSensorConfiguration/maxSamplingFrequency}} is [=present=], then:
+        1.  If |configuration|.{{MockSensorConfiguration/maxSamplingFrequency}} [=map/exists=], then:
             1.  Set |mock|'s maximum supported sampling frequency to |configuration|.{{MockSensorConfiguration/maxSamplingFrequency}}.
-        1.  If |configuration|.{{MockSensorConfiguration/minSamplingFrequency}} is [=present=], then:
+        1.  If |configuration|.{{MockSensorConfiguration/minSamplingFrequency}} [=map/exists=], then:
             1.  Set |mock|'s minimum supported sampling frequency to |configuration|.{{MockSensorConfiguration/minSamplingFrequency}}.
         1.  Let |sensor_instance| be a |type| of {{Sensor}} object, set |sensor_instance|'s associated [=platform sensor=] to |mock|.
     1.  Return [=success=] with data `null`.


### PR DESCRIPTION
whatwg/webidl#859 removed the "present" and "not present" terms; specs are
supposed to use Infra's "exists" for dictionaries instead.

We had already done this in #440, but there were some leftovers in the
Automation section.

Related to #444.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/445.html" title="Last updated on Dec 7, 2022, 4:18 PM UTC (bee4a2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/445/9f43814...rakuco:bee4a2e.html" title="Last updated on Dec 7, 2022, 4:18 PM UTC (bee4a2e)">Diff</a>