### PR TITLE
Tighten the Sensor.timestamp and latest reading["timestamp"] definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -845,13 +845,10 @@ the [=sensor reading=] as arguments.
 
 The [=latest reading=] [=ordered map|map=] contains an [=map/entry=] whose [=map/key=] is
 "timestamp" and whose [=map/value=] is a high resolution timestamp that estimates the
-[=reading timestamp=] expressed in milliseconds since the [=time origin=].
+[=reading timestamp=] expressed in milliseconds as an [=monotonic clock/unsafe current time=].
 
-Note: The accuracy of the [=reading timestamp=] estimate depends on the underlying
-platform interfaces that expose it.
-
-The [=latest reading=]["timestamp"] is initially set to null,
-unless the [=latest reading=] [=ordered map|map=] caches a previous [=sensor readings|reading=].
+[=Latest reading=]["timestamp"] is initially set to null, unless the [=latest reading=] [=map=]
+caches a previous [=sensor readings|reading=].
 
 The other [=map/entries=] of the [=latest reading=] [=ordered map|map=]
 hold the values of the different quantities measured by the [=platform sensor=].
@@ -1146,11 +1143,14 @@ with the internal slots described in the following table:
 
 ### Sensor.timestamp ### {#sensor-timestamp}
 
-The {{Sensor/timestamp!!attribute}} getter steps are to return
-the result of invoking [=get value from latest reading=] with [=this=]
-and "timestamp" as arguments.
+<div algorithm="sensor timestamp">
+    The {{Sensor/timestamp}} getter steps are:
 
-It represents a [=reading timestamp=].
+    1. Let |global| be [=this=]'s [=relevant global object=].
+    2. Let |unsafeTimestamp| be the result of invoking [=get value from latest reading=] with
+       [=this=] and "timestamp" as arguments.
+    3. Return [=relative high resolution time=] with |unsafeTimestamp| and |global|.
+</div>
 
 ### Sensor.start() ### {#sensor-start}
 
@@ -1437,6 +1437,21 @@ to {{SensorErrorEventInit}}.
         1.  Let |result| be the result of invoking |type|'s [=threshold check algorithm=]
             with |reading| and |sensor|'s [=latest reading=].
         1.  If |result| is false, then abort these steps.
+    1.  If |reading|["timestamp"] [=map/exists=]:
+        <!-- The language below is similar to what is found in
+             https://w3c.github.io/hr-time/#timeorigin-attribute -->
+        1.  Set |reading|["timestamp"] to the result of converting its current value in an
+            [=implementation-defined=] way to an [=monotonic clock/unsafe current time=] using the
+            same [=monotonic clock=] that is shared by [=time origins=].
+
+            Note: The goal of this step is to ensure that a timestamp that may have been relative to
+            a different time origin is converted to a value that can be used in computations with
+            the same [=monotonic clock=] used by the operations described in [[HR-TIME]].
+    1.  Otherwise, [=map/set=] |reading|["timestamp"] to the [=unsafe shared current time=].
+
+        Note: In neither case is an [=monotonic clock/unsafe current time=] ever exposed to script.
+        {{Sensor/timestamp|Sensor.timestamp}} always returns a [=moment/coarsened moment=] relative
+        to a [=time origin=].
     1.  [=map/For each=] |key| → <var ignore>value</var> of [=latest reading=].
         1.  [=map/Set=] [=latest reading=][|key|] to the corresponding
             value of |reading|.


### PR DESCRIPTION
latest reading["timestamp"] was not defined strictly enough: the definition
mentioned "the time origin", which is a concept that only exists related to
a given environment settings object.

We now have it be an "unsafe current time" as defined by the High
Resolution Time specification, and its value is always set using the same
monotonic clock -- if we get a timestamp directly from a device sensor (e.g.
a WinRT timestamp relative to the Windows epoch) it needs to be translated
into a timestamp that makes sense with the monotonic clock.

Finally, Sensor.timestamp no longer just returns latest reading["timestamp"]
and instead ensures that whatever "unsafe current time" the latter returns
is coarsened and converted to a value relative to its relevant time origin.

Related to #463.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/469.html" title="Last updated on Aug 10, 2023, 8:39 AM UTC (814c47b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/469/f0dca6f...814c47b.html" title="Last updated on Aug 10, 2023, 8:39 AM UTC (814c47b)">Diff</a>