### PR TITLE
Sensor.start(): Check for permission before attempting to connect to sensor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1145,6 +1145,13 @@ It represents a [=reading timestamp=].
         return.
     1.  Set [=this=].{{[[state]]}} to "activating".
     1.  Run these sub-steps [=in parallel=]:
+        1.  Let |permissionState| be the result of invoking
+            [=request sensor access=] with [=this=] as argument.
+        1.  If |permissionState| is "denied", then:
+            1.  Let |e| be the result of [=created|creating=]
+                a "{{NotAllowedError!!exception}}" {{DOMException}}.
+            1.  Queue a task to run [=notify error=] with [=this=] and |e| as arguments.
+            1.  Return.
         1.  Let |connected| be the result of invoking [=connect to sensor=] with [=this=]
             as argument.
         1.  If |connected| is false, then
@@ -1162,14 +1169,7 @@ It represents a [=reading timestamp=].
                 but it is a tradeoff some User Agent might choose to make. -->
             1.  Queue a task to run [=notify error=] with [=this=] and |e| as arguments.
             1.  Return.
-        1.  Let |permission_state| be the result of invoking
-            [=request sensor access=] with [=this=] as argument.
-        1.  If |permission_state| is "granted",
-            1.  Invoke [=activate a sensor object=] with [=this=] as argument.
-        1.  Otherwise, if |permission_state| is "denied",
-            1.  Let |e| be the result of [=created|creating=]
-                a "{{NotAllowedError!!exception}}" {{DOMException}}.
-            1.  Queue a task to run [=notify error=] with [=this=] and |e| as arguments.
+        1.  Invoke [=activate a sensor object=] with [=this=] as argument.
 </div>
 
 


### PR DESCRIPTION
This better reflects the current implementation in Chromium. Additionally,
it makes more sense to check for permission and bail out early than to run
"connect to sensor", failing and having to remove the connection.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/447.html" title="Last updated on Dec 8, 2022, 4:15 PM UTC (198a0c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/447/5766a8e...rakuco:198a0c3.html" title="Last updated on Dec 8, 2022, 4:15 PM UTC (198a0c3)">Diff</a>