### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,6 +31,13 @@ Status Text:
   <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
   No WebKit standards position has been filed.
   </div>
+  Further implementation experience is being gathered for the
+  [=permission request algorithm=] and specification clarifications
+  informed by this experience are being discussed in
+  <a href="https://github.com/w3c/sensors/issues/397">GitHub issue #397</a>.
+  The group does not expect to advance this specification beyond CR until
+  [[PERMISSIONS-REQUEST]] moves beyond incubation.
+  This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML

--- a/index.bs
+++ b/index.bs
@@ -25,13 +25,12 @@ Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Inline GitHub Issues: yes
 Default Biblio Status: current
 Status Text:
-  Further implementation experience is being gathered for the
-  [=permission request algorithm=] and specification clarifications
-  informed by this experience are being discussed in
-  <a href="https://github.com/w3c/sensors/issues/397">GitHub issue #397</a>.
-  The group does not expect to advance this specification beyond CR until
-  [[PERMISSIONS-REQUEST]] moves beyond incubation.
-  This document is maintained and updated at any time. Some parts of this document are work in progress.
+  <div class="advisement">
+  This specification is currently implemented in a single browser engine (Blink).
+  Implementer standards positions:
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  No WebKit standards position has been filed.
+  </div>
 </pre>
 <pre class="anchors">
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/sensors/pull/492.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (be8fff6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/492/0638348...marcoscaceres:be8fff6.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (be8fff6)">Diff</a>