### PR TITLE
Sensor.timestamp: Account for "get value from latest reading" returning null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1122,9 +1122,10 @@ with the internal slots described in the following table:
     The {{Sensor/timestamp}} getter steps are:
 
     1. Let |global| be [=this=]'s [=relevant global object=].
-    2. Let |unsafeTimestamp| be the result of invoking [=get value from latest reading=] with
+    1. Let |unsafeTimestamp| be the result of invoking [=get value from latest reading=] with
        [=this=] and "timestamp" as arguments.
-    3. Return [=relative high resolution time=] with |unsafeTimestamp| and |global|.
+    1. If |unsafeTimestamp| is null, return null.
+    1. Otherwise, return [=relative high resolution time=] with |unsafeTimestamp| and |global|.
 </div>
 
 ### Sensor.start() ### {#sensor-start}


### PR DESCRIPTION
This addresses a regression introduced by #469. The current algorithm
assumes that "get value from latest reading" never returns null, which is
not the case.

Return null when it does instead of passing an invalid value to "relative
high resolution time".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/480.html" title="Last updated on Feb 16, 2024, 1:10 PM UTC (31d3402)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/480/1e40156...31d3402.html" title="Last updated on Feb 16, 2024, 1:10 PM UTC (31d3402)">Diff</a>