### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,8 @@ Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Inline GitHub Issues: yes
 Default Biblio Status: current
 Status Text:
+  <p class="advisement">Multiple browser engines have expressed concerns about this specification. It is implemented in Chromium-based browsers but is not expected to advance to W3C Recommendation in its current form without cross-engine interest.</p>
+
   Further implementation experience is being gathered for the
   [=permission request algorithm=] and specification clarifications
   informed by this experience are being discussed in


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/sensors/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/sensors/pull/494.html" title="Last updated on May 14, 2026, 11:47 AM UTC (c5afa5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sensors/494/0638348...christianliebel:c5afa5b.html" title="Last updated on May 14, 2026, 11:47 AM UTC (c5afa5b)">Diff</a>