### PR TITLE
Bikeshed: Refer to "webdriver2" instead of "webdriver-2" in the anchor section.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -89,7 +89,7 @@ urlPrefix: https://w3c.github.io/proximity; spec: PROXIMITY
 spec: webidl; type:dfn; text:attribute
 spec: webidl; type:dfn; text:dictionary member
 spec: webidl; type:dfn; text:identifier
-spec: webdriver-2; type:dfn; text:error
+spec: webdriver2; type:dfn; text:error
 </pre>
 
 <pre class=biblio>


### PR DESCRIPTION
The spec shortname differed between what bikeshed-data and other W3C
databases like Reffy used.

Following the discussion in tabatkins/bikeshed#2416, Bikeshed has
switched to "webdriver2" to align with the other tools.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/448.html" title="Last updated on Dec 9, 2022, 11:06 AM UTC (dd5364f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/448/287dc53...rakuco:dd5364f.html" title="Last updated on Dec 9, 2022, 11:06 AM UTC (dd5364f)">Diff</a>