### PR TITLE
Fix reference to "coarsened moment"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1435,7 +1435,7 @@ to {{SensorErrorEventInit}}.
     1.  Otherwise, [=map/set=] |reading|["timestamp"] to the [=unsafe shared current time=].
 
         Note: In neither case is an [=monotonic clock/unsafe current time=] ever exposed to script.
-        {{Sensor/timestamp|Sensor.timestamp}} always returns a [=moment/coarsened moment=] relative
+        {{Sensor/timestamp|Sensor.timestamp}} always returns a [=coarsened moment=] relative
         to a [=time origin=].
     1.  [=map/For each=] |key| → <var ignore>value</var> of [=latest reading=].
         1.  [=map/Set=] [=latest reading=][|key|] to the corresponding


### PR DESCRIPTION
This fixes the following Biikeshed error:

    LINK ERROR: No 'dfn' refs found for 'coarsened moment' with for='['moment']'.
    [=moment/coarsened moment=]

"Coarsened moment" is a standalone definition. I probably meant to use a '|'
character instead of '/' when I wrote the original version, but just using
"coarsened moment" also works so use the latter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/473.html" title="Last updated on Oct 26, 2023, 10:22 AM UTC (01203e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/473/50ea817...01203e9.html" title="Last updated on Oct 26, 2023, 10:22 AM UTC (01203e9)">Diff</a>