### PR TITLE
Explicitly associate a Sensor and a sensor type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -896,6 +896,9 @@ dictionary SensorOptions {
 
 A {{Sensor}} object has an associated [=platform sensor=].
 
+Concrete {{Sensor}} objects also have an associated [=sensor type=], which is the [=sensor type=]
+that has their [=interface=] among its [=extension sensor interfaces=].
+
 The [=task source=] for the [=tasks=] mentioned in this specification is the <dfn>sensor task source</dfn>.
 
 <div class="example">
@@ -1346,8 +1349,8 @@ to {{SensorErrorEventInit}}.
 
     1. For each {{Sensor}} instance |sensor| in the [=current realm=]:
        1. If |sensor|.{{[[state]]}} is "idle", then [=continue=].
-       1. If |sensor|'s associated [=platform sensor=]'s [=sensor type=]'s [=sensor permission
-          names=] [=set/contains=] |permissionName|:
+       1. If |sensor|'s [=sensor type=]'s [=sensor permission names=] [=set/contains=]
+          |permissionName|:
           1. Invoke [=deactivate a sensor object=] with |sensor|.
           1. Let |exception| be the result of [=exception/create|creating=]
              a "{{NotAllowedError}}" {{DOMException}}.
@@ -1506,7 +1509,7 @@ to {{SensorErrorEventInit}}.
 
     1.  If |sensor_instance|.{{[[state]]}} is "activated",
         1.  Let |readings| be the [=latest reading=] of |sensor_instance|'s related [=platform sensor=].
-        1.  Let |type| be |sensor_instance|'s associated [=platform sensor=]'s associated [=sensor type=].
+        1.  Let |type| be |sensor_instance|'s associated [=sensor type=].
         1.  If |type|'s [=reading quantization algorithm=] is defined, then:
             1.  Set |readings| to the result of invoking |type|'s [=reading quantization algorithm=] with |readings|.
         1.  If the [=extension specification=] defines a [=local coordinate system=] for |sensor_instance|,


### PR DESCRIPTION
The association was implicit so far: in some abstract operations we
retrieved a Sensor instance's "associated sensor type" without ever
specifying what it actually meant.

Doing this also simplifies algorithms that retrieved a sensor type via a
Sensor instance's platform sensor.

Related to #463.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/467.html" title="Last updated on Aug 1, 2023, 6:33 PM UTC (ef05b22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/467/2ea4fef...ef05b22.html" title="Last updated on Aug 1, 2023, 6:33 PM UTC (ef05b22)">Diff</a>