### PR TITLE
editorial: Fix requestedSamplingFrequency's description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1777,7 +1777,7 @@ properties:
     <tr>
       <td>"`requestedSamplingFrequency`"</td>
       <td>{{Number}}</td>
-      <td>The [=virtual sensor=]'s [=sampling frequency=]</td>
+      <td>The [=virtual sensor=]'s [=virtual sensor/requested sampling frequency=]</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Refer to the right concept in the property's non-normative description.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/pull/485.html" title="Last updated on Feb 20, 2024, 9:30 AM UTC (d0a5ada)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/485/738e124...d0a5ada.html" title="Last updated on Feb 20, 2024, 9:30 AM UTC (d0a5ada)">Diff</a>