### PR TITLE
Request sensor access: remove "in parallel" block.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1552,12 +1552,11 @@ to {{SensorErrorEventInit}}.
     1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
     1.  Let |sensor_permissions| be |sensor|'s associated [=ordered set|set=] of
         [=sensor permission names|permission names=].
-    1.  Run these sub-steps [=in parallel=]:
-        1.  [=set/For each=] |permission_name| in |sensor_permissions|,
-            1.  Let |state| be the result of [=request permission to use|requesting permission to use=] |permission_name|.
-            1.  If |state| is "denied"
-                1.  Return "denied".
-        1.  Otherwise, return "granted".
+    1.  [=set/For each=] |permission_name| in |sensor_permissions|,
+        1.  Let |state| be the result of [=request permission to use|requesting permission to use=] |permission_name|.
+        1.  If |state| is "denied"
+            1.  Return "denied".
+    1.  Return "granted".
 </div>
 
 <h2 id="automation">Automation</h2>


### PR DESCRIPTION
This abstract operation is only invoked from Sensor.start(), which already
calls it from an "in parallel" step. Remove it from the operation's
algorithm to avoid needlessly two levels of "in parallel" steps.
