### PR TITLE
editorial: Export "{update,get value from} latest reading".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1393,7 +1393,7 @@ to {{SensorErrorEventInit}}.
     1.  Set [=requested sampling frequency=] to [=optimal sampling frequency=].
 </div>
 
-<h3 dfn>Update latest reading</h3>
+<h3 dfn export>Update latest reading</h3>
 
 <div algorithm="update latest reading">
 
@@ -1517,7 +1517,7 @@ to {{SensorErrorEventInit}}.
 </div>
 
 
-<h3 dfn>Get value from latest reading</h3>
+<h3 dfn export>Get value from latest reading</h3>
 
 <div algorithm="get value from latest reading">
 


### PR DESCRIPTION
These two operations have been referenced by the Ambient Light Sensor spec
since w3c/ambient-light#77 but the `<dfn>`s in this spec were not properly
exported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/453.html" title="Last updated on Jan 17, 2023, 4:00 PM UTC (6072f15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/453/2acb6cf...rakuco:6072f15.html" title="Last updated on Jan 17, 2023, 4:00 PM UTC (6072f15)">Diff</a>