### PR TITLE
Request sensor access: Access "sensor permission names" correctly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1555,9 +1555,8 @@ to {{SensorErrorEventInit}}.
     : output
     :: A [=permission state=].
 
-    1.  Let |sensor| be the [=platform sensor=] associated with |sensor_instance|.
-    1.  Let |sensor_permissions| be |sensor|'s associated [=ordered set|set=] of
-        [=sensor permission names|permission names=].
+    1.  Let |sensor_type| be |sensor_instance|'s associated [=sensor type=].
+    1.  Let |sensor_permissions| be |sensor_type|'s associated [=sensor permission names=].
     1.  [=set/For each=] |permission_name| in |sensor_permissions|,
         1.  Let |state| be the result of [=request permission to use|requesting permission to use=] |permission_name|.
         1.  If |state| is "denied"


### PR DESCRIPTION
The "sensor permission names" definition is associated with a sensor type,
not a platform sensor.

Related to: #463.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/481.html" title="Last updated on Feb 16, 2024, 1:25 PM UTC (0695edb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/481/1e40156...0695edb.html" title="Last updated on Feb 16, 2024, 1:25 PM UTC (0695edb)">Diff</a>