### PR TITLE
editorial: Remove reference to "exception type" in Sensor.onerror.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1201,7 +1201,8 @@ to notify that new [=sensor reading|reading=] is available.
 ### Sensor.onerror ### {#sensor-onerror}
 
 {{Sensor/onerror}} is an {{EventHandler}} which is called whenever
-an [=exception type|exception=] cannot be handled synchronously.
+an error in an abstract or IDL operation cannot be handled
+synchronously.
 
 
 ### Event handlers ### {#event-handlers}


### PR DESCRIPTION
The "exception type" `dfn` was removed from Web IDL years ago in
whatwg/webidl#728, and our reference has been broken ever since.

Reword the prose and explain what `onerror` does without having to resort to
talking about exceptions in the first place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/455.html" title="Last updated on Jan 24, 2023, 5:01 PM UTC (e339004)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/455/86b448c...rakuco:e339004.html" title="Last updated on Jan 24, 2023, 5:01 PM UTC (e339004)">Diff</a>