### PR TITLE
Export the "specific conditions" requirement and reword paragraph.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -755,8 +755,8 @@ all of the following are true:
  - |document|'s [=visibility state=] is "visible".
  - The [=currently focused area=] belongs to a document whose origin is [=same
    origin-domain=] with |document|'s origin.
- - <dfn>Specific conditions</dfn>: The [=extension specifications=] that add new
-   [=mandatory conditions|conditions=] hook into this specification at this point.
+ - <dfn export>Specific conditions</dfn>: [=Extension specifications=] may add new
+   conditions to this list to have stricter requirements for their sensor types.
 
 Note: In addition to the conditions above, it is important to note that {{Sensor}}
 subclasses invoke the [=check sensor policy-controlled features=] operation in their


### PR DESCRIPTION
Mostly some Bikeshed cleanup as a follow-up to #434. That pull request
removed the `<dfn>` for "mandatory conditions", which continued to be
referenced by the "specific conditions" item in the "can expose sensor
readings" list.

Remove the reference to it and, at the same time, export the `<dfn>` for
"specific conditions" so that it can actually be used by extension
specifications.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/452.html" title="Last updated on Jan 13, 2023, 1:00 PM UTC (635bc8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/452/c04e324...rakuco:635bc8d.html" title="Last updated on Jan 13, 2023, 1:00 PM UTC (635bc8d)">Diff</a>