### PR TITLE
Remove note about sharing data between platform sensors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -808,11 +808,6 @@ The current [=browsing context=]'s [=platform sensor=] must have:
   latest available [=sensor readings=].
 - An associated [=sensor type=].
 
-Note: User agents can share the [=latest reading=] [=ordered map|map=] and
-the [=activated sensor objects=] [=ordered set|set=] between different
-[=browsing context|contexts=] only if the [=/origins=] of these contexts' [=active documents=]
-are [=same origin-domain=].
-
 Any time a new [=sensor reading=] for a [=platform sensor=] is obtained and if the user agent
 [=can expose sensor readings=] to the current [=browsing context=]'s [=active document=],
 the user agent invokes [=update latest reading=] with the [=platform sensor=] and


### PR DESCRIPTION
The original note was added in #267 and expanded in #347, but its advice is
impractical:
- Sharing the activated sensors objects between multiple browsing
  contexts/documents/windows means these Sensor objects could potentially be
  shared by contexts in different top-level traversables (i.e. different
  tabs).
  Furthermore, if "can expose sensor readings" passes for one context but
  not the other, "update sensor reading" would still invoke "report latest
  reading updated" with sensors that cannot expose sensor readings.
- Similarly, if the latest reading map is shared between multiple contexts,
  an update would affect all contexts, including those for which "update
  sensor reading" should not have been invoked in the first place (e.g. two
  pages with the same origin share the latest readings map, but only one is
  visible; updates to the latest reading map would be accessible from the
  other as well).

PR #267 also made the "platform sensor" concept used in this section
per-browsing context (although in a very confusing way), which on its own is
a stricter requirement than what the note allowed, so we can drop the note
without making things less secure.

Incidentally, this also gets rid of one of the usages of "browsing context"
in the spec, which helps with #444.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/482.html" title="Last updated on Feb 16, 2024, 4:02 PM UTC (8839c23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/482/1e40156...8839c23.html" title="Last updated on Feb 16, 2024, 4:02 PM UTC (8839c23)">Diff</a>