### PR TITLE
editorial: Export "sensor reading" <dfn>.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -546,7 +546,7 @@ The term <dfn id="concept-device-sensor">device sensor</dfn> refers to a device'
 physical sensor instance.
 
 A [=device sensor=] measures a physical quantities
-and provides a corresponding <dfn>sensor reading</dfn>
+and provides a corresponding <dfn export>sensor reading</dfn>
 which is a source of information about the environment.
 
 Each [=sensor reading=] is composed of the <dfn lt="reading value">values</dfn>


### PR DESCRIPTION
This definition is used by multiple specs (e.g. accelerometer, proximity,
ambient light), and they all need to manually declare the anchor in Bikeshed
when they need to reference it -- in some cases, like Proximity, the spec
did not, and was not linking to anything.

Fixes w3c/proximity#53.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/sensors/pull/456.html" title="Last updated on Jan 27, 2023, 1:40 PM UTC (6a492f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/456/86b448c...rakuco:6a492f9.html" title="Last updated on Jan 27, 2023, 1:40 PM UTC (6a492f9)">Diff</a>